### PR TITLE
restore(renderer): recover authored sources from inline sourcemaps

### DIFF
--- a/packages/renderer/src/Ansi.tsx
+++ b/packages/renderer/src/Ansi.tsx
@@ -1,25 +1,31 @@
-import { c as _c } from "react/compiler-runtime";
-import React from 'react';
-import Link from './components/Link';
-import Text from './components/Text';
-import type { Color } from './styles';
-import { type NamedColor, Parser, type Color as TermioColor, type TextStyle } from './termio';
+import React from 'react'
+import Link from './components/Link.js'
+import Text from './components/Text.js'
+import type { Color } from './styles.js'
+import {
+  type NamedColor,
+  Parser,
+  type Color as TermioColor,
+  type TextStyle,
+} from './termio.js'
+
 type Props = {
-  children: string;
+  children: string
   /** When true, force all text to be rendered with dim styling */
-  dimColor?: boolean;
-};
+  dimColor?: boolean
+}
+
 type SpanProps = {
-  color?: Color;
-  backgroundColor?: Color;
-  dim?: boolean;
-  bold?: boolean;
-  italic?: boolean;
-  underline?: boolean;
-  strikethrough?: boolean;
-  inverse?: boolean;
-  hyperlink?: string;
-};
+  color?: Color
+  backgroundColor?: Color
+  dim?: boolean
+  bold?: boolean
+  italic?: boolean
+  underline?: boolean
+  strikethrough?: boolean
+  inverse?: boolean
+  hyperlink?: string
+}
 
 /**
  * Component that parses ANSI escape codes and renders them using Text components.
@@ -29,145 +35,156 @@ type SpanProps = {
  *
  * Memoized to prevent re-renders when parent changes but children string is the same.
  */
-export const Ansi = React.memo(function Ansi(t0: Props) {
-  const $ = _c(12);
-  const {
-    children,
-    dimColor
-  } = t0;
-  if (typeof children !== "string") {
-    let t1;
-    if ($[0] !== children || $[1] !== dimColor) {
-      t1 = dimColor ? <Text dim={true}>{String(children)}</Text> : <Text>{String(children)}</Text>;
-      $[0] = children;
-      $[1] = dimColor;
-      $[2] = t1;
-    } else {
-      t1 = $[2];
+export const Ansi = React.memo(function Ansi({
+  children,
+  dimColor,
+}: Props): React.ReactNode {
+  if (typeof children !== 'string') {
+    return dimColor ? (
+      <Text dim>{String(children)}</Text>
+    ) : (
+      <Text>{String(children)}</Text>
+    )
+  }
+
+  if (children === '') {
+    return null
+  }
+
+  const spans = parseToSpans(children)
+
+  if (spans.length === 0) {
+    return null
+  }
+
+  if (spans.length === 1 && !hasAnyProps(spans[0]!.props)) {
+    return dimColor ? (
+      <Text dim>{spans[0]!.text}</Text>
+    ) : (
+      <Text>{spans[0]!.text}</Text>
+    )
+  }
+
+  const content = spans.map((span, i) => {
+    const hyperlink = span.props.hyperlink
+    // When dimColor is forced, override the span's dim prop
+    if (dimColor) {
+      span.props.dim = true
     }
-    return t1;
-  }
-  if (children === "") {
-    return null;
-  }
-  let t1;
-  let t2;
-  if ($[3] !== children || $[4] !== dimColor) {
-    t2 = Symbol.for("react.early_return_sentinel");
-    bb0: {
-      const spans = parseToSpans(children);
-      if (spans.length === 0) {
-        t2 = null;
-        break bb0;
-      }
-      if (spans.length === 1 && !hasAnyProps(spans[0].props)) {
-        t2 = dimColor ? <Text dim={true}>{spans[0].text}</Text> : <Text>{spans[0].text}</Text>;
-        break bb0;
-      }
-      let t3;
-      if ($[7] !== dimColor) {
-        t3 = (span: Span, i: number) => {
-          const hyperlink = span.props.hyperlink;
-          if (dimColor) {
-            span.props.dim = true;
-          }
-          const hasTextProps = hasAnyTextProps(span.props);
-          if (hyperlink) {
-            return hasTextProps ? <Link key={i} url={hyperlink}><StyledText color={span.props.color} backgroundColor={span.props.backgroundColor} dim={span.props.dim} bold={span.props.bold} italic={span.props.italic} underline={span.props.underline} strikethrough={span.props.strikethrough} inverse={span.props.inverse}>{span.text}</StyledText></Link> : <Link key={i} url={hyperlink}>{span.text}</Link>;
-          }
-          return hasTextProps ? <StyledText key={i} color={span.props.color} backgroundColor={span.props.backgroundColor} dim={span.props.dim} bold={span.props.bold} italic={span.props.italic} underline={span.props.underline} strikethrough={span.props.strikethrough} inverse={span.props.inverse}>{span.text}</StyledText> : span.text;
-        };
-        $[7] = dimColor;
-        $[8] = t3;
-      } else {
-        t3 = $[8];
-      }
-      t1 = spans.map(t3);
+    const hasTextProps = hasAnyTextProps(span.props)
+
+    if (hyperlink) {
+      return hasTextProps ? (
+        <Link key={i} url={hyperlink}>
+          <StyledText
+            color={span.props.color}
+            backgroundColor={span.props.backgroundColor}
+            dim={span.props.dim}
+            bold={span.props.bold}
+            italic={span.props.italic}
+            underline={span.props.underline}
+            strikethrough={span.props.strikethrough}
+            inverse={span.props.inverse}
+          >
+            {span.text}
+          </StyledText>
+        </Link>
+      ) : (
+        <Link key={i} url={hyperlink}>
+          {span.text}
+        </Link>
+      )
     }
-    $[3] = children;
-    $[4] = dimColor;
-    $[5] = t1;
-    $[6] = t2;
-  } else {
-    t1 = $[5];
-    t2 = $[6];
-  }
-  if (t2 !== Symbol.for("react.early_return_sentinel")) {
-    return t2;
-  }
-  const content = t1;
-  let t3;
-  if ($[9] !== content || $[10] !== dimColor) {
-    t3 = dimColor ? <Text dim={true}>{content}</Text> : <Text>{content}</Text>;
-    $[9] = content;
-    $[10] = dimColor;
-    $[11] = t3;
-  } else {
-    t3 = $[11];
-  }
-  return t3;
-});
+
+    return hasTextProps ? (
+      <StyledText
+        key={i}
+        color={span.props.color}
+        backgroundColor={span.props.backgroundColor}
+        dim={span.props.dim}
+        bold={span.props.bold}
+        italic={span.props.italic}
+        underline={span.props.underline}
+        strikethrough={span.props.strikethrough}
+        inverse={span.props.inverse}
+      >
+        {span.text}
+      </StyledText>
+    ) : (
+      span.text
+    )
+  })
+
+  return dimColor ? <Text dim>{content}</Text> : <Text>{content}</Text>
+})
+
 type Span = {
-  text: string;
-  props: SpanProps;
-};
+  text: string
+  props: SpanProps
+}
 
 /**
  * Parse an ANSI string into spans using the termio parser.
  */
 function parseToSpans(input: string): Span[] {
-  const parser = new Parser();
-  const actions = parser.feed(input);
-  const spans: Span[] = [];
-  let currentHyperlink: string | undefined;
+  const parser = new Parser()
+  const actions = parser.feed(input)
+  const spans: Span[] = []
+
+  let currentHyperlink: string | undefined
+
   for (const action of actions) {
     if (action.type === 'link') {
       if (action.action.type === 'start') {
-        currentHyperlink = action.action.url;
+        currentHyperlink = action.action.url
       } else {
-        currentHyperlink = undefined;
+        currentHyperlink = undefined
       }
-      continue;
+      continue
     }
+
     if (action.type === 'text') {
-      const text = action.graphemes.map(g => g.value).join('');
-      if (!text) continue;
-      const props = textStyleToSpanProps(action.style);
+      const text = action.graphemes.map(g => g.value).join('')
+      if (!text) continue
+
+      const props = textStyleToSpanProps(action.style)
       if (currentHyperlink) {
-        props.hyperlink = currentHyperlink;
+        props.hyperlink = currentHyperlink
       }
 
       // Try to merge with previous span if props match
-      const lastSpan = spans[spans.length - 1];
+      const lastSpan = spans[spans.length - 1]
       if (lastSpan && propsEqual(lastSpan.props, props)) {
-        lastSpan.text += text;
+        lastSpan.text += text
       } else {
-        spans.push({
-          text,
-          props
-        });
+        spans.push({ text, props })
       }
     }
   }
-  return spans;
+
+  return spans
 }
 
 /**
  * Convert termio's TextStyle to SpanProps.
  */
 function textStyleToSpanProps(style: TextStyle): SpanProps {
-  const props: SpanProps = {};
-  if (style.bold) props.bold = true;
-  if (style.dim) props.dim = true;
-  if (style.italic) props.italic = true;
-  if (style.underline !== 'none') props.underline = true;
-  if (style.strikethrough) props.strikethrough = true;
-  if (style.inverse) props.inverse = true;
-  const fgColor = colorToString(style.fg);
-  if (fgColor) props.color = fgColor;
-  const bgColor = colorToString(style.bg);
-  if (bgColor) props.backgroundColor = bgColor;
-  return props;
+  const props: SpanProps = {}
+
+  if (style.bold) props.bold = true
+  if (style.dim) props.dim = true
+  if (style.italic) props.italic = true
+  if (style.underline !== 'none') props.underline = true
+  if (style.strikethrough) props.strikethrough = true
+  if (style.inverse) props.inverse = true
+
+  const fgColor = colorToString(style.fg)
+  if (fgColor) props.color = fgColor
+
+  const bgColor = colorToString(style.bg)
+  if (bgColor) props.backgroundColor = bgColor
+
+  return props
 }
 
 // Map termio named colors to the ansi: format
@@ -187,8 +204,8 @@ const NAMED_COLOR_MAP: Record<NamedColor, string> = {
   brightBlue: 'ansi:blueBright',
   brightMagenta: 'ansi:magentaBright',
   brightCyan: 'ansi:cyanBright',
-  brightWhite: 'ansi:whiteBright'
-};
+  brightWhite: 'ansi:whiteBright',
+}
 
 /**
  * Convert termio's Color to the string format used by Ink.
@@ -196,13 +213,13 @@ const NAMED_COLOR_MAP: Record<NamedColor, string> = {
 function colorToString(color: TermioColor): Color | undefined {
   switch (color.type) {
     case 'named':
-      return NAMED_COLOR_MAP[color.name] as Color;
+      return NAMED_COLOR_MAP[color.name] as Color
     case 'indexed':
-      return `ansi256(${color.index})` as Color;
+      return `ansi256(${color.index})` as Color
     case 'rgb':
-      return `rgb(${color.r},${color.g},${color.b})` as Color;
+      return `rgb(${color.r},${color.g},${color.b})` as Color
     case 'default':
-      return undefined;
+      return undefined
   }
 }
 
@@ -210,83 +227,81 @@ function colorToString(color: TermioColor): Color | undefined {
  * Check if two SpanProps are equal for merging.
  */
 function propsEqual(a: SpanProps, b: SpanProps): boolean {
-  return a.color === b.color && a.backgroundColor === b.backgroundColor && a.bold === b.bold && a.dim === b.dim && a.italic === b.italic && a.underline === b.underline && a.strikethrough === b.strikethrough && a.inverse === b.inverse && a.hyperlink === b.hyperlink;
+  return (
+    a.color === b.color &&
+    a.backgroundColor === b.backgroundColor &&
+    a.bold === b.bold &&
+    a.dim === b.dim &&
+    a.italic === b.italic &&
+    a.underline === b.underline &&
+    a.strikethrough === b.strikethrough &&
+    a.inverse === b.inverse &&
+    a.hyperlink === b.hyperlink
+  )
 }
+
 function hasAnyProps(props: SpanProps): boolean {
-  return props.color !== undefined || props.backgroundColor !== undefined || props.dim === true || props.bold === true || props.italic === true || props.underline === true || props.strikethrough === true || props.inverse === true || props.hyperlink !== undefined;
+  return (
+    props.color !== undefined ||
+    props.backgroundColor !== undefined ||
+    props.dim === true ||
+    props.bold === true ||
+    props.italic === true ||
+    props.underline === true ||
+    props.strikethrough === true ||
+    props.inverse === true ||
+    props.hyperlink !== undefined
+  )
 }
+
 function hasAnyTextProps(props: SpanProps): boolean {
-  return props.color !== undefined || props.backgroundColor !== undefined || props.dim === true || props.bold === true || props.italic === true || props.underline === true || props.strikethrough === true || props.inverse === true;
+  return (
+    props.color !== undefined ||
+    props.backgroundColor !== undefined ||
+    props.dim === true ||
+    props.bold === true ||
+    props.italic === true ||
+    props.underline === true ||
+    props.strikethrough === true ||
+    props.inverse === true
+  )
 }
 
 // Text style props without weight (bold/dim) - these are handled separately
 type BaseTextStyleProps = {
-  color?: Color;
-  backgroundColor?: Color;
-  italic?: boolean;
-  underline?: boolean;
-  strikethrough?: boolean;
-  inverse?: boolean;
-};
+  color?: Color
+  backgroundColor?: Color
+  italic?: boolean
+  underline?: boolean
+  strikethrough?: boolean
+  inverse?: boolean
+}
 
 // Wrapper component that handles bold/dim mutual exclusivity for Text
-function StyledText(t0: SpanProps & { children: React.ReactNode }) {
-  const $ = _c(14);
-  let bold;
-  let children;
-  let dim;
-  let rest;
-  if ($[0] !== t0) {
-    ({
-      bold,
-      dim,
-      children,
-      ...rest
-    } = t0);
-    $[0] = t0;
-    $[1] = bold;
-    $[2] = children;
-    $[3] = dim;
-    $[4] = rest;
-  } else {
-    bold = $[1];
-    children = $[2];
-    dim = $[3];
-    rest = $[4];
-  }
+function StyledText({
+  bold,
+  dim,
+  children,
+  ...rest
+}: BaseTextStyleProps & {
+  bold?: boolean
+  dim?: boolean
+  children: string
+}): React.ReactNode {
+  // dim takes precedence over bold when both are set (terminals treat them as mutually exclusive)
   if (dim) {
-    let t1;
-    if ($[5] !== children || $[6] !== rest) {
-      t1 = <Text {...rest} dim={true}>{children}</Text>;
-      $[5] = children;
-      $[6] = rest;
-      $[7] = t1;
-    } else {
-      t1 = $[7];
-    }
-    return t1;
+    return (
+      <Text {...rest} dim>
+        {children}
+      </Text>
+    )
   }
   if (bold) {
-    let t1;
-    if ($[8] !== children || $[9] !== rest) {
-      t1 = <Text {...rest} bold={true}>{children}</Text>;
-      $[8] = children;
-      $[9] = rest;
-      $[10] = t1;
-    } else {
-      t1 = $[10];
-    }
-    return t1;
+    return (
+      <Text {...rest} bold>
+        {children}
+      </Text>
+    )
   }
-  let t1;
-  if ($[11] !== children || $[12] !== rest) {
-    t1 = <Text {...rest}>{children}</Text>;
-    $[11] = children;
-    $[12] = rest;
-    $[13] = t1;
-  } else {
-    t1 = $[13];
-  }
-  return t1;
+  return <Text {...rest}>{children}</Text>
 }
-//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJuYW1lcyI6WyJSZWFjdCIsIkxpbmsiLCJUZXh0IiwiQ29sb3IiLCJOYW1lZENvbG9yIiwiUGFyc2VyIiwiVGVybWlvQ29sb3IiLCJUZXh0U3R5bGUiLCJQcm9wcyIsImNoaWxkcmVuIiwiZGltQ29sb3IiLCJTcGFuUHJvcHMiLCJjb2xvciIsImJhY2tncm91bmRDb2xvciIsImRpbSIsImJvbGQiLCJpdGFsaWMiLCJ1bmRlcmxpbmUiLCJzdHJpa2V0aHJvdWdoIiwiaW52ZXJzZSIsImh5cGVybGluayIsIkFuc2kiLCJtZW1vIiwidDAiLCIkIiwiX2MiLCJ0MSIsIlN0cmluZyIsInQyIiwiU3ltYm9sIiwiZm9yIiwiYmIwIiwic3BhbnMiLCJwYXJzZVRvU3BhbnMiLCJsZW5ndGgiLCJoYXNBbnlQcm9wcyIsInByb3BzIiwidGV4dCIsInQzIiwic3BhbiIsImkiLCJoYXNUZXh0UHJvcHMiLCJoYXNBbnlUZXh0UHJvcHMiLCJtYXAiLCJjb250ZW50IiwiU3BhbiIsImlucHV0IiwicGFyc2VyIiwiYWN0aW9ucyIsImZlZWQiLCJjdXJyZW50SHlwZXJsaW5rIiwiYWN0aW9uIiwidHlwZSIsInVybCIsInVuZGVmaW5lZCIsImdyYXBoZW1lcyIsImciLCJ2YWx1ZSIsImpvaW4iLCJ0ZXh0U3R5bGVUb1NwYW5Qcm9wcyIsInN0eWxlIiwibGFzdFNwYW4iLCJwcm9wc0VxdWFsIiwicHVzaCIsImZnQ29sb3IiLCJjb2xvclRvU3RyaW5nIiwiZmciLCJiZ0NvbG9yIiwiYmciLCJOQU1FRF9DT0xPUl9NQVAiLCJSZWNvcmQiLCJibGFjayIsInJlZCIsImdyZWVuIiwieWVsbG93IiwiYmx1ZSIsIm1hZ2VudGEiLCJjeWFuIiwid2hpdGUiLCJicmlnaHRCbGFjayIsImJyaWdodFJlZCIsImJyaWdodEdyZWVuIiwiYnJpZ2h0WWVsbG93IiwiYnJpZ2h0Qmx1ZSIsImJyaWdodE1hZ2VudGEiLCJicmlnaHRDeWFuIiwiYnJpZ2h0V2hpdGUiLCJuYW1lIiwiaW5kZXgiLCJyIiwiYiIsImEiLCJCYXNlVGV4dFN0eWxlUHJvcHMiLCJTdHlsZWRUZXh0IiwicmVzdCJdLCJzb3VyY2VzIjpbIkFuc2kudHN4Il0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBSZWFjdCBmcm9tICdyZWFjdCdcbmltcG9ydCBMaW5rIGZyb20gJy4vY29tcG9uZW50cy9MaW5rLmpzJ1xuaW1wb3J0IFRleHQgZnJvbSAnLi9jb21wb25lbnRzL1RleHQuanMnXG5pbXBvcnQgdHlwZSB7IENvbG9yIH0gZnJvbSAnLi9zdHlsZXMuanMnXG5pbXBvcnQge1xuICB0eXBlIE5hbWVkQ29sb3IsXG4gIFBhcnNlcixcbiAgdHlwZSBDb2xvciBhcyBUZXJtaW9Db2xvcixcbiAgdHlwZSBUZXh0U3R5bGUsXG59IGZyb20gJy4vdGVybWlvLmpzJ1xuXG50eXBlIFByb3BzID0ge1xuICBjaGlsZHJlbjogc3RyaW5nXG4gIC8qKiBXaGVuIHRydWUsIGZvcmNlIGFsbCB0ZXh0IHRvIGJlIHJlbmRlcmVkIHdpdGggZGltIHN0eWxpbmcgKi9cbiAgZGltQ29sb3I/OiBib29sZWFuXG59XG5cbnR5cGUgU3BhblByb3BzID0ge1xuICBjb2xvcj86IENvbG9yXG4gIGJhY2tncm91bmRDb2xvcj86IENvbG9yXG4gIGRpbT86IGJvb2xlYW5cbiAgYm9sZD86IGJvb2xlYW5cbiAgaXRhbGljPzogYm9vbGVhblxuICB1bmRlcmxpbmU/OiBib29sZWFuXG4gIHN0cmlrZXRocm91Z2g/OiBib29sZWFuXG4gIGludmVyc2U/OiBib29sZWFuXG4gIGh5cGVybGluaz86IHN0cmluZ1xufVxuXG4vKipcbiAqIENvbXBvbmVudCB0aGF0IHBhcnNlcyBBTlNJIGVzY2FwZSBjb2RlcyBhbmQgcmVuZGVycyB0aGVtIHVzaW5nIFRleHQgY29tcG9uZW50cy5cbiAqXG4gKiBVc2UgdGhpcyBhcyBhbiBlc2NhcGUgaGF0Y2ggd2hlbiB5b3UgaGF2ZSBwcmUtZm9ybWF0dGVkIEFOU0kgc3RyaW5ncyBmcm9tXG4gKiBleHRlcm5hbCB0b29scyAobGlrZSBjbGktaGlnaGxpZ2h0KSB0aGF0IG5lZWQgdG8gYmUgcmVuZGVyZWQgaW4gSW5rLlxuICpcbiAqIE1lbW9pemVkIHRvIHByZXZlbnQgcmUtcmVuZGVycyB3aGVuIHBhcmVudCBjaGFuZ2VzIGJ1dCBjaGlsZHJlbiBzdHJpbmcgaXMgdGhlIHNhbWUuXG4gKi9cbmV4cG9ydCBjb25zdCBBbnNpID0gUmVhY3QubWVtbyhmdW5jdGlvbiBBbnNpKHtcbiAgY2hpbGRyZW4sXG4gIGRpbUNvbG9yLFxufTogUHJvcHMpOiBSZWFjdC5SZWFjdE5vZGUge1xuICBpZiAodHlwZW9mIGNoaWxkcmVuICE9PSAnc3RyaW5nJykge1xuICAgIHJldHVybiBkaW1Db2xvciA/IChcbiAgICAgIDxUZXh0IGRpbT57U3RyaW5nKGNoaWxkcmVuKX08L1RleHQ+XG4gICAgKSA6IChcbiAgICAgIDxUZXh0PntTdHJpbmcoY2hpbGRyZW4pfTwvVGV4dD5cbiAgICApXG4gIH1cblxuICBpZiAoY2hpbGRyZW4gPT09ICcnKSB7XG4gICAgcmV0dXJuIG51bGxcbiAgfVxuXG4gIGNvbnN0IHNwYW5zID0gcGFyc2VUb1NwYW5zKGNoaWxkcmVuKVxuXG4gIGlmIChzcGFucy5sZW5ndGggPT09IDApIHtcbiAgICByZXR1cm4gbnVsbFxuICB9XG5cbiAgaWYgKHNwYW5zLmxlbmd0aCA9PT0gMSAmJiAhaGFzQW55UHJvcHMoc3BhbnNbMF0hLnByb3BzKSkge1xuICAgIHJldHVybiBkaW1Db2xvciA/IChcbiAgICAgIDxUZXh0IGRpbT57c3BhbnNbMF0hLnRleHR9PC9UZXh0PlxuICAgICkgOiAoXG4gICAgICA8VGV4dD57c3BhbnNbMF0hLnRleHR9PC9UZXh0PlxuICAgIClcbiAgfVxuXG4gIGNvbnN0IGNvbnRlbnQgPSBzcGFucy5tYXAoKHNwYW4sIGkpID0+IHtcbiAgICBjb25zdCBoeXBlcmxpbmsgPSBzcGFuLnByb3BzLmh5cGVybGlua1xuICAgIC8vIFdoZW4gZGltQ29sb3IgaXMgZm9yY2VkLCBvdmVycmlkZSB0aGUgc3BhbidzIGRpbSBwcm9wXG4gICAgaWYgKGRpbUNvbG9yKSB7XG4gICAgICBzcGFuLnByb3BzLmRpbSA9IHRydWVcbiAgICB9XG4gICAgY29uc3QgaGFzVGV4dFByb3BzID0gaGFzQW55VGV4dFByb3BzKHNwYW4ucHJvcHMpXG5cbiAgICBpZiAoaHlwZXJsaW5rKSB7XG4gICAgICByZXR1cm4gaGFzVGV4dFByb3BzID8gKFxuICAgICAgICA8TGluayBrZXk9e2l9IHVybD17aHlwZXJsaW5rfT5cbiAgICAgICAgICA8U3R5bGVkVGV4dFxuICAgICAgICAgICAgY29sb3I9e3NwYW4ucHJvcHMuY29sb3J9XG4gICAgICAgICAgICBiYWNrZ3JvdW5kQ29sb3I9e3NwYW4ucHJvcHMuYmFja2dyb3VuZENvbG9yfVxuICAgICAgICAgICAgZGltPXtzcGFuLnByb3BzLmRpbX1cbiAgICAgICAgICAgIGJvbGQ9e3NwYW4ucHJvcHMuYm9sZH1cbiAgICAgICAgICAgIGl0YWxpYz17c3Bhbi5wcm9wcy5pdGFsaWN9XG4gICAgICAgICAgICB1bmRlcmxpbmU9e3NwYW4ucHJvcHMudW5kZXJsaW5lfVxuICAgICAgICAgICAgc3RyaWtldGhyb3VnaD17c3Bhbi5wcm9wcy5zdHJpa2V0aHJvdWdofVxuICAgICAgICAgICAgaW52ZXJzZT17c3Bhbi5wcm9wcy5pbnZlcnNlfVxuICAgICAgICAgID5cbiAgICAgICAgICAgIHtzcGFuLnRleHR9XG4gICAgICAgICAgPC9TdHlsZWRUZXh0PlxuICAgICAgICA8L0xpbms+XG4gICAgICApIDogKFxuICAgICAgICA8TGluayBrZXk9e2l9IHVybD17aHlwZXJsaW5rfT5cbiAgICAgICAgICB7c3Bhbi50ZXh0fVxuICAgICAgICA8L0xpbms+XG4gICAgICApXG4gICAgfVxuXG4gICAgcmV0dXJuIGhhc1RleHRQcm9wcyA/IChcbiAgICAgIDxTdHlsZWRUZXh0XG4gICAgICAgIGtleT17aX1cbiAgICAgICAgY29sb3I9e3NwYW4ucHJvcHMuY29sb3J9XG4gICAgICAgIGJhY2tncm91bmRDb2xvcj17c3Bhbi5wcm9wcy5iYWNrZ3JvdW5kQ29sb3J9XG4gICAgICAgIGRpbT17c3Bhbi5wcm9wcy5kaW19XG4gICAgICAgIGJvbGQ9e3NwYW4ucHJvcHMuYm9sZH1cbiAgICAgICAgaXRhbGljPXtzcGFuLnByb3BzLml0YWxpY31cbiAgICAgICAgdW5kZXJsaW5lPXtzcGFuLnByb3BzLnVuZGVybGluZX1cbiAgICAgICAgc3RyaWtldGhyb3VnaD17c3Bhbi5wcm9wcy5zdHJpa2V0aHJvdWdofVxuICAgICAgICBpbnZlcnNlPXtzcGFuLnByb3BzLmludmVyc2V9XG4gICAgICA+XG4gICAgICAgIHtzcGFuLnRleHR9XG4gICAgICA8L1N0eWxlZFRleHQ+XG4gICAgKSA6IChcbiAgICAgIHNwYW4udGV4dFxuICAgIClcbiAgfSlcblxuICByZXR1cm4gZGltQ29sb3IgPyA8VGV4dCBkaW0+e2NvbnRlbnR9PC9UZXh0PiA6IDxUZXh0Pntjb250ZW50fTwvVGV4dD5cbn0pXG5cbnR5cGUgU3BhbiA9IHtcbiAgdGV4dDogc3RyaW5nXG4gIHByb3BzOiBTcGFuUHJvcHNcbn1cblxuLyoqXG4gKiBQYXJzZSBhbiBBTlNJIHN0cmluZyBpbnRvIHNwYW5zIHVzaW5nIHRoZSB0ZXJtaW8gcGFyc2VyLlxuICovXG5mdW5jdGlvbiBwYXJzZVRvU3BhbnMoaW5wdXQ6IHN0cmluZyk6IFNwYW5bXSB7XG4gIGNvbnN0IHBhcnNlciA9IG5ldyBQYXJzZXIoKVxuICBjb25zdCBhY3Rpb25zID0gcGFyc2VyLmZlZWQoaW5wdXQpXG4gIGNvbnN0IHNwYW5zOiBTcGFuW10gPSBbXVxuXG4gIGxldCBjdXJyZW50SHlwZXJsaW5rOiBzdHJpbmcgfCB1bmRlZmluZWRcblxuICBmb3IgKGNvbnN0IGFjdGlvbiBvZiBhY3Rpb25zKSB7XG4gICAgaWYgKGFjdGlvbi50eXBlID09PSAnbGluaycpIHtcbiAgICAgIGlmIChhY3Rpb24uYWN0aW9uLnR5cGUgPT09ICdzdGFydCcpIHtcbiAgICAgICAgY3VycmVudEh5cGVybGluayA9IGFjdGlvbi5hY3Rpb24udXJsXG4gICAgICB9IGVsc2Uge1xuICAgICAgICBjdXJyZW50SHlwZXJsaW5rID0gdW5kZWZpbmVkXG4gICAgICB9XG4gICAgICBjb250aW51ZVxuICAgIH1cblxuICAgIGlmIChhY3Rpb24udHlwZSA9PT0gJ3RleHQnKSB7XG4gICAgICBjb25zdCB0ZXh0ID0gYWN0aW9uLmdyYXBoZW1lcy5tYXAoZyA9PiBnLnZhbHVlKS5qb2luKCcnKVxuICAgICAgaWYgKCF0ZXh0KSBjb250aW51ZVxuXG4gICAgICBjb25zdCBwcm9wcyA9IHRleHRTdHlsZVRvU3BhblByb3BzKGFjdGlvbi5zdHlsZSlcbiAgICAgIGlmIChjdXJyZW50SHlwZXJsaW5rKSB7XG4gICAgICAgIHByb3BzLmh5cGVybGluayA9IGN1cnJlbnRIeXBlcmxpbmtcbiAgICAgIH1cblxuICAgICAgLy8gVHJ5IHRvIG1lcmdlIHdpdGggcHJldmlvdXMgc3BhbiBpZiBwcm9wcyBtYXRjaFxuICAgICAgY29uc3QgbGFzdFNwYW4gPSBzcGFuc1tzcGFucy5sZW5ndGggLSAxXVxuICAgICAgaWYgKGxhc3RTcGFuICYmIHByb3BzRXF1YWwobGFzdFNwYW4ucHJvcHMsIHByb3BzKSkge1xuICAgICAgICBsYXN0U3Bhbi50ZXh0ICs9IHRleHRcbiAgICAgIH0gZWxzZSB7XG4gICAgICAgIHNwYW5zLnB1c2goeyB0ZXh0LCBwcm9wcyB9KVxuICAgICAgfVxuICAgIH1cbiAgfVxuXG4gIHJldHVybiBzcGFuc1xufVxuXG4vKipcbiAqIENvbnZlcnQgdGVybWlvJ3MgVGV4dFN0eWxlIHRvIFNwYW5Qcm9wcy5cbiAqL1xuZnVuY3Rpb24gdGV4dFN0eWxlVG9TcGFuUHJvcHMoc3R5bGU6IFRleHRTdHlsZSk6IFNwYW5Qcm9wcyB7XG4gIGNvbnN0IHByb3BzOiBTcGFuUHJvcHMgPSB7fVxuXG4gIGlmIChzdHlsZS5ib2xkKSBwcm9wcy5ib2xkID0gdHJ1ZVxuICBpZiAoc3R5bGUuZGltKSBwcm9wcy5kaW0gPSB0cnVlXG4gIGlmIChzdHlsZS5pdGFsaWMpIHByb3BzLml0YWxpYyA9IHRydWVcbiAgaWYgKHN0eWxlLnVuZGVybGluZSAhPT0gJ25vbmUnKSBwcm9wcy51bmRlcmxpbmUgPSB0cnVlXG4gIGlmIChzdHlsZS5zdHJpa2V0aHJvdWdoKSBwcm9wcy5zdHJpa2V0aHJvdWdoID0gdHJ1ZVxuICBpZiAoc3R5bGUuaW52ZXJzZSkgcHJvcHMuaW52ZXJzZSA9IHRydWVcblxuICBjb25zdCBmZ0NvbG9yID0gY29sb3JUb1N0cmluZyhzdHlsZS5mZylcbiAgaWYgKGZnQ29sb3IpIHByb3BzLmNvbG9yID0gZmdDb2xvclxuXG4gIGNvbnN0IGJnQ29sb3IgPSBjb2xvclRvU3RyaW5nKHN0eWxlLmJnKVxuICBpZiAoYmdDb2xvcikgcHJvcHMuYmFja2dyb3VuZENvbG9yID0gYmdDb2xvclxuXG4gIHJldHVybiBwcm9wc1xufVxuXG4vLyBNYXAgdGVybWlvIG5hbWVkIGNvbG9ycyB0byB0aGUgYW5zaTogZm9ybWF0XG5jb25zdCBOQU1FRF9DT0xPUl9NQVA6IFJlY29yZDxOYW1lZENvbG9yLCBzdHJpbmc+ID0ge1xuICBibGFjazogJ2Fuc2k6YmxhY2snLFxuICByZWQ6ICdhbnNpOnJlZCcsXG4gIGdyZWVuOiAnYW5zaTpncmVlbicsXG4gIHllbGxvdzogJ2Fuc2k6eWVsbG93JyxcbiAgYmx1ZTogJ2Fuc2k6Ymx1ZScsXG4gIG1hZ2VudGE6ICdhbnNpOm1hZ2VudGEnLFxuICBjeWFuOiAnYW5zaTpjeWFuJyxcbiAgd2hpdGU6ICdhbnNpOndoaXRlJyxcbiAgYnJpZ2h0QmxhY2s6ICdhbnNpOmJsYWNrQnJpZ2h0JyxcbiAgYnJpZ2h0UmVkOiAnYW5zaTpyZWRCcmlnaHQnLFxuICBicmlnaHRHcmVlbjogJ2Fuc2k6Z3JlZW5CcmlnaHQnLFxuICBicmlnaHRZZWxsb3c6ICdhbnNpOnllbGxvd0JyaWdodCcsXG4gIGJyaWdodEJsdWU6ICdhbnNpOmJsdWVCcmlnaHQnLFxuICBicmlnaHRNYWdlbnRhOiAnYW5zaTptYWdlbnRhQnJpZ2h0JyxcbiAgYnJpZ2h0Q3lhbjogJ2Fuc2k6Y3lhbkJyaWdodCcsXG4gIGJyaWdodFdoaXRlOiAnYW5zaTp3aGl0ZUJyaWdodCcsXG59XG5cbi8qKlxuICogQ29udmVydCB0ZXJtaW8ncyBDb2xvciB0byB0aGUgc3RyaW5nIGZvcm1hdCB1c2VkIGJ5IEluay5cbiAqL1xuZnVuY3Rpb24gY29sb3JUb1N0cmluZyhjb2xvcjogVGVybWlvQ29sb3IpOiBDb2xvciB8IHVuZGVmaW5lZCB7XG4gIHN3aXRjaCAoY29sb3IudHlwZSkge1xuICAgIGNhc2UgJ25hbWVkJzpcbiAgICAgIHJldHVybiBOQU1FRF9DT0xPUl9NQVBbY29sb3IubmFtZV0gYXMgQ29sb3JcbiAgICBjYXNlICdpbmRleGVkJzpcbiAgICAgIHJldHVybiBgYW5zaTI1Nigke2NvbG9yLmluZGV4fSlgIGFzIENvbG9yXG4gICAgY2FzZSAncmdiJzpcbiAgICAgIHJldHVybiBgcmdiKCR7Y29sb3Iucn0sJHtjb2xvci5nfSwke2NvbG9yLmJ9KWAgYXMgQ29sb3JcbiAgICBjYXNlICdkZWZhdWx0JzpcbiAgICAgIHJldHVybiB1bmRlZmluZWRcbiAgfVxufVxuXG4vKipcbiAqIENoZWNrIGlmIHR3byBTcGFuUHJvcHMgYXJlIGVxdWFsIGZvciBtZXJnaW5nLlxuICovXG5mdW5jdGlvbiBwcm9wc0VxdWFsKGE6IFNwYW5Qcm9wcywgYjogU3BhblByb3BzKTogYm9vbGVhbiB7XG4gIHJldHVybiAoXG4gICAgYS5jb2xvciA9PT0gYi5jb2xvciAmJlxuICAgIGEuYmFja2dyb3VuZENvbG9yID09PSBiLmJhY2tncm91bmRDb2xvciAmJlxuICAgIGEuYm9sZCA9PT0gYi5ib2xkICYmXG4gICAgYS5kaW0gPT09IGIuZGltICYmXG4gICAgYS5pdGFsaWMgPT09IGIuaXRhbGljICYmXG4gICAgYS51bmRlcmxpbmUgPT09IGIudW5kZXJsaW5lICYmXG4gICAgYS5zdHJpa2V0aHJvdWdoID09PSBiLnN0cmlrZXRocm91Z2ggJiZcbiAgICBhLmludmVyc2UgPT09IGIuaW52ZXJzZSAmJlxuICAgIGEuaHlwZXJsaW5rID09PSBiLmh5cGVybGlua1xuICApXG59XG5cbmZ1bmN0aW9uIGhhc0FueVByb3BzKHByb3BzOiBTcGFuUHJvcHMpOiBib29sZWFuIHtcbiAgcmV0dXJuIChcbiAgICBwcm9wcy5jb2xvciAhPT0gdW5kZWZpbmVkIHx8XG4gICAgcHJvcHMuYmFja2dyb3VuZENvbG9yICE9PSB1bmRlZmluZWQgfHxcbiAgICBwcm9wcy5kaW0gPT09IHRydWUgfHxcbiAgICBwcm9wcy5ib2xkID09PSB0cnVlIHx8XG4gICAgcHJvcHMuaXRhbGljID09PSB0cnVlIHx8XG4gICAgcHJvcHMudW5kZXJsaW5lID09PSB0cnVlIHx8XG4gICAgcHJvcHMuc3RyaWtldGhyb3VnaCA9PT0gdHJ1ZSB8fFxuICAgIHByb3BzLmludmVyc2UgPT09IHRydWUgfHxcbiAgICBwcm9wcy5oeXBlcmxpbmsgIT09IHVuZGVmaW5lZFxuICApXG59XG5cbmZ1bmN0aW9uIGhhc0FueVRleHRQcm9wcyhwcm9wczogU3BhblByb3BzKTogYm9vbGVhbiB7XG4gIHJldHVybiAoXG4gICAgcHJvcHMuY29sb3IgIT09IHVuZGVmaW5lZCB8fFxuICAgIHByb3BzLmJhY2tncm91bmRDb2xvciAhPT0gdW5kZWZpbmVkIHx8XG4gICAgcHJvcHMuZGltID09PSB0cnVlIHx8XG4gICAgcHJvcHMuYm9sZCA9PT0gdHJ1ZSB8fFxuICAgIHByb3BzLml0YWxpYyA9PT0gdHJ1ZSB8fFxuICAgIHByb3BzLnVuZGVybGluZSA9PT0gdHJ1ZSB8fFxuICAgIHByb3BzLnN0cmlrZXRocm91Z2ggPT09IHRydWUgfHxcbiAgICBwcm9wcy5pbnZlcnNlID09PSB0cnVlXG4gIClcbn1cblxuLy8gVGV4dCBzdHlsZSBwcm9wcyB3aXRob3V0IHdlaWdodCAoYm9sZC9kaW0pIC0gdGhlc2UgYXJlIGhhbmRsZWQgc2VwYXJhdGVseVxudHlwZSBCYXNlVGV4dFN0eWxlUHJvcHMgPSB7XG4gIGNvbG9yPzogQ29sb3JcbiAgYmFja2dyb3VuZENvbG9yPzogQ29sb3JcbiAgaXRhbGljPzogYm9vbGVhblxuICB1bmRlcmxpbmU/OiBib29sZWFuXG4gIHN0cmlrZXRocm91Z2g/OiBib29sZWFuXG4gIGludmVyc2U/OiBib29sZWFuXG59XG5cbi8vIFdyYXBwZXIgY29tcG9uZW50IHRoYXQgaGFuZGxlcyBib2xkL2RpbSBtdXR1YWwgZXhjbHVzaXZpdHkgZm9yIFRleHRcbmZ1bmN0aW9uIFN0eWxlZFRleHQoe1xuICBib2xkLFxuICBkaW0sXG4gIGNoaWxkcmVuLFxuICAuLi5yZXN0XG59OiBCYXNlVGV4dFN0eWxlUHJvcHMgJiB7XG4gIGJvbGQ/OiBib29sZWFuXG4gIGRpbT86IGJvb2xlYW5cbiAgY2hpbGRyZW46IHN0cmluZ1xufSk6IFJlYWN0LlJlYWN0Tm9kZSB7XG4gIC8vIGRpbSB0YWtlcyBwcmVjZWRlbmNlIG92ZXIgYm9sZCB3aGVuIGJvdGggYXJlIHNldCAodGVybWluYWxzIHRyZWF0IHRoZW0gYXMgbXV0dWFsbHkgZXhjbHVzaXZlKVxuICBpZiAoZGltKSB7XG4gICAgcmV0dXJuIChcbiAgICAgIDxUZXh0IHsuLi5yZXN0fSBkaW0+XG4gICAgICAgIHtjaGlsZHJlbn1cbiAgICAgIDwvVGV4dD5cbiAgICApXG4gIH1cbiAgaWYgKGJvbGQpIHtcbiAgICByZXR1cm4gKFxuICAgICAgPFRleHQgey4uLnJlc3R9IGJvbGQ+XG4gICAgICAgIHtjaGlsZHJlbn1cbiAgICAgIDwvVGV4dD5cbiAgICApXG4gIH1cbiAgcmV0dXJuIDxUZXh0IHsuLi5yZXN0fT57Y2hpbGRyZW59PC9UZXh0PlxufVxuIl0sIm1hcHBpbmdzIjoiO0FBQUEsT0FBT0EsS0FBSyxNQUFNLE9BQU87QUFDekIsT0FBT0MsSUFBSSxNQUFNLHNCQUFzQjtBQUN2QyxPQUFPQyxJQUFJLE1BQU0sc0JBQXNCO0FBQ3ZDLGNBQWNDLEtBQUssUUFBUSxhQUFhO0FBQ3hDLFNBQ0UsS0FBS0MsVUFBVSxFQUNmQyxNQUFNLEVBQ04sS0FBS0YsS0FBSyxJQUFJRyxXQUFXLEVBQ3pCLEtBQUtDLFNBQVMsUUFDVCxhQUFhO0FBRXBCLEtBQUtDLEtBQUssR0FBRztFQUNYQyxRQUFRLEVBQUUsTUFBTTtFQUNoQjtFQUNBQyxRQUFRLENBQUMsRUFBRSxPQUFPO0FBQ3BCLENBQUM7QUFFRCxLQUFLQyxTQUFTLEdBQUc7RUFDZkMsS0FBSyxDQUFDLEVBQUVULEtBQUs7RUFDYlUsZUFBZSxDQUFDLEVBQUVWLEtBQUs7RUFDdkJXLEdBQUcsQ0FBQyxFQUFFLE9BQU87RUFDYkMsSUFBSSxDQUFDLEVBQUUsT0FBTztFQUNkQyxNQUFNLENBQUMsRUFBRSxPQUFPO0VBQ2hCQyxTQUFTLENBQUMsRUFBRSxPQUFPO0VBQ25CQyxhQUFhLENBQUMsRUFBRSxPQUFPO0VBQ3ZCQyxPQUFPLENBQUMsRUFBRSxPQUFPO0VBQ2pCQyxTQUFTLENBQUMsRUFBRSxNQUFNO0FBQ3BCLENBQUM7O0FBRUQ7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBLE9BQU8sTUFBTUMsSUFBSSxHQUFHckIsS0FBSyxDQUFDc0IsSUFBSSxDQUFDLFNBQUFELEtBQUFFLEVBQUE7RUFBQSxNQUFBQyxDQUFBLEdBQUFDLEVBQUE7RUFBYztJQUFBaEIsUUFBQTtJQUFBQztFQUFBLElBQUFhLEVBR3JDO0VBQ04sSUFBSSxPQUFPZCxRQUFRLEtBQUssUUFBUTtJQUFBLElBQUFpQixFQUFBO0lBQUEsSUFBQUYsQ0FBQSxRQUFBZixRQUFBLElBQUFlLENBQUEsUUFBQWQsUUFBQTtNQUN2QmdCLEVBQUEsR0FBQWhCLFFBQVEsR0FDYixDQUFDLElBQUksQ0FBQyxHQUFHLENBQUgsS0FBRSxDQUFDLENBQUUsQ0FBQWlCLE1BQU0sQ0FBQ2xCLFFBQVEsRUFBRSxFQUEzQixJQUFJLENBR04sR0FEQyxDQUFDLElBQUksQ0FBRSxDQUFBa0IsTUFBTSxDQUFDbEIsUUFBUSxFQUFFLEVBQXZCLElBQUksQ0FDTjtNQUFBZSxDQUFBLE1BQUFmLFFBQUE7TUFBQWUsQ0FBQSxNQUFBZCxRQUFBO01BQUFjLENBQUEsTUFBQUUsRUFBQTtJQUFBO01BQUFBLEVBQUEsR0FBQUYsQ0FBQTtJQUFBO0lBQUEsT0FKTUUsRUFJTjtFQUFBO0VBR0gsSUFBSWpCLFFBQVEsS0FBSyxFQUFFO0lBQUEsT0FDVixJQUFJO0VBQUE7RUFDWixJQUFBaUIsRUFBQTtFQUFBLElBQUFFLEVBQUE7RUFBQSxJQUFBSixDQUFBLFFBQUFmLFFBQUEsSUFBQWUsQ0FBQSxRQUFBZCxRQUFBO0lBS1FrQixFQUFBLEdBQUFDLE1BQUksQ0FBQUMsR0FBQSxDQUFKLDZCQUFHLENBQUM7SUFBQUMsR0FBQTtNQUhiLE1BQUFDLEtBQUEsR0FBY0MsWUFBWSxDQUFDeEIsUUFBUSxDQUFDO01BRXBDLElBQUl1QixLQUFLLENBQUFFLE1BQU8sS0FBSyxDQUFDO1FBQ2JOLEVBQUEsT0FBSTtRQUFKLE1BQUFHLEdBQUE7TUFBSTtNQUdiLElBQUlDLEtBQUssQ0FBQUUsTUFBTyxLQUFLLENBQWtDLElBQW5ELENBQXVCQyxXQUFXLENBQUNILEtBQUssR0FBRyxDQUFBSSxLQUFPLENBQUM7UUFDOUNSLEVBQUEsR0FBQWxCLFFBQVEsR0FDYixDQUFDLElBQUksQ0FBQyxHQUFHLENBQUgsS0FBRSxDQUFDLENBQUUsQ0FBQXNCLEtBQUssR0FBRyxDQUFBSyxJQUFLLENBQUUsRUFBekIsSUFBSSxDQUdOLEdBREMsQ0FBQyxJQUFJLENBQUUsQ0FBQUwsS0FBSyxHQUFHLENBQUFLLElBQUssQ0FBRSxFQUFyQixJQUFJLENBQ047UUFKTSxNQUFBTixHQUFBO01BSU47TUFDRixJQUFBTyxFQUFBO01BQUEsSUFBQWQsQ0FBQSxRQUFBZCxRQUFBO1FBRXlCNEIsRUFBQSxHQUFBQSxDQUFBQyxJQUFBLEVBQUFDLENBQUE7VUFDeEIsTUFBQXBCLFNBQUEsR0FBa0JtQixJQUFJLENBQUFILEtBQU0sQ0FBQWhCLFNBQVU7VUFFdEMsSUFBSVYsUUFBUTtZQUNWNkIsSUFBSSxDQUFBSCxLQUFNLENBQUF0QixHQUFBLEdBQU8sSUFBSDtVQUFBO1VBRWhCLE1BQUEyQixZQUFBLEdBQXFCQyxlQUFlLENBQUNILElBQUksQ0FBQUgsS0FBTSxDQUFDO1VBRWhELElBQUloQixTQUFTO1lBQUEsT0FDSnFCLFlBQVksR0FDakIsQ0FBQyxJQUFJLENBQU1ELEdBQUMsQ0FBREEsRUFBQSxDQUFDLENBQU9wQixHQUFTLENBQVRBLFVBQVEsQ0FBQyxDQUMxQixDQUFDLFVBQVUsQ0FDRixLQUFnQixDQUFoQixDQUFBbUIsSUFBSSxDQUFBSCxLQUFNLENBQUF4QixLQUFLLENBQUMsQ0FDTixlQUEwQixDQUExQixDQUFBMkIsSUFBSSxDQUFBSCxLQUFNLENBQUF2QixlQUFlLENBQUMsQ0FDdEMsR0FBYyxDQUFkLENBQUEwQixJQUFJLENBQUFILEtBQU0sQ0FBQXRCLEdBQUcsQ0FBQyxDQUNiLElBQWUsQ0FBZixDQUFBeUIsSUFBSSxDQUFBSCxLQUFNLENBQUFyQixJQUFJLENBQUMsQ0FDYixNQUFpQixDQUFqQixDQUFBd0IsSUFBSSxDQUFBSCxLQUFNLENBQUFwQixNQUFNLENBQUMsQ0FDZCxTQUFvQixDQUFwQixDQUFBdUIsSUFBSSxDQUFBSCxLQUFNLENBQUFuQixTQUFTLENBQUMsQ0FDaEIsYUFBd0IsQ0FBeEIsQ0FBQXNCLElBQUksQ0FBQUgsS0FBTSxDQUFBbEIsYUFBYSxDQUFDLENBQzlCLE9BQWtCLENBQWxCLENBQUFxQixJQUFJLENBQUFILEtBQU0sQ0FBQWpCLE9BQU8sQ0FBQyxDQUUxQixDQUFBb0IsSUFBSSxDQUFBRixJQUFJLENBQ1gsRUFYQyxVQUFVLENBWWIsRUFiQyxJQUFJLENBa0JOLEdBSEMsQ0FBQyxJQUFJLENBQU1HLEdBQUMsQ0FBREEsRUFBQSxDQUFDLENBQU9wQixHQUFTLENBQVRBLFVBQVEsQ0FBQyxDQUN6QixDQUFBbUIsSUFBSSxDQUFBRixJQUFJLENBQ1gsRUFGQyxJQUFJLENBR047VUFBQTtVQUNGLE9BRU1JLFlBQVksR0FDakIsQ0FBQyxVQUFVLENBQ0pELEdBQUMsQ0FBREEsRUFBQSxDQUFDLENBQ0MsS0FBZ0IsQ0FBaEIsQ0FBQUQsSUFBSSxDQUFBSCxLQUFNLENBQUF4QixLQUFLLENBQUMsQ0FDTixlQUEwQixDQUExQixDQUFBMkIsSUFBSSxDQUFBSCxLQUFNLENBQUF2QixlQUFlLENBQUMsQ0FDdEMsR0FBYyxDQUFkLENBQUEwQixJQUFJLENBQUFILEtBQU0sQ0FBQXRCLEdBQUcsQ0FBQyxDQUNiLElBQWUsQ0FBZixDQUFBeUIsSUFBSSxDQUFBSCxLQUFNLENBQUFyQixJQUFJLENBQUMsQ0FDYixNQUFpQixDQUFqQixDQUFBd0IsSUFBSSxDQUFBSCxLQUFNLENBQUFwQixNQUFNLENBQUMsQ0FDZCxTQUFvQixDQUFwQixDQUFBdUIsSUFBSSxDQUFBSCxLQUFNLENBQUFuQixTQUFTLENBQUMsQ0FDaEIsYUFBd0IsQ0FBeEIsQ0FBQXNCLElBQUksQ0FBQUgsS0FBTSxDQUFBbEIsYUFBYSxDQUFDLENBQzlCLE9BQWtCLENBQWxCLENBQUFxQixJQUFJLENBQUFILEtBQU0sQ0FBQWpCLE9BQU8sQ0FBQyxDQUUxQixDQUFBb0IsSUFBSSxDQUFBRixJQUFJLENBQ1gsRUFaQyxVQUFVLENBZVosR0FEQ0UsSUFBSSxDQUFBRixJQUNMO1FBQUEsQ0FDRjtRQUFBYixDQUFBLE1BQUFkLFFBQUE7UUFBQWMsQ0FBQSxNQUFBYyxFQUFBO01BQUE7UUFBQUEsRUFBQSxHQUFBZCxDQUFBO01BQUE7TUFoRGVFLEVBQUEsR0FBQU0sS0FBSyxDQUFBVyxHQUFJLENBQUNMLEVBZ0R6QixDQUFDO0lBQUE7SUFBQWQsQ0FBQSxNQUFBZixRQUFBO0lBQUFlLENBQUEsTUFBQWQsUUFBQTtJQUFBYyxDQUFBLE1BQUFFLEVBQUE7SUFBQUYsQ0FBQSxNQUFBSSxFQUFBO0VBQUE7SUFBQUYsRUFBQSxHQUFBRixDQUFBO0lBQUFJLEVBQUEsR0FBQUosQ0FBQTtFQUFBO0VBQUEsSUFBQUksRUFBQSxLQUFBQyxNQUFBLENBQUFDLEdBQUE7SUFBQSxPQUFBRixFQUFBO0VBQUE7RUFoREYsTUFBQWdCLE9BQUEsR0FBZ0JsQixFQWdEZDtFQUFBLElBQUFZLEVBQUE7RUFBQSxJQUFBZCxDQUFBLFFBQUFvQixPQUFBLElBQUFwQixDQUFBLFNBQUFkLFFBQUE7SUFFSzRCLEVBQUEsR0FBQTVCLFFBQVEsR0FBRyxDQUFDLElBQUksQ0FBQyxHQUFHLENBQUgsS0FBRSxDQUFDLENBQUVrQyxRQUFNLENBQUUsRUFBbEIsSUFBSSxDQUE4QyxHQUF0QixDQUFDLElBQUksQ0FBRUEsUUFBTSxDQUFFLEVBQWQsSUFBSSxDQUFpQjtJQUFBcEIsQ0FBQSxNQUFBb0IsT0FBQTtJQUFBcEIsQ0FBQSxPQUFBZCxRQUFBO0lBQUFjLENBQUEsT0FBQWMsRUFBQTtFQUFBO0lBQUFBLEVBQUEsR0FBQWQsQ0FBQTtFQUFBO0VBQUEsT0FBOURjLEVBQThEO0FBQUEsQ0FDdEUsQ0FBQztBQUVGLEtBQUtPLElBQUksR0FBRztFQUNWUixJQUFJLEVBQUUsTUFBTTtFQUNaRCxLQUFLLEVBQUV6QixTQUFTO0FBQ2xCLENBQUM7O0FBRUQ7QUFDQTtBQUNBO0FBQ0EsU0FBU3NCLFlBQVlBLENBQUNhLEtBQUssRUFBRSxNQUFNLENBQUMsRUFBRUQsSUFBSSxFQUFFLENBQUM7RUFDM0MsTUFBTUUsTUFBTSxHQUFHLElBQUkxQyxNQUFNLENBQUMsQ0FBQztFQUMzQixNQUFNMkMsT0FBTyxHQUFHRCxNQUFNLENBQUNFLElBQUksQ0FBQ0gsS0FBSyxDQUFDO0VBQ2xDLE1BQU1kLEtBQUssRUFBRWEsSUFBSSxFQUFFLEdBQUcsRUFBRTtFQUV4QixJQUFJSyxnQkFBZ0IsRUFBRSxNQUFNLEdBQUcsU0FBUztFQUV4QyxLQUFLLE1BQU1DLE1BQU0sSUFBSUgsT0FBTyxFQUFFO0lBQzVCLElBQUlHLE1BQU0sQ0FBQ0MsSUFBSSxLQUFLLE1BQU0sRUFBRTtNQUMxQixJQUFJRCxNQUFNLENBQUNBLE1BQU0sQ0FBQ0MsSUFBSSxLQUFLLE9BQU8sRUFBRTtRQUNsQ0YsZ0JBQWdCLEdBQUdDLE1BQU0sQ0FBQ0EsTUFBTSxDQUFDRSxHQUFHO01BQ3RDLENBQUMsTUFBTTtRQUNMSCxnQkFBZ0IsR0FBR0ksU0FBUztNQUM5QjtNQUNBO0lBQ0Y7SUFFQSxJQUFJSCxNQUFNLENBQUNDLElBQUksS0FBSyxNQUFNLEVBQUU7TUFDMUIsTUFBTWYsSUFBSSxHQUFHYyxNQUFNLENBQUNJLFNBQVMsQ0FBQ1osR0FBRyxDQUFDYSxDQUFDLElBQUlBLENBQUMsQ0FBQ0MsS0FBSyxDQUFDLENBQUNDLElBQUksQ0FBQyxFQUFFLENBQUM7TUFDeEQsSUFBSSxDQUFDckIsSUFBSSxFQUFFO01BRVgsTUFBTUQsS0FBSyxHQUFHdUIsb0JBQW9CLENBQUNSLE1BQU0sQ0FBQ1MsS0FBSyxDQUFDO01BQ2hELElBQUlWLGdCQUFnQixFQUFFO1FBQ3BCZCxLQUFLLENBQUNoQixTQUFTLEdBQUc4QixnQkFBZ0I7TUFDcEM7O01BRUE7TUFDQSxNQUFNVyxRQUFRLEdBQUc3QixLQUFLLENBQUNBLEtBQUssQ0FBQ0UsTUFBTSxHQUFHLENBQUMsQ0FBQztNQUN4QyxJQUFJMkIsUUFBUSxJQUFJQyxVQUFVLENBQUNELFFBQVEsQ0FBQ3pCLEtBQUssRUFBRUEsS0FBSyxDQUFDLEVBQUU7UUFDakR5QixRQUFRLENBQUN4QixJQUFJLElBQUlBLElBQUk7TUFDdkIsQ0FBQyxNQUFNO1FBQ0xMLEtBQUssQ0FBQytCLElBQUksQ0FBQztVQUFFMUIsSUFBSTtVQUFFRDtRQUFNLENBQUMsQ0FBQztNQUM3QjtJQUNGO0VBQ0Y7RUFFQSxPQUFPSixLQUFLO0FBQ2Q7O0FBRUE7QUFDQTtBQUNBO0FBQ0EsU0FBUzJCLG9CQUFvQkEsQ0FBQ0MsS0FBSyxFQUFFckQsU0FBUyxDQUFDLEVBQUVJLFNBQVMsQ0FBQztFQUN6RCxNQUFNeUIsS0FBSyxFQUFFekIsU0FBUyxHQUFHLENBQUMsQ0FBQztFQUUzQixJQUFJaUQsS0FBSyxDQUFDN0MsSUFBSSxFQUFFcUIsS0FBSyxDQUFDckIsSUFBSSxHQUFHLElBQUk7RUFDakMsSUFBSTZDLEtBQUssQ0FBQzlDLEdBQUcsRUFBRXNCLEtBQUssQ0FBQ3RCLEdBQUcsR0FBRyxJQUFJO0VBQy9CLElBQUk4QyxLQUFLLENBQUM1QyxNQUFNLEVBQUVvQixLQUFLLENBQUNwQixNQUFNLEdBQUcsSUFBSTtFQUNyQyxJQUFJNEMsS0FBSyxDQUFDM0MsU0FBUyxLQUFLLE1BQU0sRUFBRW1CLEtBQUssQ0FBQ25CLFNBQVMsR0FBRyxJQUFJO0VBQ3RELElBQUkyQyxLQUFLLENBQUMxQyxhQUFhLEVBQUVrQixLQUFLLENBQUNsQixhQUFhLEdBQUcsSUFBSTtFQUNuRCxJQUFJMEMsS0FBSyxDQUFDekMsT0FBTyxFQUFFaUIsS0FBSyxDQUFDakIsT0FBTyxHQUFHLElBQUk7RUFFdkMsTUFBTTZDLE9BQU8sR0FBR0MsYUFBYSxDQUFDTCxLQUFLLENBQUNNLEVBQUUsQ0FBQztFQUN2QyxJQUFJRixPQUFPLEVBQUU1QixLQUFLLENBQUN4QixLQUFLLEdBQUdvRCxPQUFPO0VBRWxDLE1BQU1HLE9BQU8sR0FBR0YsYUFBYSxDQUFDTCxLQUFLLENBQUNRLEVBQUUsQ0FBQztFQUN2QyxJQUFJRCxPQUFPLEVBQUUvQixLQUFLLENBQUN2QixlQUFlLEdBQUdzRCxPQUFPO0VBRTVDLE9BQU8vQixLQUFLO0FBQ2Q7O0FBRUE7QUFDQSxNQUFNaUMsZUFBZSxFQUFFQyxNQUFNLENBQUNsRSxVQUFVLEVBQUUsTUFBTSxDQUFDLEdBQUc7RUFDbERtRSxLQUFLLEVBQUUsWUFBWTtFQUNuQkMsR0FBRyxFQUFFLFVBQVU7RUFDZkMsS0FBSyxFQUFFLFlBQVk7RUFDbkJDLE1BQU0sRUFBRSxhQUFhO0VBQ3JCQyxJQUFJLEVBQUUsV0FBVztFQUNqQkMsT0FBTyxFQUFFLGNBQWM7RUFDdkJDLElBQUksRUFBRSxXQUFXO0VBQ2pCQyxLQUFLLEVBQUUsWUFBWTtFQUNuQkMsV0FBVyxFQUFFLGtCQUFrQjtFQUMvQkMsU0FBUyxFQUFFLGdCQUFnQjtFQUMzQkMsV0FBVyxFQUFFLGtCQUFrQjtFQUMvQkMsWUFBWSxFQUFFLG1CQUFtQjtFQUNqQ0MsVUFBVSxFQUFFLGlCQUFpQjtFQUM3QkMsYUFBYSxFQUFFLG9CQUFvQjtFQUNuQ0MsVUFBVSxFQUFFLGlCQUFpQjtFQUM3QkMsV0FBVyxFQUFFO0FBQ2YsQ0FBQzs7QUFFRDtBQUNBO0FBQ0E7QUFDQSxTQUFTckIsYUFBYUEsQ0FBQ3JELEtBQUssRUFBRU4sV0FBVyxDQUFDLEVBQUVILEtBQUssR0FBRyxTQUFTLENBQUM7RUFDNUQsUUFBUVMsS0FBSyxDQUFDd0MsSUFBSTtJQUNoQixLQUFLLE9BQU87TUFDVixPQUFPaUIsZUFBZSxDQUFDekQsS0FBSyxDQUFDMkUsSUFBSSxDQUFDLElBQUlwRixLQUFLO0lBQzdDLEtBQUssU0FBUztNQUNaLE9BQU8sV0FBV1MsS0FBSyxDQUFDNEUsS0FBSyxHQUFHLElBQUlyRixLQUFLO0lBQzNDLEtBQUssS0FBSztNQUNSLE9BQU8sT0FBT1MsS0FBSyxDQUFDNkUsQ0FBQyxJQUFJN0UsS0FBSyxDQUFDNEMsQ0FBQyxJQUFJNUMsS0FBSyxDQUFDOEUsQ0FBQyxHQUFHLElBQUl2RixLQUFLO0lBQ3pELEtBQUssU0FBUztNQUNaLE9BQU9tRCxTQUFTO0VBQ3BCO0FBQ0Y7O0FBRUE7QUFDQTtBQUNBO0FBQ0EsU0FBU1EsVUFBVUEsQ0FBQzZCLENBQUMsRUFBRWhGLFNBQVMsRUFBRStFLENBQUMsRUFBRS9FLFNBQVMsQ0FBQyxFQUFFLE9BQU8sQ0FBQztFQUN2RCxPQUNFZ0YsQ0FBQyxDQUFDL0UsS0FBSyxLQUFLOEUsQ0FBQyxDQUFDOUUsS0FBSyxJQUNuQitFLENBQUMsQ0FBQzlFLGVBQWUsS0FBSzZFLENBQUMsQ0FBQzdFLGVBQWUsSUFDdkM4RSxDQUFDLENBQUM1RSxJQUFJLEtBQUsyRSxDQUFDLENBQUMzRSxJQUFJLElBQ2pCNEUsQ0FBQyxDQUFDN0UsR0FBRyxLQUFLNEUsQ0FBQyxDQUFDNUUsR0FBRyxJQUNmNkUsQ0FBQyxDQUFDM0UsTUFBTSxLQUFLMEUsQ0FBQyxDQUFDMUUsTUFBTSxJQUNyQjJFLENBQUMsQ0FBQzFFLFNBQVMsS0FBS3lFLENBQUMsQ0FBQ3pFLFNBQVMsSUFDM0IwRSxDQUFDLENBQUN6RSxhQUFhLEtBQUt3RSxDQUFDLENBQUN4RSxhQUFhLElBQ25DeUUsQ0FBQyxDQUFDeEUsT0FBTyxLQUFLdUUsQ0FBQyxDQUFDdkUsT0FBTyxJQUN2QndFLENBQUMsQ0FBQ3ZFLFNBQVMsS0FBS3NFLENBQUMsQ0FBQ3RFLFNBQVM7QUFFL0I7QUFFQSxTQUFTZSxXQUFXQSxDQUFDQyxLQUFLLEVBQUV6QixTQUFTLENBQUMsRUFBRSxPQUFPLENBQUM7RUFDOUMsT0FDRXlCLEtBQUssQ0FBQ3hCLEtBQUssS0FBSzBDLFNBQVMsSUFDekJsQixLQUFLLENBQUN2QixlQUFlLEtBQUt5QyxTQUFTLElBQ25DbEIsS0FBSyxDQUFDdEIsR0FBRyxLQUFLLElBQUksSUFDbEJzQixLQUFLLENBQUNyQixJQUFJLEtBQUssSUFBSSxJQUNuQnFCLEtBQUssQ0FBQ3BCLE1BQU0sS0FBSyxJQUFJLElBQ3JCb0IsS0FBSyxDQUFDbkIsU0FBUyxLQUFLLElBQUksSUFDeEJtQixLQUFLLENBQUNsQixhQUFhLEtBQUssSUFBSSxJQUM1QmtCLEtBQUssQ0FBQ2pCLE9BQU8sS0FBSyxJQUFJLElBQ3RCaUIsS0FBSyxDQUFDaEIsU0FBUyxLQUFLa0MsU0FBUztBQUVqQztBQUVBLFNBQVNaLGVBQWVBLENBQUNOLEtBQUssRUFBRXpCLFNBQVMsQ0FBQyxFQUFFLE9BQU8sQ0FBQztFQUNsRCxPQUNFeUIsS0FBSyxDQUFDeEIsS0FBSyxLQUFLMEMsU0FBUyxJQUN6QmxCLEtBQUssQ0FBQ3ZCLGVBQWUsS0FBS3lDLFNBQVMsSUFDbkNsQixLQUFLLENBQUN0QixHQUFHLEtBQUssSUFBSSxJQUNsQnNCLEtBQUssQ0FBQ3JCLElBQUksS0FBSyxJQUFJLElBQ25CcUIsS0FBSyxDQUFDcEIsTUFBTSxLQUFLLElBQUksSUFDckJvQixLQUFLLENBQUNuQixTQUFTLEtBQUssSUFBSSxJQUN4Qm1CLEtBQUssQ0FBQ2xCLGFBQWEsS0FBSyxJQUFJLElBQzVCa0IsS0FBSyxDQUFDakIsT0FBTyxLQUFLLElBQUk7QUFFMUI7O0FBRUE7QUFDQSxLQUFLeUUsa0JBQWtCLEdBQUc7RUFDeEJoRixLQUFLLENBQUMsRUFBRVQsS0FBSztFQUNiVSxlQUFlLENBQUMsRUFBRVYsS0FBSztFQUN2QmEsTUFBTSxDQUFDLEVBQUUsT0FBTztFQUNoQkMsU0FBUyxDQUFDLEVBQUUsT0FBTztFQUNuQkMsYUFBYSxDQUFDLEVBQUUsT0FBTztFQUN2QkMsT0FBTyxDQUFDLEVBQUUsT0FBTztBQUNuQixDQUFDOztBQUVEO0FBQ0EsU0FBQTBFLFdBQUF0RSxFQUFBO0VBQUEsTUFBQUMsQ0FBQSxHQUFBQyxFQUFBO0VBQUEsSUFBQVYsSUFBQTtFQUFBLElBQUFOLFFBQUE7RUFBQSxJQUFBSyxHQUFBO0VBQUEsSUFBQWdGLElBQUE7RUFBQSxJQUFBdEUsQ0FBQSxRQUFBRCxFQUFBO0lBQW9CO01BQUFSLElBQUE7TUFBQUQsR0FBQTtNQUFBTCxRQUFBO01BQUEsR0FBQXFGO0lBQUEsSUFBQXZFLEVBU25CO0lBQUFDLENBQUEsTUFBQUQsRUFBQTtJQUFBQyxDQUFBLE1BQUFULElBQUE7SUFBQVMsQ0FBQSxNQUFBZixRQUFBO0lBQUFlLENBQUEsTUFBQVYsR0FBQTtJQUFBVSxDQUFBLE1BQUFzRSxJQUFBO0VBQUE7SUFBQS9FLElBQUEsR0FBQVMsQ0FBQTtJQUFBZixRQUFBLEdBQUFlLENBQUE7SUFBQVYsR0FBQSxHQUFBVSxDQUFBO0lBQUFzRSxJQUFBLEdBQUF0RSxDQUFBO0VBQUE7RUFFQyxJQUFJVixHQUFHO0lBQUEsSUFBQVksRUFBQTtJQUFBLElBQUFGLENBQUEsUUFBQWYsUUFBQSxJQUFBZSxDQUFBLFFBQUFzRSxJQUFBO01BRUhwRSxFQUFBLElBQUMsSUFBSSxLQUFLb0UsSUFBSSxFQUFFLEdBQUcsQ0FBSCxLQUFFLENBQUMsQ0FDaEJyRixTQUFPLENBQ1YsRUFGQyxJQUFJLENBRUU7TUFBQWUsQ0FBQSxNQUFBZixRQUFBO01BQUFlLENBQUEsTUFBQXNFLElBQUE7TUFBQXRFLENBQUEsTUFBQUUsRUFBQTtJQUFBO01BQUFBLEVBQUEsR0FBQUYsQ0FBQTtJQUFBO0lBQUEsT0FGUEUsRUFFTztFQUFBO0VBR1gsSUFBSVgsSUFBSTtJQUFBLElBQUFXLEVBQUE7SUFBQSxJQUFBRixDQUFBLFFBQUFmLFFBQUEsSUFBQWUsQ0FBQSxRQUFBc0UsSUFBQTtNQUVKcEUsRUFBQSxJQUFDLElBQUksS0FBS29FLElBQUksRUFBRSxJQUFJLENBQUosS0FBRyxDQUFDLENBQ2pCckYsU0FBTyxDQUNWLEVBRkMsSUFBSSxDQUVFO01BQUFlLENBQUEsTUFBQWYsUUFBQTtNQUFBZSxDQUFBLE1BQUFzRSxJQUFBO01BQUF0RSxDQUFBLE9BQUFFLEVBQUE7SUFBQTtNQUFBQSxFQUFBLEdBQUFGLENBQUE7SUFBQTtJQUFBLE9BRlBFLEVBRU87RUFBQTtFQUVWLElBQUFBLEVBQUE7RUFBQSxJQUFBRixDQUFBLFNBQUFmLFFBQUEsSUFBQWUsQ0FBQSxTQUFBc0UsSUFBQTtJQUNNcEUsRUFBQSxJQUFDLElBQUksS0FBS29FLElBQUksRUFBR3JGLFNBQU8sQ0FBRSxFQUF6QixJQUFJLENBQTRCO0lBQUFlLENBQUEsT0FBQWYsUUFBQTtJQUFBZSxDQUFBLE9BQUFzRSxJQUFBO0lBQUF0RSxDQUFBLE9BQUFFLEVBQUE7RUFBQTtJQUFBQSxFQUFBLEdBQUFGLENBQUE7RUFBQTtFQUFBLE9BQWpDRSxFQUFpQztBQUFBIiwiaWdub3JlTGlzdCI6W119

--- a/packages/renderer/src/components/AlternateScreen.tsx
+++ b/packages/renderer/src/components/AlternateScreen.tsx
@@ -1,14 +1,23 @@
-import { c as _c } from "react/compiler-runtime";
-import React, { type PropsWithChildren, useContext, useInsertionEffect } from 'react';
-import instances from '../instances';
-import { DISABLE_MOUSE_TRACKING, ENABLE_MOUSE_TRACKING, ENTER_ALT_SCREEN, EXIT_ALT_SCREEN } from '../termio/dec';
-import { TerminalWriteContext } from '../useTerminalNotification';
-import Box from './Box';
-import { TerminalSizeContext } from './TerminalSizeContext';
+import React, {
+  type PropsWithChildren,
+  useContext,
+  useInsertionEffect,
+} from 'react'
+import instances from '../instances.js'
+import {
+  DISABLE_MOUSE_TRACKING,
+  ENABLE_MOUSE_TRACKING,
+  ENTER_ALT_SCREEN,
+  EXIT_ALT_SCREEN,
+} from '../termio/dec.js'
+import { TerminalWriteContext } from '../useTerminalNotification.js'
+import Box from './Box.js'
+import { TerminalSizeContext } from './TerminalSizeContext.js'
+
 type Props = PropsWithChildren<{
   /** Enable SGR mouse tracking (wheel + click/drag). Default true. */
-  mouseTracking?: boolean;
-}>;
+  mouseTracking?: boolean
+}>
 
 /**
  * Run children in the terminal's alternate screen buffer, constrained to
@@ -30,51 +39,49 @@ type Props = PropsWithChildren<{
  * from scrolling content) and so signal-exit cleanup can exit the alt
  * screen if the component's own unmount doesn't run.
  */
-export function AlternateScreen(t0: Props) {
-  const $ = _c(7);
-  const {
-    children,
-    mouseTracking: t1
-  } = t0;
-  const mouseTracking = t1 === undefined ? true : t1;
-  const size = useContext(TerminalSizeContext);
-  const writeRaw = useContext(TerminalWriteContext);
-  let t2;
-  let t3;
-  if ($[0] !== mouseTracking || $[1] !== writeRaw) {
-    t2 = () => {
-      const ink = instances.get(process.stdout);
-      if (!writeRaw) {
-        return;
-      }
-      writeRaw(ENTER_ALT_SCREEN + "\x1B[2J\x1B[H" + (mouseTracking ? ENABLE_MOUSE_TRACKING : ""));
-      ink?.setAltScreenActive(true, mouseTracking);
-      return () => {
-        ink?.setAltScreenActive(false);
-        ink?.clearTextSelection();
-        writeRaw((mouseTracking ? DISABLE_MOUSE_TRACKING : "") + EXIT_ALT_SCREEN);
-      };
-    };
-    t3 = [writeRaw, mouseTracking];
-    $[0] = mouseTracking;
-    $[1] = writeRaw;
-    $[2] = t2;
-    $[3] = t3;
-  } else {
-    t2 = $[2];
-    t3 = $[3];
-  }
-  useInsertionEffect(t2, t3);
-  const t4 = size?.rows ?? 24;
-  let t5;
-  if ($[4] !== children || $[5] !== t4) {
-    t5 = <Box flexDirection="column" height={t4} width="100%" flexShrink={0}>{children}</Box>;
-    $[4] = children;
-    $[5] = t4;
-    $[6] = t5;
-  } else {
-    t5 = $[6];
-  }
-  return t5;
+export function AlternateScreen({
+  children,
+  mouseTracking = true,
+}: Props): React.ReactNode {
+  const size = useContext(TerminalSizeContext)
+  const writeRaw = useContext(TerminalWriteContext)
+
+  // useInsertionEffect (not useLayoutEffect): react-reconciler calls
+  // resetAfterCommit between the mutation and layout commit phases, and
+  // Ink's resetAfterCommit triggers onRender. With useLayoutEffect, that
+  // first onRender fires BEFORE this effect — writing a full frame to the
+  // main screen with altScreen=false. That frame is preserved when we
+  // enter alt screen and revealed on exit as a broken view. Insertion
+  // effects fire during the mutation phase, before resetAfterCommit, so
+  // ENTER_ALT_SCREEN reaches the terminal before the first frame does.
+  // Cleanup timing is unchanged: both insertion and layout effect cleanup
+  // run in the mutation phase on unmount, before resetAfterCommit.
+  useInsertionEffect(() => {
+    const ink = instances.get(process.stdout)
+    if (!writeRaw) return
+
+    writeRaw(
+      ENTER_ALT_SCREEN +
+        '\x1b[2J\x1b[H' +
+        (mouseTracking ? ENABLE_MOUSE_TRACKING : ''),
+    )
+    ink?.setAltScreenActive(true, mouseTracking)
+
+    return () => {
+      ink?.setAltScreenActive(false)
+      ink?.clearTextSelection()
+      writeRaw((mouseTracking ? DISABLE_MOUSE_TRACKING : '') + EXIT_ALT_SCREEN)
+    }
+  }, [writeRaw, mouseTracking])
+
+  return (
+    <Box
+      flexDirection="column"
+      height={size?.rows ?? 24}
+      width="100%"
+      flexShrink={0}
+    >
+      {children}
+    </Box>
+  )
 }
-//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJuYW1lcyI6WyJSZWFjdCIsIlByb3BzV2l0aENoaWxkcmVuIiwidXNlQ29udGV4dCIsInVzZUluc2VydGlvbkVmZmVjdCIsImluc3RhbmNlcyIsIkRJU0FCTEVfTU9VU0VfVFJBQ0tJTkciLCJFTkFCTEVfTU9VU0VfVFJBQ0tJTkciLCJFTlRFUl9BTFRfU0NSRUVOIiwiRVhJVF9BTFRfU0NSRUVOIiwiVGVybWluYWxXcml0ZUNvbnRleHQiLCJCb3giLCJUZXJtaW5hbFNpemVDb250ZXh0IiwiUHJvcHMiLCJtb3VzZVRyYWNraW5nIiwiQWx0ZXJuYXRlU2NyZWVuIiwidDAiLCIkIiwiX2MiLCJjaGlsZHJlbiIsInQxIiwidW5kZWZpbmVkIiwic2l6ZSIsIndyaXRlUmF3IiwidDIiLCJ0MyIsImluayIsImdldCIsInByb2Nlc3MiLCJzdGRvdXQiLCJzZXRBbHRTY3JlZW5BY3RpdmUiLCJjbGVhclRleHRTZWxlY3Rpb24iLCJ0NCIsInJvd3MiLCJ0NSJdLCJzb3VyY2VzIjpbIkFsdGVybmF0ZVNjcmVlbi50c3giXSwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IFJlYWN0LCB7XG4gIHR5cGUgUHJvcHNXaXRoQ2hpbGRyZW4sXG4gIHVzZUNvbnRleHQsXG4gIHVzZUluc2VydGlvbkVmZmVjdCxcbn0gZnJvbSAncmVhY3QnXG5pbXBvcnQgaW5zdGFuY2VzIGZyb20gJy4uL2luc3RhbmNlcy5qcydcbmltcG9ydCB7XG4gIERJU0FCTEVfTU9VU0VfVFJBQ0tJTkcsXG4gIEVOQUJMRV9NT1VTRV9UUkFDS0lORyxcbiAgRU5URVJfQUxUX1NDUkVFTixcbiAgRVhJVF9BTFRfU0NSRUVOLFxufSBmcm9tICcuLi90ZXJtaW8vZGVjLmpzJ1xuaW1wb3J0IHsgVGVybWluYWxXcml0ZUNvbnRleHQgfSBmcm9tICcuLi91c2VUZXJtaW5hbE5vdGlmaWNhdGlvbi5qcydcbmltcG9ydCBCb3ggZnJvbSAnLi9Cb3guanMnXG5pbXBvcnQgeyBUZXJtaW5hbFNpemVDb250ZXh0IH0gZnJvbSAnLi9UZXJtaW5hbFNpemVDb250ZXh0LmpzJ1xuXG50eXBlIFByb3BzID0gUHJvcHNXaXRoQ2hpbGRyZW48e1xuICAvKiogRW5hYmxlIFNHUiBtb3VzZSB0cmFja2luZyAod2hlZWwgKyBjbGljay9kcmFnKS4gRGVmYXVsdCB0cnVlLiAqL1xuICBtb3VzZVRyYWNraW5nPzogYm9vbGVhblxufT5cblxuLyoqXG4gKiBSdW4gY2hpbGRyZW4gaW4gdGhlIHRlcm1pbmFsJ3MgYWx0ZXJuYXRlIHNjcmVlbiBidWZmZXIsIGNvbnN0cmFpbmVkIHRvXG4gKiB0aGUgdmlld3BvcnQgaGVpZ2h0LiBXaGlsZSBtb3VudGVkOlxuICpcbiAqIC0gRW50ZXJzIHRoZSBhbHQgc2NyZWVuIChERUMgMTA0OSksIGNsZWFycyBpdCwgaG9tZXMgdGhlIGN1cnNvclxuICogLSBDb25zdHJhaW5zIGl0cyBvd24gaGVpZ2h0IHRvIHRoZSB0ZXJtaW5hbCByb3cgY291bnQsIHNvIG92ZXJmbG93IG11c3RcbiAqICAgYmUgaGFuZGxlZCB2aWEgYG92ZXJmbG93OiBzY3JvbGxgIC8gZmxleGJveCAobm8gbmF0aXZlIHNjcm9sbGJhY2spXG4gKiAtIE9wdGlvbmFsbHkgZW5hYmxlcyBTR1IgbW91c2UgdHJhY2tpbmcgKHdoZWVsICsgY2xpY2svZHJhZykg4oCUIGV2ZW50c1xuICogICBzdXJmYWNlIGFzIGBQYXJzZWRLZXlgICh3aGVlbCkgYW5kIHVwZGF0ZSB0aGUgSW5rIGluc3RhbmNlJ3NcbiAqICAgc2VsZWN0aW9uIHN0YXRlIChjbGljay9kcmFnKVxuICpcbiAqIE9uIHVubW91bnQsIGRpc2FibGVzIG1vdXNlIHRyYWNraW5nIGFuZCBleGl0cyB0aGUgYWx0IHNjcmVlbiwgcmVzdG9yaW5nXG4gKiB0aGUgbWFpbiBzY3JlZW4ncyBjb250ZW50LiBTYWZlIGZvciB1c2UgaW4gY3RybC1vIHRyYW5zY3JpcHQgb3ZlcmxheXNcbiAqIGFuZCBzaW1pbGFyIHRlbXBvcmFyeSBmdWxsc2NyZWVuIHZpZXdzIOKAlCB0aGUgbWFpbiBzY3JlZW4gaXMgcHJlc2VydmVkLlxuICpcbiAqIE5vdGlmaWVzIHRoZSBJbmsgaW5zdGFuY2UgdmlhIGBzZXRBbHRTY3JlZW5BY3RpdmUoKWAgc28gdGhlIHJlbmRlcmVyXG4gKiBrZWVwcyB0aGUgY3Vyc29yIGluc2lkZSB0aGUgdmlld3BvcnQgKHByZXZlbnRpbmcgdGhlIGN1cnNvci1yZXN0b3JlIExGXG4gKiBmcm9tIHNjcm9sbGluZyBjb250ZW50KSBhbmQgc28gc2lnbmFsLWV4aXQgY2xlYW51cCBjYW4gZXhpdCB0aGUgYWx0XG4gKiBzY3JlZW4gaWYgdGhlIGNvbXBvbmVudCdzIG93biB1bm1vdW50IGRvZXNuJ3QgcnVuLlxuICovXG5leHBvcnQgZnVuY3Rpb24gQWx0ZXJuYXRlU2NyZWVuKHtcbiAgY2hpbGRyZW4sXG4gIG1vdXNlVHJhY2tpbmcgPSB0cnVlLFxufTogUHJvcHMpOiBSZWFjdC5SZWFjdE5vZGUge1xuICBjb25zdCBzaXplID0gdXNlQ29udGV4dChUZXJtaW5hbFNpemVDb250ZXh0KVxuICBjb25zdCB3cml0ZVJhdyA9IHVzZUNvbnRleHQoVGVybWluYWxXcml0ZUNvbnRleHQpXG5cbiAgLy8gdXNlSW5zZXJ0aW9uRWZmZWN0IChub3QgdXNlTGF5b3V0RWZmZWN0KTogcmVhY3QtcmVjb25jaWxlciBjYWxsc1xuICAvLyByZXNldEFmdGVyQ29tbWl0IGJldHdlZW4gdGhlIG11dGF0aW9uIGFuZCBsYXlvdXQgY29tbWl0IHBoYXNlcywgYW5kXG4gIC8vIEluaydzIHJlc2V0QWZ0ZXJDb21taXQgdHJpZ2dlcnMgb25SZW5kZXIuIFdpdGggdXNlTGF5b3V0RWZmZWN0LCB0aGF0XG4gIC8vIGZpcnN0IG9uUmVuZGVyIGZpcmVzIEJFRk9SRSB0aGlzIGVmZmVjdCDigJQgd3JpdGluZyBhIGZ1bGwgZnJhbWUgdG8gdGhlXG4gIC8vIG1haW4gc2NyZWVuIHdpdGggYWx0U2NyZWVuPWZhbHNlLiBUaGF0IGZyYW1lIGlzIHByZXNlcnZlZCB3aGVuIHdlXG4gIC8vIGVudGVyIGFsdCBzY3JlZW4gYW5kIHJldmVhbGVkIG9uIGV4aXQgYXMgYSBicm9rZW4gdmlldy4gSW5zZXJ0aW9uXG4gIC8vIGVmZmVjdHMgZmlyZSBkdXJpbmcgdGhlIG11dGF0aW9uIHBoYXNlLCBiZWZvcmUgcmVzZXRBZnRlckNvbW1pdCwgc29cbiAgLy8gRU5URVJfQUxUX1NDUkVFTiByZWFjaGVzIHRoZSB0ZXJtaW5hbCBiZWZvcmUgdGhlIGZpcnN0IGZyYW1lIGRvZXMuXG4gIC8vIENsZWFudXAgdGltaW5nIGlzIHVuY2hhbmdlZDogYm90aCBpbnNlcnRpb24gYW5kIGxheW91dCBlZmZlY3QgY2xlYW51cFxuICAvLyBydW4gaW4gdGhlIG11dGF0aW9uIHBoYXNlIG9uIHVubW91bnQsIGJlZm9yZSByZXNldEFmdGVyQ29tbWl0LlxuICB1c2VJbnNlcnRpb25FZmZlY3QoKCkgPT4ge1xuICAgIGNvbnN0IGluayA9IGluc3RhbmNlcy5nZXQocHJvY2Vzcy5zdGRvdXQpXG4gICAgaWYgKCF3cml0ZVJhdykgcmV0dXJuXG5cbiAgICB3cml0ZVJhdyhcbiAgICAgIEVOVEVSX0FMVF9TQ1JFRU4gK1xuICAgICAgICAnXFx4MWJbMkpcXHgxYltIJyArXG4gICAgICAgIChtb3VzZVRyYWNraW5nID8gRU5BQkxFX01PVVNFX1RSQUNLSU5HIDogJycpLFxuICAgIClcbiAgICBpbms/LnNldEFsdFNjcmVlbkFjdGl2ZSh0cnVlLCBtb3VzZVRyYWNraW5nKVxuXG4gICAgcmV0dXJuICgpID0+IHtcbiAgICAgIGluaz8uc2V0QWx0U2NyZWVuQWN0aXZlKGZhbHNlKVxuICAgICAgaW5rPy5jbGVhclRleHRTZWxlY3Rpb24oKVxuICAgICAgd3JpdGVSYXcoKG1vdXNlVHJhY2tpbmcgPyBESVNBQkxFX01PVVNFX1RSQUNLSU5HIDogJycpICsgRVhJVF9BTFRfU0NSRUVOKVxuICAgIH1cbiAgfSwgW3dyaXRlUmF3LCBtb3VzZVRyYWNraW5nXSlcblxuICByZXR1cm4gKFxuICAgIDxCb3hcbiAgICAgIGZsZXhEaXJlY3Rpb249XCJjb2x1bW5cIlxuICAgICAgaGVpZ2h0PXtzaXplPy5yb3dzID8/IDI0fVxuICAgICAgd2lkdGg9XCIxMDAlXCJcbiAgICAgIGZsZXhTaHJpbms9ezB9XG4gICAgPlxuICAgICAge2NoaWxkcmVufVxuICAgIDwvQm94PlxuICApXG59XG4iXSwibWFwcGluZ3MiOiI7QUFBQSxPQUFPQSxLQUFLLElBQ1YsS0FBS0MsaUJBQWlCLEVBQ3RCQyxVQUFVLEVBQ1ZDLGtCQUFrQixRQUNiLE9BQU87QUFDZCxPQUFPQyxTQUFTLE1BQU0saUJBQWlCO0FBQ3ZDLFNBQ0VDLHNCQUFzQixFQUN0QkMscUJBQXFCLEVBQ3JCQyxnQkFBZ0IsRUFDaEJDLGVBQWUsUUFDVixrQkFBa0I7QUFDekIsU0FBU0Msb0JBQW9CLFFBQVEsK0JBQStCO0FBQ3BFLE9BQU9DLEdBQUcsTUFBTSxVQUFVO0FBQzFCLFNBQVNDLG1CQUFtQixRQUFRLDBCQUEwQjtBQUU5RCxLQUFLQyxLQUFLLEdBQUdYLGlCQUFpQixDQUFDO0VBQzdCO0VBQ0FZLGFBQWEsQ0FBQyxFQUFFLE9BQU87QUFDekIsQ0FBQyxDQUFDOztBQUVGO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQSxPQUFPLFNBQUFDLGdCQUFBQyxFQUFBO0VBQUEsTUFBQUMsQ0FBQSxHQUFBQyxFQUFBO0VBQXlCO0lBQUFDLFFBQUE7SUFBQUwsYUFBQSxFQUFBTTtFQUFBLElBQUFKLEVBR3hCO0VBRE4sTUFBQUYsYUFBQSxHQUFBTSxFQUFvQixLQUFwQkMsU0FBb0IsR0FBcEIsSUFBb0IsR0FBcEJELEVBQW9CO0VBRXBCLE1BQUFFLElBQUEsR0FBYW5CLFVBQVUsQ0FBQ1MsbUJBQW1CLENBQUM7RUFDNUMsTUFBQVcsUUFBQSxHQUFpQnBCLFVBQVUsQ0FBQ08sb0JBQW9CLENBQUM7RUFBQSxJQUFBYyxFQUFBO0VBQUEsSUFBQUMsRUFBQTtFQUFBLElBQUFSLENBQUEsUUFBQUgsYUFBQSxJQUFBRyxDQUFBLFFBQUFNLFFBQUE7SUFZOUJDLEVBQUEsR0FBQUEsQ0FBQTtNQUNqQixNQUFBRSxHQUFBLEdBQVlyQixTQUFTLENBQUFzQixHQUFJLENBQUNDLE9BQU8sQ0FBQUMsTUFBTyxDQUFDO01BQ3pDLElBQUksQ0FBQ04sUUFBUTtRQUFBO01BQUE7TUFFYkEsUUFBUSxDQUNOZixnQkFBZ0IsR0FDZCxlQUFlLElBQ2RNLGFBQWEsR0FBYlAscUJBQTBDLEdBQTFDLEVBQTBDLENBQy9DLENBQUM7TUFDRG1CLEdBQUcsRUFBQUksa0JBQXlDLENBQXBCLElBQUksRUFBRWhCLGFBQWEsQ0FBQztNQUFBLE9BRXJDO1FBQ0xZLEdBQUcsRUFBQUksa0JBQTJCLENBQU4sS0FBSyxDQUFDO1FBQzlCSixHQUFHLEVBQUFLLGtCQUFzQixDQUFELENBQUM7UUFDekJSLFFBQVEsQ0FBQyxDQUFDVCxhQUFhLEdBQWJSLHNCQUEyQyxHQUEzQyxFQUEyQyxJQUFJRyxlQUFlLENBQUM7TUFBQSxDQUMxRTtJQUFBLENBQ0Y7SUFBRWdCLEVBQUEsSUFBQ0YsUUFBUSxFQUFFVCxhQUFhLENBQUM7SUFBQUcsQ0FBQSxNQUFBSCxhQUFBO0lBQUFHLENBQUEsTUFBQU0sUUFBQTtJQUFBTixDQUFBLE1BQUFPLEVBQUE7SUFBQVAsQ0FBQSxNQUFBUSxFQUFBO0VBQUE7SUFBQUQsRUFBQSxHQUFBUCxDQUFBO0lBQUFRLEVBQUEsR0FBQVIsQ0FBQTtFQUFBO0VBaEI1QmIsa0JBQWtCLENBQUNvQixFQWdCbEIsRUFBRUMsRUFBeUIsQ0FBQztFQUtqQixNQUFBTyxFQUFBLEdBQUFWLElBQUksRUFBQVcsSUFBWSxJQUFoQixFQUFnQjtFQUFBLElBQUFDLEVBQUE7RUFBQSxJQUFBakIsQ0FBQSxRQUFBRSxRQUFBLElBQUFGLENBQUEsUUFBQWUsRUFBQTtJQUYxQkUsRUFBQSxJQUFDLEdBQUcsQ0FDWSxhQUFRLENBQVIsUUFBUSxDQUNkLE1BQWdCLENBQWhCLENBQUFGLEVBQWUsQ0FBQyxDQUNsQixLQUFNLENBQU4sTUFBTSxDQUNBLFVBQUMsQ0FBRCxHQUFDLENBRVpiLFNBQU8sQ0FDVixFQVBDLEdBQUcsQ0FPRTtJQUFBRixDQUFBLE1BQUFFLFFBQUE7SUFBQUYsQ0FBQSxNQUFBZSxFQUFBO0lBQUFmLENBQUEsTUFBQWlCLEVBQUE7RUFBQTtJQUFBQSxFQUFBLEdBQUFqQixDQUFBO0VBQUE7RUFBQSxPQVBOaUIsRUFPTTtBQUFBIiwiaWdub3JlTGlzdCI6W119

--- a/packages/renderer/src/components/Box.tsx
+++ b/packages/renderer/src/components/Box.tsx
@@ -1,213 +1,119 @@
-import { c as _c } from "react/compiler-runtime";
-import React, { type PropsWithChildren, type Ref } from 'react';
-import type { Except } from 'type-fest';
-import type { DOMElement } from '../dom';
-import type { ClickEvent } from '../events/click-event';
-import type { FocusEvent } from '../events/focus-event';
-import type { KeyboardEvent } from '../events/keyboard-event';
-import type { Styles } from '../styles';
-import * as warn from '../warn';
+import '../global.d.ts'
+import React, { type PropsWithChildren, type Ref } from 'react'
+import type { Except } from 'type-fest'
+import type { DOMElement } from '../dom.js'
+import type { ClickEvent } from '../events/click-event.js'
+import type { FocusEvent } from '../events/focus-event.js'
+import type { KeyboardEvent } from '../events/keyboard-event.js'
+import type { Styles } from '../styles.js'
+import * as warn from '../warn.js'
+
 export type Props = Except<Styles, 'textWrap'> & {
-  ref?: Ref<DOMElement>;
+  ref?: Ref<DOMElement>
   /**
    * Tab order index. Nodes with `tabIndex >= 0` participate in
    * Tab/Shift+Tab cycling; `-1` means programmatically focusable only.
    */
-  tabIndex?: number;
+  tabIndex?: number
   /**
    * Focus this element when it mounts. Like the HTML `autofocus`
    * attribute — the FocusManager calls `focus(node)` during the
    * reconciler's `commitMount` phase.
    */
-  autoFocus?: boolean;
+  autoFocus?: boolean
   /**
    * Fired on left-button click (press + release without drag). Only works
    * inside `<AlternateScreen>` where mouse tracking is enabled — no-op
    * otherwise. The event bubbles from the deepest hit Box up through
    * ancestors; call `event.stopImmediatePropagation()` to stop bubbling.
    */
-  onClick?: (event: ClickEvent) => void;
-  onFocus?: (event: FocusEvent) => void;
-  onFocusCapture?: (event: FocusEvent) => void;
-  onBlur?: (event: FocusEvent) => void;
-  onBlurCapture?: (event: FocusEvent) => void;
-  onKeyDown?: (event: KeyboardEvent) => void;
-  onKeyDownCapture?: (event: KeyboardEvent) => void;
+  onClick?: (event: ClickEvent) => void
+  onFocus?: (event: FocusEvent) => void
+  onFocusCapture?: (event: FocusEvent) => void
+  onBlur?: (event: FocusEvent) => void
+  onBlurCapture?: (event: FocusEvent) => void
+  onKeyDown?: (event: KeyboardEvent) => void
+  onKeyDownCapture?: (event: KeyboardEvent) => void
   /**
    * Fired when the mouse moves into this Box's rendered rect. Like DOM
    * `mouseenter`, does NOT bubble — moving between children does not
    * re-fire on the parent. Only works inside `<AlternateScreen>` where
    * mode-1003 mouse tracking is enabled.
    */
-  onMouseEnter?: () => void;
+  onMouseEnter?: () => void
   /** Fired when the mouse moves out of this Box's rendered rect. */
-  onMouseLeave?: () => void;
-};
+  onMouseLeave?: () => void
+}
 
 /**
  * `<Box>` is an essential Ink component to build your layout. It's like `<div style="display: flex">` in the browser.
  */
-function Box(t0: PropsWithChildren<Props>) {
-  const $ = _c(42);
-  let autoFocus;
-  let children;
-  let flexDirection;
-  let flexGrow;
-  let flexShrink;
-  let flexWrap;
-  let onBlur;
-  let onBlurCapture;
-  let onClick;
-  let onFocus;
-  let onFocusCapture;
-  let onKeyDown;
-  let onKeyDownCapture;
-  let onMouseEnter;
-  let onMouseLeave;
-  let ref;
-  let style;
-  let tabIndex;
-  if ($[0] !== t0) {
-    const {
-      children: t1,
-      flexWrap: t2,
-      flexDirection: t3,
-      flexGrow: t4,
-      flexShrink: t5,
-      ref: t6,
-      tabIndex: t7,
-      autoFocus: t8,
-      onClick: t9,
-      onFocus: t10,
-      onFocusCapture: t11,
-      onBlur: t12,
-      onBlurCapture: t13,
-      onMouseEnter: t14,
-      onMouseLeave: t15,
-      onKeyDown: t16,
-      onKeyDownCapture: t17,
-      ...t18
-    } = t0;
-    children = t1;
-    ref = t6;
-    tabIndex = t7;
-    autoFocus = t8;
-    onClick = t9;
-    onFocus = t10;
-    onFocusCapture = t11;
-    onBlur = t12;
-    onBlurCapture = t13;
-    onMouseEnter = t14;
-    onMouseLeave = t15;
-    onKeyDown = t16;
-    onKeyDownCapture = t17;
-    style = t18;
-    flexWrap = t2 === undefined ? "nowrap" : t2;
-    flexDirection = t3 === undefined ? "row" : t3;
-    flexGrow = t4 === undefined ? 0 : t4;
-    flexShrink = t5 === undefined ? 1 : t5;
-    warn.ifNotInteger(style.margin, "margin");
-    warn.ifNotInteger(style.marginX, "marginX");
-    warn.ifNotInteger(style.marginY, "marginY");
-    warn.ifNotInteger(style.marginTop, "marginTop");
-    warn.ifNotInteger(style.marginBottom, "marginBottom");
-    warn.ifNotInteger(style.marginLeft, "marginLeft");
-    warn.ifNotInteger(style.marginRight, "marginRight");
-    warn.ifNotInteger(style.padding, "padding");
-    warn.ifNotInteger(style.paddingX, "paddingX");
-    warn.ifNotInteger(style.paddingY, "paddingY");
-    warn.ifNotInteger(style.paddingTop, "paddingTop");
-    warn.ifNotInteger(style.paddingBottom, "paddingBottom");
-    warn.ifNotInteger(style.paddingLeft, "paddingLeft");
-    warn.ifNotInteger(style.paddingRight, "paddingRight");
-    warn.ifNotInteger(style.gap, "gap");
-    warn.ifNotInteger(style.columnGap, "columnGap");
-    warn.ifNotInteger(style.rowGap, "rowGap");
-    $[0] = t0;
-    $[1] = autoFocus;
-    $[2] = children;
-    $[3] = flexDirection;
-    $[4] = flexGrow;
-    $[5] = flexShrink;
-    $[6] = flexWrap;
-    $[7] = onBlur;
-    $[8] = onBlurCapture;
-    $[9] = onClick;
-    $[10] = onFocus;
-    $[11] = onFocusCapture;
-    $[12] = onKeyDown;
-    $[13] = onKeyDownCapture;
-    $[14] = onMouseEnter;
-    $[15] = onMouseLeave;
-    $[16] = ref;
-    $[17] = style;
-    $[18] = tabIndex;
-  } else {
-    autoFocus = $[1];
-    children = $[2];
-    flexDirection = $[3];
-    flexGrow = $[4];
-    flexShrink = $[5];
-    flexWrap = $[6];
-    onBlur = $[7];
-    onBlurCapture = $[8];
-    onClick = $[9];
-    onFocus = $[10];
-    onFocusCapture = $[11];
-    onKeyDown = $[12];
-    onKeyDownCapture = $[13];
-    onMouseEnter = $[14];
-    onMouseLeave = $[15];
-    ref = $[16];
-    style = $[17];
-    tabIndex = $[18];
-  }
-  const t1 = style.overflowX ?? style.overflow ?? "visible";
-  const t2 = style.overflowY ?? style.overflow ?? "visible";
-  let t3;
-  if ($[19] !== flexDirection || $[20] !== flexGrow || $[21] !== flexShrink || $[22] !== flexWrap || $[23] !== style || $[24] !== t1 || $[25] !== t2) {
-    t3 = {
-      flexWrap,
-      flexDirection,
-      flexGrow,
-      flexShrink,
-      ...style,
-      overflowX: t1,
-      overflowY: t2
-    };
-    $[19] = flexDirection;
-    $[20] = flexGrow;
-    $[21] = flexShrink;
-    $[22] = flexWrap;
-    $[23] = style;
-    $[24] = t1;
-    $[25] = t2;
-    $[26] = t3;
-  } else {
-    t3 = $[26];
-  }
-  let t4;
-  if ($[27] !== autoFocus || $[28] !== children || $[29] !== onBlur || $[30] !== onBlurCapture || $[31] !== onClick || $[32] !== onFocus || $[33] !== onFocusCapture || $[34] !== onKeyDown || $[35] !== onKeyDownCapture || $[36] !== onMouseEnter || $[37] !== onMouseLeave || $[38] !== ref || $[39] !== t3 || $[40] !== tabIndex) {
-    t4 = <ink-box ref={ref} tabIndex={tabIndex} autoFocus={autoFocus} onClick={onClick} onFocus={onFocus} onFocusCapture={onFocusCapture} onBlur={onBlur} onBlurCapture={onBlurCapture} onMouseEnter={onMouseEnter} onMouseLeave={onMouseLeave} onKeyDown={onKeyDown} onKeyDownCapture={onKeyDownCapture} style={t3}>{children}</ink-box>;
-    $[27] = autoFocus;
-    $[28] = children;
-    $[29] = onBlur;
-    $[30] = onBlurCapture;
-    $[31] = onClick;
-    $[32] = onFocus;
-    $[33] = onFocusCapture;
-    $[34] = onKeyDown;
-    $[35] = onKeyDownCapture;
-    $[36] = onMouseEnter;
-    $[37] = onMouseLeave;
-    $[38] = ref;
-    $[39] = t3;
-    $[40] = tabIndex;
-    $[41] = t4;
-  } else {
-    t4 = $[41];
-  }
-  return t4;
+function Box({
+  children,
+  flexWrap = 'nowrap',
+  flexDirection = 'row',
+  flexGrow = 0,
+  flexShrink = 1,
+  ref,
+  tabIndex,
+  autoFocus,
+  onClick,
+  onFocus,
+  onFocusCapture,
+  onBlur,
+  onBlurCapture,
+  onMouseEnter,
+  onMouseLeave,
+  onKeyDown,
+  onKeyDownCapture,
+  ...style
+}: PropsWithChildren<Props>): React.ReactNode {
+  // Warn if spacing values are not integers to prevent fractional layout dimensions
+  warn.ifNotInteger(style.margin, 'margin')
+  warn.ifNotInteger(style.marginX, 'marginX')
+  warn.ifNotInteger(style.marginY, 'marginY')
+  warn.ifNotInteger(style.marginTop, 'marginTop')
+  warn.ifNotInteger(style.marginBottom, 'marginBottom')
+  warn.ifNotInteger(style.marginLeft, 'marginLeft')
+  warn.ifNotInteger(style.marginRight, 'marginRight')
+  warn.ifNotInteger(style.padding, 'padding')
+  warn.ifNotInteger(style.paddingX, 'paddingX')
+  warn.ifNotInteger(style.paddingY, 'paddingY')
+  warn.ifNotInteger(style.paddingTop, 'paddingTop')
+  warn.ifNotInteger(style.paddingBottom, 'paddingBottom')
+  warn.ifNotInteger(style.paddingLeft, 'paddingLeft')
+  warn.ifNotInteger(style.paddingRight, 'paddingRight')
+  warn.ifNotInteger(style.gap, 'gap')
+  warn.ifNotInteger(style.columnGap, 'columnGap')
+  warn.ifNotInteger(style.rowGap, 'rowGap')
+
+  return (
+    <ink-box
+      ref={ref}
+      tabIndex={tabIndex}
+      autoFocus={autoFocus}
+      onClick={onClick}
+      onFocus={onFocus}
+      onFocusCapture={onFocusCapture}
+      onBlur={onBlur}
+      onBlurCapture={onBlurCapture}
+      onMouseEnter={onMouseEnter}
+      onMouseLeave={onMouseLeave}
+      onKeyDown={onKeyDown}
+      onKeyDownCapture={onKeyDownCapture}
+      style={{
+        flexWrap,
+        flexDirection,
+        flexGrow,
+        flexShrink,
+        ...style,
+        overflowX: style.overflowX ?? style.overflow ?? 'visible',
+        overflowY: style.overflowY ?? style.overflow ?? 'visible',
+      }}
+    >
+      {children}
+    </ink-box>
+  )
 }
-export default Box;
-//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJuYW1lcyI6WyJSZWFjdCIsIlByb3BzV2l0aENoaWxkcmVuIiwiUmVmIiwiRXhjZXB0IiwiRE9NRWxlbWVudCIsIkNsaWNrRXZlbnQiLCJGb2N1c0V2ZW50IiwiS2V5Ym9hcmRFdmVudCIsIlN0eWxlcyIsIndhcm4iLCJQcm9wcyIsInJlZiIsInRhYkluZGV4IiwiYXV0b0ZvY3VzIiwib25DbGljayIsImV2ZW50Iiwib25Gb2N1cyIsIm9uRm9jdXNDYXB0dXJlIiwib25CbHVyIiwib25CbHVyQ2FwdHVyZSIsIm9uS2V5RG93biIsIm9uS2V5RG93bkNhcHR1cmUiLCJvbk1vdXNlRW50ZXIiLCJvbk1vdXNlTGVhdmUiLCJCb3giLCJ0MCIsIiQiLCJfYyIsImNoaWxkcmVuIiwiZmxleERpcmVjdGlvbiIsImZsZXhHcm93IiwiZmxleFNocmluayIsImZsZXhXcmFwIiwic3R5bGUiLCJ0MSIsInQyIiwidDMiLCJ0NCIsInQ1IiwidDYiLCJ0NyIsInQ4IiwidDkiLCJ0MTAiLCJ0MTEiLCJ0MTIiLCJ0MTMiLCJ0MTQiLCJ0MTUiLCJ0MTYiLCJ0MTciLCJ0MTgiLCJ1bmRlZmluZWQiLCJpZk5vdEludGVnZXIiLCJtYXJnaW4iLCJtYXJnaW5YIiwibWFyZ2luWSIsIm1hcmdpblRvcCIsIm1hcmdpbkJvdHRvbSIsIm1hcmdpbkxlZnQiLCJtYXJnaW5SaWdodCIsInBhZGRpbmciLCJwYWRkaW5nWCIsInBhZGRpbmdZIiwicGFkZGluZ1RvcCIsInBhZGRpbmdCb3R0b20iLCJwYWRkaW5nTGVmdCIsInBhZGRpbmdSaWdodCIsImdhcCIsImNvbHVtbkdhcCIsInJvd0dhcCIsIm92ZXJmbG93WCIsIm92ZXJmbG93Iiwib3ZlcmZsb3dZIl0sInNvdXJjZXMiOlsiQm94LnRzeCJdLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgJy4uL2dsb2JhbC5kLnRzJ1xuaW1wb3J0IFJlYWN0LCB7IHR5cGUgUHJvcHNXaXRoQ2hpbGRyZW4sIHR5cGUgUmVmIH0gZnJvbSAncmVhY3QnXG5pbXBvcnQgdHlwZSB7IEV4Y2VwdCB9IGZyb20gJ3R5cGUtZmVzdCdcbmltcG9ydCB0eXBlIHsgRE9NRWxlbWVudCB9IGZyb20gJy4uL2RvbS5qcydcbmltcG9ydCB0eXBlIHsgQ2xpY2tFdmVudCB9IGZyb20gJy4uL2V2ZW50cy9jbGljay1ldmVudC5qcydcbmltcG9ydCB0eXBlIHsgRm9jdXNFdmVudCB9IGZyb20gJy4uL2V2ZW50cy9mb2N1cy1ldmVudC5qcydcbmltcG9ydCB0eXBlIHsgS2V5Ym9hcmRFdmVudCB9IGZyb20gJy4uL2V2ZW50cy9rZXlib2FyZC1ldmVudC5qcydcbmltcG9ydCB0eXBlIHsgU3R5bGVzIH0gZnJvbSAnLi4vc3R5bGVzLmpzJ1xuaW1wb3J0ICogYXMgd2FybiBmcm9tICcuLi93YXJuLmpzJ1xuXG5leHBvcnQgdHlwZSBQcm9wcyA9IEV4Y2VwdDxTdHlsZXMsICd0ZXh0V3JhcCc+ICYge1xuICByZWY/OiBSZWY8RE9NRWxlbWVudD5cbiAgLyoqXG4gICAqIFRhYiBvcmRlciBpbmRleC4gTm9kZXMgd2l0aCBgdGFiSW5kZXggPj0gMGAgcGFydGljaXBhdGUgaW5cbiAgICogVGFiL1NoaWZ0K1RhYiBjeWNsaW5nOyBgLTFgIG1lYW5zIHByb2dyYW1tYXRpY2FsbHkgZm9jdXNhYmxlIG9ubHkuXG4gICAqL1xuICB0YWJJbmRleD86IG51bWJlclxuICAvKipcbiAgICogRm9jdXMgdGhpcyBlbGVtZW50IHdoZW4gaXQgbW91bnRzLiBMaWtlIHRoZSBIVE1MIGBhdXRvZm9jdXNgXG4gICAqIGF0dHJpYnV0ZSDigJQgdGhlIEZvY3VzTWFuYWdlciBjYWxscyBgZm9jdXMobm9kZSlgIGR1cmluZyB0aGVcbiAgICogcmVjb25jaWxlcidzIGBjb21taXRNb3VudGAgcGhhc2UuXG4gICAqL1xuICBhdXRvRm9jdXM/OiBib29sZWFuXG4gIC8qKlxuICAgKiBGaXJlZCBvbiBsZWZ0LWJ1dHRvbiBjbGljayAocHJlc3MgKyByZWxlYXNlIHdpdGhvdXQgZHJhZykuIE9ubHkgd29ya3NcbiAgICogaW5zaWRlIGA8QWx0ZXJuYXRlU2NyZWVuPmAgd2hlcmUgbW91c2UgdHJhY2tpbmcgaXMgZW5hYmxlZCDigJQgbm8tb3BcbiAgICogb3RoZXJ3aXNlLiBUaGUgZXZlbnQgYnViYmxlcyBmcm9tIHRoZSBkZWVwZXN0IGhpdCBCb3ggdXAgdGhyb3VnaFxuICAgKiBhbmNlc3RvcnM7IGNhbGwgYGV2ZW50LnN0b3BJbW1lZGlhdGVQcm9wYWdhdGlvbigpYCB0byBzdG9wIGJ1YmJsaW5nLlxuICAgKi9cbiAgb25DbGljaz86IChldmVudDogQ2xpY2tFdmVudCkgPT4gdm9pZFxuICBvbkZvY3VzPzogKGV2ZW50OiBGb2N1c0V2ZW50KSA9PiB2b2lkXG4gIG9uRm9jdXNDYXB0dXJlPzogKGV2ZW50OiBGb2N1c0V2ZW50KSA9PiB2b2lkXG4gIG9uQmx1cj86IChldmVudDogRm9jdXNFdmVudCkgPT4gdm9pZFxuICBvbkJsdXJDYXB0dXJlPzogKGV2ZW50OiBGb2N1c0V2ZW50KSA9PiB2b2lkXG4gIG9uS2V5RG93bj86IChldmVudDogS2V5Ym9hcmRFdmVudCkgPT4gdm9pZFxuICBvbktleURvd25DYXB0dXJlPzogKGV2ZW50OiBLZXlib2FyZEV2ZW50KSA9PiB2b2lkXG4gIC8qKlxuICAgKiBGaXJlZCB3aGVuIHRoZSBtb3VzZSBtb3ZlcyBpbnRvIHRoaXMgQm94J3MgcmVuZGVyZWQgcmVjdC4gTGlrZSBET01cbiAgICogYG1vdXNlZW50ZXJgLCBkb2VzIE5PVCBidWJibGUg4oCUIG1vdmluZyBiZXR3ZWVuIGNoaWxkcmVuIGRvZXMgbm90XG4gICAqIHJlLWZpcmUgb24gdGhlIHBhcmVudC4gT25seSB3b3JrcyBpbnNpZGUgYDxBbHRlcm5hdGVTY3JlZW4+YCB3aGVyZVxuICAgKiBtb2RlLTEwMDMgbW91c2UgdHJhY2tpbmcgaXMgZW5hYmxlZC5cbiAgICovXG4gIG9uTW91c2VFbnRlcj86ICgpID0+IHZvaWRcbiAgLyoqIEZpcmVkIHdoZW4gdGhlIG1vdXNlIG1vdmVzIG91dCBvZiB0aGlzIEJveCdzIHJlbmRlcmVkIHJlY3QuICovXG4gIG9uTW91c2VMZWF2ZT86ICgpID0+IHZvaWRcbn1cblxuLyoqXG4gKiBgPEJveD5gIGlzIGFuIGVzc2VudGlhbCBJbmsgY29tcG9uZW50IHRvIGJ1aWxkIHlvdXIgbGF5b3V0LiBJdCdzIGxpa2UgYDxkaXYgc3R5bGU9XCJkaXNwbGF5OiBmbGV4XCI+YCBpbiB0aGUgYnJvd3Nlci5cbiAqL1xuZnVuY3Rpb24gQm94KHtcbiAgY2hpbGRyZW4sXG4gIGZsZXhXcmFwID0gJ25vd3JhcCcsXG4gIGZsZXhEaXJlY3Rpb24gPSAncm93JyxcbiAgZmxleEdyb3cgPSAwLFxuICBmbGV4U2hyaW5rID0gMSxcbiAgcmVmLFxuICB0YWJJbmRleCxcbiAgYXV0b0ZvY3VzLFxuICBvbkNsaWNrLFxuICBvbkZvY3VzLFxuICBvbkZvY3VzQ2FwdHVyZSxcbiAgb25CbHVyLFxuICBvbkJsdXJDYXB0dXJlLFxuICBvbk1vdXNlRW50ZXIsXG4gIG9uTW91c2VMZWF2ZSxcbiAgb25LZXlEb3duLFxuICBvbktleURvd25DYXB0dXJlLFxuICAuLi5zdHlsZVxufTogUHJvcHNXaXRoQ2hpbGRyZW48UHJvcHM+KTogUmVhY3QuUmVhY3ROb2RlIHtcbiAgLy8gV2FybiBpZiBzcGFjaW5nIHZhbHVlcyBhcmUgbm90IGludGVnZXJzIHRvIHByZXZlbnQgZnJhY3Rpb25hbCBsYXlvdXQgZGltZW5zaW9uc1xuICB3YXJuLmlmTm90SW50ZWdlcihzdHlsZS5tYXJnaW4sICdtYXJnaW4nKVxuICB3YXJuLmlmTm90SW50ZWdlcihzdHlsZS5tYXJnaW5YLCAnbWFyZ2luWCcpXG4gIHdhcm4uaWZOb3RJbnRlZ2VyKHN0eWxlLm1hcmdpblksICdtYXJnaW5ZJylcbiAgd2Fybi5pZk5vdEludGVnZXIoc3R5bGUubWFyZ2luVG9wLCAnbWFyZ2luVG9wJylcbiAgd2Fybi5pZk5vdEludGVnZXIoc3R5bGUubWFyZ2luQm90dG9tLCAnbWFyZ2luQm90dG9tJylcbiAgd2Fybi5pZk5vdEludGVnZXIoc3R5bGUubWFyZ2luTGVmdCwgJ21hcmdpbkxlZnQnKVxuICB3YXJuLmlmTm90SW50ZWdlcihzdHlsZS5tYXJnaW5SaWdodCwgJ21hcmdpblJpZ2h0JylcbiAgd2Fybi5pZk5vdEludGVnZXIoc3R5bGUucGFkZGluZywgJ3BhZGRpbmcnKVxuICB3YXJuLmlmTm90SW50ZWdlcihzdHlsZS5wYWRkaW5nWCwgJ3BhZGRpbmdYJylcbiAgd2Fybi5pZk5vdEludGVnZXIoc3R5bGUucGFkZGluZ1ksICdwYWRkaW5nWScpXG4gIHdhcm4uaWZOb3RJbnRlZ2VyKHN0eWxlLnBhZGRpbmdUb3AsICdwYWRkaW5nVG9wJylcbiAgd2Fybi5pZk5vdEludGVnZXIoc3R5bGUucGFkZGluZ0JvdHRvbSwgJ3BhZGRpbmdCb3R0b20nKVxuICB3YXJuLmlmTm90SW50ZWdlcihzdHlsZS5wYWRkaW5nTGVmdCwgJ3BhZGRpbmdMZWZ0JylcbiAgd2Fybi5pZk5vdEludGVnZXIoc3R5bGUucGFkZGluZ1JpZ2h0LCAncGFkZGluZ1JpZ2h0JylcbiAgd2Fybi5pZk5vdEludGVnZXIoc3R5bGUuZ2FwLCAnZ2FwJylcbiAgd2Fybi5pZk5vdEludGVnZXIoc3R5bGUuY29sdW1uR2FwLCAnY29sdW1uR2FwJylcbiAgd2Fybi5pZk5vdEludGVnZXIoc3R5bGUucm93R2FwLCAncm93R2FwJylcblxuICByZXR1cm4gKFxuICAgIDxpbmstYm94XG4gICAgICByZWY9e3JlZn1cbiAgICAgIHRhYkluZGV4PXt0YWJJbmRleH1cbiAgICAgIGF1dG9Gb2N1cz17YXV0b0ZvY3VzfVxuICAgICAgb25DbGljaz17b25DbGlja31cbiAgICAgIG9uRm9jdXM9e29uRm9jdXN9XG4gICAgICBvbkZvY3VzQ2FwdHVyZT17b25Gb2N1c0NhcHR1cmV9XG4gICAgICBvbkJsdXI9e29uQmx1cn1cbiAgICAgIG9uQmx1ckNhcHR1cmU9e29uQmx1ckNhcHR1cmV9XG4gICAgICBvbk1vdXNlRW50ZXI9e29uTW91c2VFbnRlcn1cbiAgICAgIG9uTW91c2VMZWF2ZT17b25Nb3VzZUxlYXZlfVxuICAgICAgb25LZXlEb3duPXtvbktleURvd259XG4gICAgICBvbktleURvd25DYXB0dXJlPXtvbktleURvd25DYXB0dXJlfVxuICAgICAgc3R5bGU9e3tcbiAgICAgICAgZmxleFdyYXAsXG4gICAgICAgIGZsZXhEaXJlY3Rpb24sXG4gICAgICAgIGZsZXhHcm93LFxuICAgICAgICBmbGV4U2hyaW5rLFxuICAgICAgICAuLi5zdHlsZSxcbiAgICAgICAgb3ZlcmZsb3dYOiBzdHlsZS5vdmVyZmxvd1ggPz8gc3R5bGUub3ZlcmZsb3cgPz8gJ3Zpc2libGUnLFxuICAgICAgICBvdmVyZmxvd1k6IHN0eWxlLm92ZXJmbG93WSA/PyBzdHlsZS5vdmVyZmxvdyA/PyAndmlzaWJsZScsXG4gICAgICB9fVxuICAgID5cbiAgICAgIHtjaGlsZHJlbn1cbiAgICA8L2luay1ib3g+XG4gIClcbn1cblxuZXhwb3J0IGRlZmF1bHQgQm94XG4iXSwibWFwcGluZ3MiOiI7QUFBQSxPQUFPLGdCQUFnQjtBQUN2QixPQUFPQSxLQUFLLElBQUksS0FBS0MsaUJBQWlCLEVBQUUsS0FBS0MsR0FBRyxRQUFRLE9BQU87QUFDL0QsY0FBY0MsTUFBTSxRQUFRLFdBQVc7QUFDdkMsY0FBY0MsVUFBVSxRQUFRLFdBQVc7QUFDM0MsY0FBY0MsVUFBVSxRQUFRLDBCQUEwQjtBQUMxRCxjQUFjQyxVQUFVLFFBQVEsMEJBQTBCO0FBQzFELGNBQWNDLGFBQWEsUUFBUSw2QkFBNkI7QUFDaEUsY0FBY0MsTUFBTSxRQUFRLGNBQWM7QUFDMUMsT0FBTyxLQUFLQyxJQUFJLE1BQU0sWUFBWTtBQUVsQyxPQUFPLEtBQUtDLEtBQUssR0FBR1AsTUFBTSxDQUFDSyxNQUFNLEVBQUUsVUFBVSxDQUFDLEdBQUc7RUFDL0NHLEdBQUcsQ0FBQyxFQUFFVCxHQUFHLENBQUNFLFVBQVUsQ0FBQztFQUNyQjtBQUNGO0FBQ0E7QUFDQTtFQUNFUSxRQUFRLENBQUMsRUFBRSxNQUFNO0VBQ2pCO0FBQ0Y7QUFDQTtBQUNBO0FBQ0E7RUFDRUMsU0FBUyxDQUFDLEVBQUUsT0FBTztFQUNuQjtBQUNGO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7RUFDRUMsT0FBTyxDQUFDLEVBQUUsQ0FBQ0MsS0FBSyxFQUFFVixVQUFVLEVBQUUsR0FBRyxJQUFJO0VBQ3JDVyxPQUFPLENBQUMsRUFBRSxDQUFDRCxLQUFLLEVBQUVULFVBQVUsRUFBRSxHQUFHLElBQUk7RUFDckNXLGNBQWMsQ0FBQyxFQUFFLENBQUNGLEtBQUssRUFBRVQsVUFBVSxFQUFFLEdBQUcsSUFBSTtFQUM1Q1ksTUFBTSxDQUFDLEVBQUUsQ0FBQ0gsS0FBSyxFQUFFVCxVQUFVLEVBQUUsR0FBRyxJQUFJO0VBQ3BDYSxhQUFhLENBQUMsRUFBRSxDQUFDSixLQUFLLEVBQUVULFVBQVUsRUFBRSxHQUFHLElBQUk7RUFDM0NjLFNBQVMsQ0FBQyxFQUFFLENBQUNMLEtBQUssRUFBRVIsYUFBYSxFQUFFLEdBQUcsSUFBSTtFQUMxQ2MsZ0JBQWdCLENBQUMsRUFBRSxDQUFDTixLQUFLLEVBQUVSLGFBQWEsRUFBRSxHQUFHLElBQUk7RUFDakQ7QUFDRjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0VlLFlBQVksQ0FBQyxFQUFFLEdBQUcsR0FBRyxJQUFJO0VBQ3pCO0VBQ0FDLFlBQVksQ0FBQyxFQUFFLEdBQUcsR0FBRyxJQUFJO0FBQzNCLENBQUM7O0FBRUQ7QUFDQTtBQUNBO0FBQ0EsU0FBQUMsSUFBQUMsRUFBQTtFQUFBLE1BQUFDLENBQUEsR0FBQUMsRUFBQTtFQUFBLElBQUFkLFNBQUE7RUFBQSxJQUFBZSxRQUFBO0VBQUEsSUFBQUMsYUFBQTtFQUFBLElBQUFDLFFBQUE7RUFBQSxJQUFBQyxVQUFBO0VBQUEsSUFBQUMsUUFBQTtFQUFBLElBQUFkLE1BQUE7RUFBQSxJQUFBQyxhQUFBO0VBQUEsSUFBQUwsT0FBQTtFQUFBLElBQUFFLE9BQUE7RUFBQSxJQUFBQyxjQUFBO0VBQUEsSUFBQUcsU0FBQTtFQUFBLElBQUFDLGdCQUFBO0VBQUEsSUFBQUMsWUFBQTtFQUFBLElBQUFDLFlBQUE7RUFBQSxJQUFBWixHQUFBO0VBQUEsSUFBQXNCLEtBQUE7RUFBQSxJQUFBckIsUUFBQTtFQUFBLElBQUFjLENBQUEsUUFBQUQsRUFBQTtJQUFhO01BQUFHLFFBQUEsRUFBQU0sRUFBQTtNQUFBRixRQUFBLEVBQUFHLEVBQUE7TUFBQU4sYUFBQSxFQUFBTyxFQUFBO01BQUFOLFFBQUEsRUFBQU8sRUFBQTtNQUFBTixVQUFBLEVBQUFPLEVBQUE7TUFBQTNCLEdBQUEsRUFBQTRCLEVBQUE7TUFBQTNCLFFBQUEsRUFBQTRCLEVBQUE7TUFBQTNCLFNBQUEsRUFBQTRCLEVBQUE7TUFBQTNCLE9BQUEsRUFBQTRCLEVBQUE7TUFBQTFCLE9BQUEsRUFBQTJCLEdBQUE7TUFBQTFCLGNBQUEsRUFBQTJCLEdBQUE7TUFBQTFCLE1BQUEsRUFBQTJCLEdBQUE7TUFBQTFCLGFBQUEsRUFBQTJCLEdBQUE7TUFBQXhCLFlBQUEsRUFBQXlCLEdBQUE7TUFBQXhCLFlBQUEsRUFBQXlCLEdBQUE7TUFBQTVCLFNBQUEsRUFBQTZCLEdBQUE7TUFBQTVCLGdCQUFBLEVBQUE2QixHQUFBO01BQUEsR0FBQUM7SUFBQSxJQUFBMUIsRUFtQmM7SUFuQmRHLFFBQUEsR0FBQU0sRUFBQTtJQUFBdkIsR0FBQSxHQUFBNEIsRUFBQTtJQUFBM0IsUUFBQSxHQUFBNEIsRUFBQTtJQUFBM0IsU0FBQSxHQUFBNEIsRUFBQTtJQUFBM0IsT0FBQSxHQUFBNEIsRUFBQTtJQUFBMUIsT0FBQSxHQUFBMkIsR0FBQTtJQUFBMUIsY0FBQSxHQUFBMkIsR0FBQTtJQUFBMUIsTUFBQSxHQUFBMkIsR0FBQTtJQUFBMUIsYUFBQSxHQUFBMkIsR0FBQTtJQUFBeEIsWUFBQSxHQUFBeUIsR0FBQTtJQUFBeEIsWUFBQSxHQUFBeUIsR0FBQTtJQUFBNUIsU0FBQSxHQUFBNkIsR0FBQTtJQUFBNUIsZ0JBQUEsR0FBQTZCLEdBQUE7SUFBQWpCLEtBQUEsR0FBQWtCLEdBQUE7SUFFWG5CLFFBQUEsR0FBQUcsRUFBbUIsS0FBbkJpQixTQUFtQixHQUFuQixRQUFtQixHQUFuQmpCLEVBQW1CO0lBQ25CTixhQUFBLEdBQUFPLEVBQXFCLEtBQXJCZ0IsU0FBcUIsR0FBckIsS0FBcUIsR0FBckJoQixFQUFxQjtJQUNyQk4sUUFBQSxHQUFBTyxFQUFZLEtBQVplLFNBQVksR0FBWixDQUFZLEdBQVpmLEVBQVk7SUFDWk4sVUFBQSxHQUFBTyxFQUFjLEtBQWRjLFNBQWMsR0FBZCxDQUFjLEdBQWRkLEVBQWM7SUFnQmQ3QixJQUFJLENBQUE0QyxZQUFhLENBQUNwQixLQUFLLENBQUFxQixNQUFPLEVBQUUsUUFBUSxDQUFDO0lBQ3pDN0MsSUFBSSxDQUFBNEMsWUFBYSxDQUFDcEIsS0FBSyxDQUFBc0IsT0FBUSxFQUFFLFNBQVMsQ0FBQztJQUMzQzlDLElBQUksQ0FBQTRDLFlBQWEsQ0FBQ3BCLEtBQUssQ0FBQXVCLE9BQVEsRUFBRSxTQUFTLENBQUM7SUFDM0MvQyxJQUFJLENBQUE0QyxZQUFhLENBQUNwQixLQUFLLENBQUF3QixTQUFVLEVBQUUsV0FBVyxDQUFDO0lBQy9DaEQsSUFBSSxDQUFBNEMsWUFBYSxDQUFDcEIsS0FBSyxDQUFBeUIsWUFBYSxFQUFFLGNBQWMsQ0FBQztJQUNyRGpELElBQUksQ0FBQTRDLFlBQWEsQ0FBQ3BCLEtBQUssQ0FBQTBCLFVBQVcsRUFBRSxZQUFZLENBQUM7SUFDakRsRCxJQUFJLENBQUE0QyxZQUFhLENBQUNwQixLQUFLLENBQUEyQixXQUFZLEVBQUUsYUFBYSxDQUFDO0lBQ25EbkQsSUFBSSxDQUFBNEMsWUFBYSxDQUFDcEIsS0FBSyxDQUFBNEIsT0FBUSxFQUFFLFNBQVMsQ0FBQztJQUMzQ3BELElBQUksQ0FBQTRDLFlBQWEsQ0FBQ3BCLEtBQUssQ0FBQTZCLFFBQVMsRUFBRSxVQUFVLENBQUM7SUFDN0NyRCxJQUFJLENBQUE0QyxZQUFhLENBQUNwQixLQUFLLENBQUE4QixRQUFTLEVBQUUsVUFBVSxDQUFDO0lBQzdDdEQsSUFBSSxDQUFBNEMsWUFBYSxDQUFDcEIsS0FBSyxDQUFBK0IsVUFBVyxFQUFFLFlBQVksQ0FBQztJQUNqRHZELElBQUksQ0FBQTRDLFlBQWEsQ0FBQ3BCLEtBQUssQ0FBQWdDLGFBQWMsRUFBRSxlQUFlLENBQUM7SUFDdkR4RCxJQUFJLENBQUE0QyxZQUFhLENBQUNwQixLQUFLLENBQUFpQyxXQUFZLEVBQUUsYUFBYSxDQUFDO0lBQ25EekQsSUFBSSxDQUFBNEMsWUFBYSxDQUFDcEIsS0FBSyxDQUFBa0MsWUFBYSxFQUFFLGNBQWMsQ0FBQztJQUNyRDFELElBQUksQ0FBQTRDLFlBQWEsQ0FBQ3BCLEtBQUssQ0FBQW1DLEdBQUksRUFBRSxLQUFLLENBQUM7SUFDbkMzRCxJQUFJLENBQUE0QyxZQUFhLENBQUNwQixLQUFLLENBQUFvQyxTQUFVLEVBQUUsV0FBVyxDQUFDO0lBQy9DNUQsSUFBSSxDQUFBNEMsWUFBYSxDQUFDcEIsS0FBSyxDQUFBcUMsTUFBTyxFQUFFLFFBQVEsQ0FBQztJQUFBNUMsQ0FBQSxNQUFBRCxFQUFBO0lBQUFDLENBQUEsTUFBQWIsU0FBQTtJQUFBYSxDQUFBLE1BQUFFLFFBQUE7SUFBQUYsQ0FBQSxNQUFBRyxhQUFBO0lBQUFILENBQUEsTUFBQUksUUFBQTtJQUFBSixDQUFBLE1BQUFLLFVBQUE7SUFBQUwsQ0FBQSxNQUFBTSxRQUFBO0lBQUFOLENBQUEsTUFBQVIsTUFBQTtJQUFBUSxDQUFBLE1BQUFQLGFBQUE7SUFBQU8sQ0FBQSxNQUFBWixPQUFBO0lBQUFZLENBQUEsT0FBQVYsT0FBQTtJQUFBVSxDQUFBLE9BQUFULGNBQUE7SUFBQVMsQ0FBQSxPQUFBTixTQUFBO0lBQUFNLENBQUEsT0FBQUwsZ0JBQUE7SUFBQUssQ0FBQSxPQUFBSixZQUFBO0lBQUFJLENBQUEsT0FBQUgsWUFBQTtJQUFBRyxDQUFBLE9BQUFmLEdBQUE7SUFBQWUsQ0FBQSxPQUFBTyxLQUFBO0lBQUFQLENBQUEsT0FBQWQsUUFBQTtFQUFBO0lBQUFDLFNBQUEsR0FBQWEsQ0FBQTtJQUFBRSxRQUFBLEdBQUFGLENBQUE7SUFBQUcsYUFBQSxHQUFBSCxDQUFBO0lBQUFJLFFBQUEsR0FBQUosQ0FBQTtJQUFBSyxVQUFBLEdBQUFMLENBQUE7SUFBQU0sUUFBQSxHQUFBTixDQUFBO0lBQUFSLE1BQUEsR0FBQVEsQ0FBQTtJQUFBUCxhQUFBLEdBQUFPLENBQUE7SUFBQVosT0FBQSxHQUFBWSxDQUFBO0lBQUFWLE9BQUEsR0FBQVUsQ0FBQTtJQUFBVCxjQUFBLEdBQUFTLENBQUE7SUFBQU4sU0FBQSxHQUFBTSxDQUFBO0lBQUFMLGdCQUFBLEdBQUFLLENBQUE7SUFBQUosWUFBQSxHQUFBSSxDQUFBO0lBQUFILFlBQUEsR0FBQUcsQ0FBQTtJQUFBZixHQUFBLEdBQUFlLENBQUE7SUFBQU8sS0FBQSxHQUFBUCxDQUFBO0lBQUFkLFFBQUEsR0FBQWMsQ0FBQTtFQUFBO0VBc0J4QixNQUFBUSxFQUFBLEdBQUFELEtBQUssQ0FBQXNDLFNBQTRCLElBQWR0QyxLQUFLLENBQUF1QyxRQUFzQixJQUE5QyxTQUE4QztFQUM5QyxNQUFBckMsRUFBQSxHQUFBRixLQUFLLENBQUF3QyxTQUE0QixJQUFkeEMsS0FBSyxDQUFBdUMsUUFBc0IsSUFBOUMsU0FBOEM7RUFBQSxJQUFBcEMsRUFBQTtFQUFBLElBQUFWLENBQUEsU0FBQUcsYUFBQSxJQUFBSCxDQUFBLFNBQUFJLFFBQUEsSUFBQUosQ0FBQSxTQUFBSyxVQUFBLElBQUFMLENBQUEsU0FBQU0sUUFBQSxJQUFBTixDQUFBLFNBQUFPLEtBQUEsSUFBQVAsQ0FBQSxTQUFBUSxFQUFBLElBQUFSLENBQUEsU0FBQVMsRUFBQTtJQVBwREMsRUFBQTtNQUFBSixRQUFBO01BQUFILGFBQUE7TUFBQUMsUUFBQTtNQUFBQyxVQUFBO01BQUEsR0FLRkUsS0FBSztNQUFBc0MsU0FBQSxFQUNHckMsRUFBOEM7TUFBQXVDLFNBQUEsRUFDOUN0QztJQUNiLENBQUM7SUFBQVQsQ0FBQSxPQUFBRyxhQUFBO0lBQUFILENBQUEsT0FBQUksUUFBQTtJQUFBSixDQUFBLE9BQUFLLFVBQUE7SUFBQUwsQ0FBQSxPQUFBTSxRQUFBO0lBQUFOLENBQUEsT0FBQU8sS0FBQTtJQUFBUCxDQUFBLE9BQUFRLEVBQUE7SUFBQVIsQ0FBQSxPQUFBUyxFQUFBO0lBQUFULENBQUEsT0FBQVUsRUFBQTtFQUFBO0lBQUFBLEVBQUEsR0FBQVYsQ0FBQTtFQUFBO0VBQUEsSUFBQVcsRUFBQTtFQUFBLElBQUFYLENBQUEsU0FBQWIsU0FBQSxJQUFBYSxDQUFBLFNBQUFFLFFBQUEsSUFBQUYsQ0FBQSxTQUFBUixNQUFBLElBQUFRLENBQUEsU0FBQVAsYUFBQSxJQUFBTyxDQUFBLFNBQUFaLE9BQUEsSUFBQVksQ0FBQSxTQUFBVixPQUFBLElBQUFVLENBQUEsU0FBQVQsY0FBQSxJQUFBUyxDQUFBLFNBQUFOLFNBQUEsSUFBQU0sQ0FBQSxTQUFBTCxnQkFBQSxJQUFBSyxDQUFBLFNBQUFKLFlBQUEsSUFBQUksQ0FBQSxTQUFBSCxZQUFBLElBQUFHLENBQUEsU0FBQWYsR0FBQSxJQUFBZSxDQUFBLFNBQUFVLEVBQUEsSUFBQVYsQ0FBQSxTQUFBZCxRQUFBO0lBckJIeUIsRUFBQSxXQXdCVSxDQXZCSDFCLEdBQUcsQ0FBSEEsSUFBRSxDQUFDLENBQ0VDLFFBQVEsQ0FBUkEsU0FBTyxDQUFDLENBQ1BDLFNBQVMsQ0FBVEEsVUFBUSxDQUFDLENBQ1hDLE9BQU8sQ0FBUEEsUUFBTSxDQUFDLENBQ1BFLE9BQU8sQ0FBUEEsUUFBTSxDQUFDLENBQ0FDLGNBQWMsQ0FBZEEsZUFBYSxDQUFDLENBQ3RCQyxNQUFNLENBQU5BLE9BQUssQ0FBQyxDQUNDQyxhQUFhLENBQWJBLGNBQVksQ0FBQyxDQUNkRyxZQUFZLENBQVpBLGFBQVcsQ0FBQyxDQUNaQyxZQUFZLENBQVpBLGFBQVcsQ0FBQyxDQUNmSCxTQUFTLENBQVRBLFVBQVEsQ0FBQyxDQUNGQyxnQkFBZ0IsQ0FBaEJBLGlCQUFlLENBQUMsQ0FDM0IsS0FRTixDQVJNLENBQUFlLEVBUVAsQ0FBQyxDQUVBUixTQUFPLENBQ1YsRUF4QkEsT0F3QlU7SUFBQUYsQ0FBQSxPQUFBYixTQUFBO0lBQUFhLENBQUEsT0FBQUUsUUFBQTtJQUFBRixDQUFBLE9BQUFSLE1BQUE7SUFBQVEsQ0FBQSxPQUFBUCxhQUFBO0lBQUFPLENBQUEsT0FBQVosT0FBQTtJQUFBWSxDQUFBLE9BQUFWLE9BQUE7SUFBQVUsQ0FBQSxPQUFBVCxjQUFBO0lBQUFTLENBQUEsT0FBQU4sU0FBQTtJQUFBTSxDQUFBLE9BQUFMLGdCQUFBO0lBQUFLLENBQUEsT0FBQUosWUFBQTtJQUFBSSxDQUFBLE9BQUFILFlBQUE7SUFBQUcsQ0FBQSxPQUFBZixHQUFBO0lBQUFlLENBQUEsT0FBQVUsRUFBQTtJQUFBVixDQUFBLE9BQUFkLFFBQUE7SUFBQWMsQ0FBQSxPQUFBVyxFQUFBO0VBQUE7SUFBQUEsRUFBQSxHQUFBWCxDQUFBO0VBQUE7RUFBQSxPQXhCVlcsRUF3QlU7QUFBQTtBQUlkLGVBQWViLEdBQUciLCJpZ25vcmVMaXN0IjpbXX0=
+
+export default Box

--- a/packages/renderer/src/components/Box.tsx
+++ b/packages/renderer/src/components/Box.tsx
@@ -1,4 +1,3 @@
-import '../global.d.ts'
 import React, { type PropsWithChildren, type Ref } from 'react'
 import type { Except } from 'type-fest'
 import type { DOMElement } from '../dom.js'

--- a/packages/renderer/src/components/Button.tsx
+++ b/packages/renderer/src/components/Button.tsx
@@ -1,32 +1,39 @@
-import { c as _c } from "react/compiler-runtime";
-import React, { type Ref, useCallback, useEffect, useRef, useState } from 'react';
-import type { Except } from 'type-fest';
-import type { DOMElement } from '../dom';
-import type { ClickEvent } from '../events/click-event';
-import type { FocusEvent } from '../events/focus-event';
-import type { KeyboardEvent } from '../events/keyboard-event';
-import type { Styles } from '../styles';
-import Box from './Box';
+import React, {
+  type Ref,
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+} from 'react'
+import type { Except } from 'type-fest'
+import type { DOMElement } from '../dom.js'
+import type { ClickEvent } from '../events/click-event.js'
+import type { FocusEvent } from '../events/focus-event.js'
+import type { KeyboardEvent } from '../events/keyboard-event.js'
+import type { Styles } from '../styles.js'
+import Box from './Box.js'
+
 type ButtonState = {
-  focused: boolean;
-  hovered: boolean;
-  active: boolean;
-};
+  focused: boolean
+  hovered: boolean
+  active: boolean
+}
+
 export type Props = Except<Styles, 'textWrap'> & {
-  ref?: Ref<DOMElement>;
+  ref?: Ref<DOMElement>
   /**
    * Called when the button is activated via Enter, Space, or click.
    */
-  onAction: () => void;
+  onAction: () => void
   /**
    * Tab order index. Defaults to 0 (in tab order).
    * Set to -1 for programmatically focusable only.
    */
-  tabIndex?: number;
+  tabIndex?: number
   /**
    * Focus this button when it mounts.
    */
-  autoFocus?: boolean;
+  autoFocus?: boolean
   /**
    * Render prop receiving the interactive state. Use this to
    * style children based on focus/hover/active — Button itself
@@ -34,159 +41,82 @@ export type Props = Except<Styles, 'textWrap'> & {
    *
    * If not provided, children render as-is (no state-dependent styling).
    */
-  children: ((state: ButtonState) => React.ReactNode) | React.ReactNode;
-};
-function Button(t0: Props) {
-  const $ = _c(30);
-  let autoFocus;
-  let children;
-  let onAction;
-  let ref;
-  let style;
-  let t1;
-  if ($[0] !== t0) {
-    ({
-      onAction,
-      tabIndex: t1,
-      autoFocus,
-      children,
-      ref,
-      ...style
-    } = t0);
-    $[0] = t0;
-    $[1] = autoFocus;
-    $[2] = children;
-    $[3] = onAction;
-    $[4] = ref;
-    $[5] = style;
-    $[6] = t1;
-  } else {
-    autoFocus = $[1];
-    children = $[2];
-    onAction = $[3];
-    ref = $[4];
-    style = $[5];
-    t1 = $[6];
-  }
-  const tabIndex = t1 === undefined ? 0 : t1;
-  const [isFocused, setIsFocused] = useState(false);
-  const [isHovered, setIsHovered] = useState(false);
-  const [isActive, setIsActive] = useState(false);
-  const activeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
-  let t2;
-  let t3;
-  if ($[7] === Symbol.for("react.memo_cache_sentinel")) {
-    t2 = () => () => {
-      if (activeTimer.current) {
-        clearTimeout(activeTimer.current);
-      }
-    };
-    t3 = [] as const;
-    $[7] = t2;
-    $[8] = t3;
-  } else {
-    t2 = $[7];
-    t3 = $[8];
-  }
-  useEffect(t2, t3);
-  let t4;
-  if ($[9] !== onAction) {
-    t4 = (e: KeyboardEvent) => {
-      if (e.key === "return" || e.key === " ") {
-        e.preventDefault();
-        setIsActive(true);
-        onAction();
-        if (activeTimer.current) {
-          clearTimeout(activeTimer.current);
-        }
-        activeTimer.current = setTimeout(_temp, 100, setIsActive);
-      }
-    };
-    $[9] = onAction;
-    $[10] = t4;
-  } else {
-    t4 = $[10];
-  }
-  const handleKeyDown = t4;
-  let t5;
-  if ($[11] !== onAction) {
-    t5 = (_e: ClickEvent) => {
-      onAction();
-    };
-    $[11] = onAction;
-    $[12] = t5;
-  } else {
-    t5 = $[12];
-  }
-  const handleClick = t5;
-  let t6;
-  if ($[13] === Symbol.for("react.memo_cache_sentinel")) {
-    t6 = (_e_0: FocusEvent) => setIsFocused(true);
-    $[13] = t6;
-  } else {
-    t6 = $[13];
-  }
-  const handleFocus = t6;
-  let t7;
-  if ($[14] === Symbol.for("react.memo_cache_sentinel")) {
-    t7 = (_e_1: FocusEvent) => setIsFocused(false);
-    $[14] = t7;
-  } else {
-    t7 = $[14];
-  }
-  const handleBlur = t7;
-  let t8;
-  if ($[15] === Symbol.for("react.memo_cache_sentinel")) {
-    t8 = () => setIsHovered(true);
-    $[15] = t8;
-  } else {
-    t8 = $[15];
-  }
-  const handleMouseEnter = t8;
-  let t9;
-  if ($[16] === Symbol.for("react.memo_cache_sentinel")) {
-    t9 = () => setIsHovered(false);
-    $[16] = t9;
-  } else {
-    t9 = $[16];
-  }
-  const handleMouseLeave = t9;
-  let t10;
-  if ($[17] !== children || $[18] !== isActive || $[19] !== isFocused || $[20] !== isHovered) {
-    const state = {
-      focused: isFocused,
-      hovered: isHovered,
-      active: isActive
-    };
-    t10 = typeof children === "function" ? children(state) : children;
-    $[17] = children;
-    $[18] = isActive;
-    $[19] = isFocused;
-    $[20] = isHovered;
-    $[21] = t10;
-  } else {
-    t10 = $[21];
-  }
-  const content = t10;
-  let t11;
-  if ($[22] !== autoFocus || $[23] !== content || $[24] !== handleClick || $[25] !== handleKeyDown || $[26] !== ref || $[27] !== style || $[28] !== tabIndex) {
-    t11 = <Box ref={ref} tabIndex={tabIndex} autoFocus={autoFocus} onKeyDown={handleKeyDown} onClick={handleClick} onFocus={handleFocus} onBlur={handleBlur} onMouseEnter={handleMouseEnter} onMouseLeave={handleMouseLeave} {...style}>{content}</Box>;
-    $[22] = autoFocus;
-    $[23] = content;
-    $[24] = handleClick;
-    $[25] = handleKeyDown;
-    $[26] = ref;
-    $[27] = style;
-    $[28] = tabIndex;
-    $[29] = t11;
-  } else {
-    t11 = $[29];
-  }
-  return t11;
+  children: ((state: ButtonState) => React.ReactNode) | React.ReactNode
 }
-function _temp(setter: (v: boolean) => void) {
-  return setter(false);
+
+function Button({
+  onAction,
+  tabIndex = 0,
+  autoFocus,
+  children,
+  ref,
+  ...style
+}: Props): React.ReactNode {
+  const [isFocused, setIsFocused] = useState(false)
+  const [isHovered, setIsHovered] = useState(false)
+  const [isActive, setIsActive] = useState(false)
+
+  const activeTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  useEffect(() => {
+    return () => {
+      if (activeTimer.current) clearTimeout(activeTimer.current)
+    }
+  }, [])
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent) => {
+      if (e.key === 'return' || e.key === ' ') {
+        e.preventDefault()
+        setIsActive(true)
+        onAction()
+        if (activeTimer.current) clearTimeout(activeTimer.current)
+        activeTimer.current = setTimeout(
+          setter => setter(false),
+          100,
+          setIsActive,
+        )
+      }
+    },
+    [onAction],
+  )
+
+  const handleClick = useCallback(
+    (_e: ClickEvent) => {
+      onAction()
+    },
+    [onAction],
+  )
+
+  const handleFocus = useCallback((_e: FocusEvent) => setIsFocused(true), [])
+  const handleBlur = useCallback((_e: FocusEvent) => setIsFocused(false), [])
+  const handleMouseEnter = useCallback(() => setIsHovered(true), [])
+  const handleMouseLeave = useCallback(() => setIsHovered(false), [])
+
+  const state: ButtonState = {
+    focused: isFocused,
+    hovered: isHovered,
+    active: isActive,
+  }
+  const content = typeof children === 'function' ? children(state) : children
+
+  return (
+    <Box
+      ref={ref}
+      tabIndex={tabIndex}
+      autoFocus={autoFocus}
+      onKeyDown={handleKeyDown}
+      onClick={handleClick}
+      onFocus={handleFocus}
+      onBlur={handleBlur}
+      onMouseEnter={handleMouseEnter}
+      onMouseLeave={handleMouseLeave}
+      {...style}
+    >
+      {content}
+    </Box>
+  )
 }
-export default Button;
-export type { ButtonState };
-//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJuYW1lcyI6WyJSZWFjdCIsIlJlZiIsInVzZUNhbGxiYWNrIiwidXNlRWZmZWN0IiwidXNlUmVmIiwidXNlU3RhdGUiLCJFeGNlcHQiLCJET01FbGVtZW50IiwiQ2xpY2tFdmVudCIsIkZvY3VzRXZlbnQiLCJLZXlib2FyZEV2ZW50IiwiU3R5bGVzIiwiQm94IiwiQnV0dG9uU3RhdGUiLCJmb2N1c2VkIiwiaG92ZXJlZCIsImFjdGl2ZSIsIlByb3BzIiwicmVmIiwib25BY3Rpb24iLCJ0YWJJbmRleCIsImF1dG9Gb2N1cyIsImNoaWxkcmVuIiwic3RhdGUiLCJSZWFjdE5vZGUiLCJCdXR0b24iLCJ0MCIsIiQiLCJfYyIsInN0eWxlIiwidDEiLCJ1bmRlZmluZWQiLCJpc0ZvY3VzZWQiLCJzZXRJc0ZvY3VzZWQiLCJpc0hvdmVyZWQiLCJzZXRJc0hvdmVyZWQiLCJpc0FjdGl2ZSIsInNldElzQWN0aXZlIiwiYWN0aXZlVGltZXIiLCJ0MiIsInQzIiwiU3ltYm9sIiwiZm9yIiwiY3VycmVudCIsImNsZWFyVGltZW91dCIsInQ0IiwiZSIsImtleSIsInByZXZlbnREZWZhdWx0Iiwic2V0VGltZW91dCIsIl90ZW1wIiwiaGFuZGxlS2V5RG93biIsInQ1IiwiX2UiLCJoYW5kbGVDbGljayIsInQ2IiwiX2VfMCIsImhhbmRsZUZvY3VzIiwidDciLCJfZV8xIiwiaGFuZGxlQmx1ciIsInQ4IiwiaGFuZGxlTW91c2VFbnRlciIsInQ5IiwiaGFuZGxlTW91c2VMZWF2ZSIsInQxMCIsImNvbnRlbnQiLCJ0MTEiLCJzZXR0ZXIiXSwic291cmNlcyI6WyJCdXR0b24udHN4Il0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBSZWFjdCwge1xuICB0eXBlIFJlZixcbiAgdXNlQ2FsbGJhY2ssXG4gIHVzZUVmZmVjdCxcbiAgdXNlUmVmLFxuICB1c2VTdGF0ZSxcbn0gZnJvbSAncmVhY3QnXG5pbXBvcnQgdHlwZSB7IEV4Y2VwdCB9IGZyb20gJ3R5cGUtZmVzdCdcbmltcG9ydCB0eXBlIHsgRE9NRWxlbWVudCB9IGZyb20gJy4uL2RvbS5qcydcbmltcG9ydCB0eXBlIHsgQ2xpY2tFdmVudCB9IGZyb20gJy4uL2V2ZW50cy9jbGljay1ldmVudC5qcydcbmltcG9ydCB0eXBlIHsgRm9jdXNFdmVudCB9IGZyb20gJy4uL2V2ZW50cy9mb2N1cy1ldmVudC5qcydcbmltcG9ydCB0eXBlIHsgS2V5Ym9hcmRFdmVudCB9IGZyb20gJy4uL2V2ZW50cy9rZXlib2FyZC1ldmVudC5qcydcbmltcG9ydCB0eXBlIHsgU3R5bGVzIH0gZnJvbSAnLi4vc3R5bGVzLmpzJ1xuaW1wb3J0IEJveCBmcm9tICcuL0JveC5qcydcblxudHlwZSBCdXR0b25TdGF0ZSA9IHtcbiAgZm9jdXNlZDogYm9vbGVhblxuICBob3ZlcmVkOiBib29sZWFuXG4gIGFjdGl2ZTogYm9vbGVhblxufVxuXG5leHBvcnQgdHlwZSBQcm9wcyA9IEV4Y2VwdDxTdHlsZXMsICd0ZXh0V3JhcCc+ICYge1xuICByZWY/OiBSZWY8RE9NRWxlbWVudD5cbiAgLyoqXG4gICAqIENhbGxlZCB3aGVuIHRoZSBidXR0b24gaXMgYWN0aXZhdGVkIHZpYSBFbnRlciwgU3BhY2UsIG9yIGNsaWNrLlxuICAgKi9cbiAgb25BY3Rpb246ICgpID0+IHZvaWRcbiAgLyoqXG4gICAqIFRhYiBvcmRlciBpbmRleC4gRGVmYXVsdHMgdG8gMCAoaW4gdGFiIG9yZGVyKS5cbiAgICogU2V0IHRvIC0xIGZvciBwcm9ncmFtbWF0aWNhbGx5IGZvY3VzYWJsZSBvbmx5LlxuICAgKi9cbiAgdGFiSW5kZXg/OiBudW1iZXJcbiAgLyoqXG4gICAqIEZvY3VzIHRoaXMgYnV0dG9uIHdoZW4gaXQgbW91bnRzLlxuICAgKi9cbiAgYXV0b0ZvY3VzPzogYm9vbGVhblxuICAvKipcbiAgICogUmVuZGVyIHByb3AgcmVjZWl2aW5nIHRoZSBpbnRlcmFjdGl2ZSBzdGF0ZS4gVXNlIHRoaXMgdG9cbiAgICogc3R5bGUgY2hpbGRyZW4gYmFzZWQgb24gZm9jdXMvaG92ZXIvYWN0aXZlIOKAlCBCdXR0b24gaXRzZWxmXG4gICAqIGlzIGludGVudGlvbmFsbHkgdW5zdHlsZWQuXG4gICAqXG4gICAqIElmIG5vdCBwcm92aWRlZCwgY2hpbGRyZW4gcmVuZGVyIGFzLWlzIChubyBzdGF0ZS1kZXBlbmRlbnQgc3R5bGluZykuXG4gICAqL1xuICBjaGlsZHJlbjogKChzdGF0ZTogQnV0dG9uU3RhdGUpID0+IFJlYWN0LlJlYWN0Tm9kZSkgfCBSZWFjdC5SZWFjdE5vZGVcbn1cblxuZnVuY3Rpb24gQnV0dG9uKHtcbiAgb25BY3Rpb24sXG4gIHRhYkluZGV4ID0gMCxcbiAgYXV0b0ZvY3VzLFxuICBjaGlsZHJlbixcbiAgcmVmLFxuICAuLi5zdHlsZVxufTogUHJvcHMpOiBSZWFjdC5SZWFjdE5vZGUge1xuICBjb25zdCBbaXNGb2N1c2VkLCBzZXRJc0ZvY3VzZWRdID0gdXNlU3RhdGUoZmFsc2UpXG4gIGNvbnN0IFtpc0hvdmVyZWQsIHNldElzSG92ZXJlZF0gPSB1c2VTdGF0ZShmYWxzZSlcbiAgY29uc3QgW2lzQWN0aXZlLCBzZXRJc0FjdGl2ZV0gPSB1c2VTdGF0ZShmYWxzZSlcblxuICBjb25zdCBhY3RpdmVUaW1lciA9IHVzZVJlZjxSZXR1cm5UeXBlPHR5cGVvZiBzZXRUaW1lb3V0PiB8IG51bGw+KG51bGwpXG5cbiAgdXNlRWZmZWN0KCgpID0+IHtcbiAgICByZXR1cm4gKCkgPT4ge1xuICAgICAgaWYgKGFjdGl2ZVRpbWVyLmN1cnJlbnQpIGNsZWFyVGltZW91dChhY3RpdmVUaW1lci5jdXJyZW50KVxuICAgIH1cbiAgfSwgW10pXG5cbiAgY29uc3QgaGFuZGxlS2V5RG93biA9IHVzZUNhbGxiYWNrKFxuICAgIChlOiBLZXlib2FyZEV2ZW50KSA9PiB7XG4gICAgICBpZiAoZS5rZXkgPT09ICdyZXR1cm4nIHx8IGUua2V5ID09PSAnICcpIHtcbiAgICAgICAgZS5wcmV2ZW50RGVmYXVsdCgpXG4gICAgICAgIHNldElzQWN0aXZlKHRydWUpXG4gICAgICAgIG9uQWN0aW9uKClcbiAgICAgICAgaWYgKGFjdGl2ZVRpbWVyLmN1cnJlbnQpIGNsZWFyVGltZW91dChhY3RpdmVUaW1lci5jdXJyZW50KVxuICAgICAgICBhY3RpdmVUaW1lci5jdXJyZW50ID0gc2V0VGltZW91dChcbiAgICAgICAgICBzZXR0ZXIgPT4gc2V0dGVyKGZhbHNlKSxcbiAgICAgICAgICAxMDAsXG4gICAgICAgICAgc2V0SXNBY3RpdmUsXG4gICAgICAgIClcbiAgICAgIH1cbiAgICB9LFxuICAgIFtvbkFjdGlvbl0sXG4gIClcblxuICBjb25zdCBoYW5kbGVDbGljayA9IHVzZUNhbGxiYWNrKFxuICAgIChfZTogQ2xpY2tFdmVudCkgPT4ge1xuICAgICAgb25BY3Rpb24oKVxuICAgIH0sXG4gICAgW29uQWN0aW9uXSxcbiAgKVxuXG4gIGNvbnN0IGhhbmRsZUZvY3VzID0gdXNlQ2FsbGJhY2soKF9lOiBGb2N1c0V2ZW50KSA9PiBzZXRJc0ZvY3VzZWQodHJ1ZSksIFtdKVxuICBjb25zdCBoYW5kbGVCbHVyID0gdXNlQ2FsbGJhY2soKF9lOiBGb2N1c0V2ZW50KSA9PiBzZXRJc0ZvY3VzZWQoZmFsc2UpLCBbXSlcbiAgY29uc3QgaGFuZGxlTW91c2VFbnRlciA9IHVzZUNhbGxiYWNrKCgpID0+IHNldElzSG92ZXJlZCh0cnVlKSwgW10pXG4gIGNvbnN0IGhhbmRsZU1vdXNlTGVhdmUgPSB1c2VDYWxsYmFjaygoKSA9PiBzZXRJc0hvdmVyZWQoZmFsc2UpLCBbXSlcblxuICBjb25zdCBzdGF0ZTogQnV0dG9uU3RhdGUgPSB7XG4gICAgZm9jdXNlZDogaXNGb2N1c2VkLFxuICAgIGhvdmVyZWQ6IGlzSG92ZXJlZCxcbiAgICBhY3RpdmU6IGlzQWN0aXZlLFxuICB9XG4gIGNvbnN0IGNvbnRlbnQgPSB0eXBlb2YgY2hpbGRyZW4gPT09ICdmdW5jdGlvbicgPyBjaGlsZHJlbihzdGF0ZSkgOiBjaGlsZHJlblxuXG4gIHJldHVybiAoXG4gICAgPEJveFxuICAgICAgcmVmPXtyZWZ9XG4gICAgICB0YWJJbmRleD17dGFiSW5kZXh9XG4gICAgICBhdXRvRm9jdXM9e2F1dG9Gb2N1c31cbiAgICAgIG9uS2V5RG93bj17aGFuZGxlS2V5RG93bn1cbiAgICAgIG9uQ2xpY2s9e2hhbmRsZUNsaWNrfVxuICAgICAgb25Gb2N1cz17aGFuZGxlRm9jdXN9XG4gICAgICBvbkJsdXI9e2hhbmRsZUJsdXJ9XG4gICAgICBvbk1vdXNlRW50ZXI9e2hhbmRsZU1vdXNlRW50ZXJ9XG4gICAgICBvbk1vdXNlTGVhdmU9e2hhbmRsZU1vdXNlTGVhdmV9XG4gICAgICB7Li4uc3R5bGV9XG4gICAgPlxuICAgICAge2NvbnRlbnR9XG4gICAgPC9Cb3g+XG4gIClcbn1cblxuZXhwb3J0IGRlZmF1bHQgQnV0dG9uXG5leHBvcnQgdHlwZSB7IEJ1dHRvblN0YXRlIH1cbiJdLCJtYXBwaW5ncyI6IjtBQUFBLE9BQU9BLEtBQUssSUFDVixLQUFLQyxHQUFHLEVBQ1JDLFdBQVcsRUFDWEMsU0FBUyxFQUNUQyxNQUFNLEVBQ05DLFFBQVEsUUFDSCxPQUFPO0FBQ2QsY0FBY0MsTUFBTSxRQUFRLFdBQVc7QUFDdkMsY0FBY0MsVUFBVSxRQUFRLFdBQVc7QUFDM0MsY0FBY0MsVUFBVSxRQUFRLDBCQUEwQjtBQUMxRCxjQUFjQyxVQUFVLFFBQVEsMEJBQTBCO0FBQzFELGNBQWNDLGFBQWEsUUFBUSw2QkFBNkI7QUFDaEUsY0FBY0MsTUFBTSxRQUFRLGNBQWM7QUFDMUMsT0FBT0MsR0FBRyxNQUFNLFVBQVU7QUFFMUIsS0FBS0MsV0FBVyxHQUFHO0VBQ2pCQyxPQUFPLEVBQUUsT0FBTztFQUNoQkMsT0FBTyxFQUFFLE9BQU87RUFDaEJDLE1BQU0sRUFBRSxPQUFPO0FBQ2pCLENBQUM7QUFFRCxPQUFPLEtBQUtDLEtBQUssR0FBR1gsTUFBTSxDQUFDSyxNQUFNLEVBQUUsVUFBVSxDQUFDLEdBQUc7RUFDL0NPLEdBQUcsQ0FBQyxFQUFFakIsR0FBRyxDQUFDTSxVQUFVLENBQUM7RUFDckI7QUFDRjtBQUNBO0VBQ0VZLFFBQVEsRUFBRSxHQUFHLEdBQUcsSUFBSTtFQUNwQjtBQUNGO0FBQ0E7QUFDQTtFQUNFQyxRQUFRLENBQUMsRUFBRSxNQUFNO0VBQ2pCO0FBQ0Y7QUFDQTtFQUNFQyxTQUFTLENBQUMsRUFBRSxPQUFPO0VBQ25CO0FBQ0Y7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0VDLFFBQVEsRUFBRSxDQUFDLENBQUNDLEtBQUssRUFBRVYsV0FBVyxFQUFFLEdBQUdiLEtBQUssQ0FBQ3dCLFNBQVMsQ0FBQyxHQUFHeEIsS0FBSyxDQUFDd0IsU0FBUztBQUN2RSxDQUFDO0FBRUQsU0FBQUMsT0FBQUMsRUFBQTtFQUFBLE1BQUFDLENBQUEsR0FBQUMsRUFBQTtFQUFBLElBQUFQLFNBQUE7RUFBQSxJQUFBQyxRQUFBO0VBQUEsSUFBQUgsUUFBQTtFQUFBLElBQUFELEdBQUE7RUFBQSxJQUFBVyxLQUFBO0VBQUEsSUFBQUMsRUFBQTtFQUFBLElBQUFILENBQUEsUUFBQUQsRUFBQTtJQUFnQjtNQUFBUCxRQUFBO01BQUFDLFFBQUEsRUFBQVUsRUFBQTtNQUFBVCxTQUFBO01BQUFDLFFBQUE7TUFBQUosR0FBQTtNQUFBLEdBQUFXO0lBQUEsSUFBQUgsRUFPUjtJQUFBQyxDQUFBLE1BQUFELEVBQUE7SUFBQUMsQ0FBQSxNQUFBTixTQUFBO0lBQUFNLENBQUEsTUFBQUwsUUFBQTtJQUFBSyxDQUFBLE1BQUFSLFFBQUE7SUFBQVEsQ0FBQSxNQUFBVCxHQUFBO0lBQUFTLENBQUEsTUFBQUUsS0FBQTtJQUFBRixDQUFBLE1BQUFHLEVBQUE7RUFBQTtJQUFBVCxTQUFBLEdBQUFNLENBQUE7SUFBQUwsUUFBQSxHQUFBSyxDQUFBO0lBQUFSLFFBQUEsR0FBQVEsQ0FBQTtJQUFBVCxHQUFBLEdBQUFTLENBQUE7SUFBQUUsS0FBQSxHQUFBRixDQUFBO0lBQUFHLEVBQUEsR0FBQUgsQ0FBQTtFQUFBO0VBTE4sTUFBQVAsUUFBQSxHQUFBVSxFQUFZLEtBQVpDLFNBQVksR0FBWixDQUFZLEdBQVpELEVBQVk7RUFNWixPQUFBRSxTQUFBLEVBQUFDLFlBQUEsSUFBa0M1QixRQUFRLENBQUMsS0FBSyxDQUFDO0VBQ2pELE9BQUE2QixTQUFBLEVBQUFDLFlBQUEsSUFBa0M5QixRQUFRLENBQUMsS0FBSyxDQUFDO0VBQ2pELE9BQUErQixRQUFBLEVBQUFDLFdBQUEsSUFBZ0NoQyxRQUFRLENBQUMsS0FBSyxDQUFDO0VBRS9DLE1BQUFpQyxXQUFBLEdBQW9CbEMsTUFBTSxDQUF1QyxJQUFJLENBQUM7RUFBQSxJQUFBbUMsRUFBQTtFQUFBLElBQUFDLEVBQUE7RUFBQSxJQUFBYixDQUFBLFFBQUFjLE1BQUEsQ0FBQUMsR0FBQTtJQUU1REgsRUFBQSxHQUFBQSxDQUFBLEtBQ0Q7TUFDTCxJQUFJRCxXQUFXLENBQUFLLE9BQVE7UUFBRUMsWUFBWSxDQUFDTixXQUFXLENBQUFLLE9BQVEsQ0FBQztNQUFBO0lBQUEsQ0FFN0Q7SUFBRUgsRUFBQSxLQUFFO0lBQUFiLENBQUEsTUFBQVksRUFBQTtJQUFBWixDQUFBLE1BQUFhLEVBQUE7RUFBQTtJQUFBRCxFQUFBLEdBQUFaLENBQUE7SUFBQWEsRUFBQSxHQUFBYixDQUFBO0VBQUE7RUFKTHhCLFNBQVMsQ0FBQ29DLEVBSVQsRUFBRUMsRUFBRSxDQUFDO0VBQUEsSUFBQUssRUFBQTtFQUFBLElBQUFsQixDQUFBLFFBQUFSLFFBQUE7SUFHSjBCLEVBQUEsR0FBQUMsQ0FBQTtNQUNFLElBQUlBLENBQUMsQ0FBQUMsR0FBSSxLQUFLLFFBQXlCLElBQWJELENBQUMsQ0FBQUMsR0FBSSxLQUFLLEdBQUc7UUFDckNELENBQUMsQ0FBQUUsY0FBZSxDQUFDLENBQUM7UUFDbEJYLFdBQVcsQ0FBQyxJQUFJLENBQUM7UUFDakJsQixRQUFRLENBQUMsQ0FBQztRQUNWLElBQUltQixXQUFXLENBQUFLLE9BQVE7VUFBRUMsWUFBWSxDQUFDTixXQUFXLENBQUFLLE9BQVEsQ0FBQztRQUFBO1FBQzFETCxXQUFXLENBQUFLLE9BQUEsR0FBV00sVUFBVSxDQUM5QkMsS0FBdUIsRUFDdkIsR0FBRyxFQUNIYixXQUNGLENBSm1CO01BQUE7SUFLcEIsQ0FDRjtJQUFBVixDQUFBLE1BQUFSLFFBQUE7SUFBQVEsQ0FBQSxPQUFBa0IsRUFBQTtFQUFBO0lBQUFBLEVBQUEsR0FBQWxCLENBQUE7RUFBQTtFQWJILE1BQUF3QixhQUFBLEdBQXNCTixFQWVyQjtFQUFBLElBQUFPLEVBQUE7RUFBQSxJQUFBekIsQ0FBQSxTQUFBUixRQUFBO0lBR0NpQyxFQUFBLEdBQUFDLEVBQUE7TUFDRWxDLFFBQVEsQ0FBQyxDQUFDO0lBQUEsQ0FDWDtJQUFBUSxDQUFBLE9BQUFSLFFBQUE7SUFBQVEsQ0FBQSxPQUFBeUIsRUFBQTtFQUFBO0lBQUFBLEVBQUEsR0FBQXpCLENBQUE7RUFBQTtFQUhILE1BQUEyQixXQUFBLEdBQW9CRixFQUtuQjtFQUFBLElBQUFHLEVBQUE7RUFBQSxJQUFBNUIsQ0FBQSxTQUFBYyxNQUFBLENBQUFDLEdBQUE7SUFFK0JhLEVBQUEsR0FBQUMsSUFBQSxJQUFvQnZCLFlBQVksQ0FBQyxJQUFJLENBQUM7SUFBQU4sQ0FBQSxPQUFBNEIsRUFBQTtFQUFBO0lBQUFBLEVBQUEsR0FBQTVCLENBQUE7RUFBQTtFQUF0RSxNQUFBOEIsV0FBQSxHQUFvQkYsRUFBdUQ7RUFBQSxJQUFBRyxFQUFBO0VBQUEsSUFBQS9CLENBQUEsU0FBQWMsTUFBQSxDQUFBQyxHQUFBO0lBQzVDZ0IsRUFBQSxHQUFBQyxJQUFBLElBQW9CMUIsWUFBWSxDQUFDLEtBQUssQ0FBQztJQUFBTixDQUFBLE9BQUErQixFQUFBO0VBQUE7SUFBQUEsRUFBQSxHQUFBL0IsQ0FBQTtFQUFBO0VBQXRFLE1BQUFpQyxVQUFBLEdBQW1CRixFQUF3RDtFQUFBLElBQUFHLEVBQUE7RUFBQSxJQUFBbEMsQ0FBQSxTQUFBYyxNQUFBLENBQUFDLEdBQUE7SUFDdENtQixFQUFBLEdBQUFBLENBQUEsS0FBTTFCLFlBQVksQ0FBQyxJQUFJLENBQUM7SUFBQVIsQ0FBQSxPQUFBa0MsRUFBQTtFQUFBO0lBQUFBLEVBQUEsR0FBQWxDLENBQUE7RUFBQTtFQUE3RCxNQUFBbUMsZ0JBQUEsR0FBeUJELEVBQXlDO0VBQUEsSUFBQUUsRUFBQTtFQUFBLElBQUFwQyxDQUFBLFNBQUFjLE1BQUEsQ0FBQUMsR0FBQTtJQUM3QnFCLEVBQUEsR0FBQUEsQ0FBQSxLQUFNNUIsWUFBWSxDQUFDLEtBQUssQ0FBQztJQUFBUixDQUFBLE9BQUFvQyxFQUFBO0VBQUE7SUFBQUEsRUFBQSxHQUFBcEMsQ0FBQTtFQUFBO0VBQTlELE1BQUFxQyxnQkFBQSxHQUF5QkQsRUFBMEM7RUFBQSxJQUFBRSxHQUFBO0VBQUEsSUFBQXRDLENBQUEsU0FBQUwsUUFBQSxJQUFBSyxDQUFBLFNBQUFTLFFBQUEsSUFBQVQsQ0FBQSxTQUFBSyxTQUFBLElBQUFMLENBQUEsU0FBQU8sU0FBQTtJQUVuRSxNQUFBWCxLQUFBLEdBQTJCO01BQUFULE9BQUEsRUFDaEJrQixTQUFTO01BQUFqQixPQUFBLEVBQ1RtQixTQUFTO01BQUFsQixNQUFBLEVBQ1ZvQjtJQUNWLENBQUM7SUFDZTZCLEdBQUEsVUFBTzNDLFFBQVEsS0FBSyxVQUF1QyxHQUExQkEsUUFBUSxDQUFDQyxLQUFnQixDQUFDLEdBQTNERCxRQUEyRDtJQUFBSyxDQUFBLE9BQUFMLFFBQUE7SUFBQUssQ0FBQSxPQUFBUyxRQUFBO0lBQUFULENBQUEsT0FBQUssU0FBQTtJQUFBTCxDQUFBLE9BQUFPLFNBQUE7SUFBQVAsQ0FBQSxPQUFBc0MsR0FBQTtFQUFBO0lBQUFBLEdBQUEsR0FBQXRDLENBQUE7RUFBQTtFQUEzRSxNQUFBdUMsT0FBQSxHQUFnQkQsR0FBMkQ7RUFBQSxJQUFBRSxHQUFBO0VBQUEsSUFBQXhDLENBQUEsU0FBQU4sU0FBQSxJQUFBTSxDQUFBLFNBQUF1QyxPQUFBLElBQUF2QyxDQUFBLFNBQUEyQixXQUFBLElBQUEzQixDQUFBLFNBQUF3QixhQUFBLElBQUF4QixDQUFBLFNBQUFULEdBQUEsSUFBQVMsQ0FBQSxTQUFBRSxLQUFBLElBQUFGLENBQUEsU0FBQVAsUUFBQTtJQUd6RStDLEdBQUEsSUFBQyxHQUFHLENBQ0dqRCxHQUFHLENBQUhBLElBQUUsQ0FBQyxDQUNFRSxRQUFRLENBQVJBLFNBQU8sQ0FBQyxDQUNQQyxTQUFTLENBQVRBLFVBQVEsQ0FBQyxDQUNUOEIsU0FBYSxDQUFiQSxjQUFZLENBQUMsQ0FDZkcsT0FBVyxDQUFYQSxZQUFVLENBQUMsQ0FDWEcsT0FBVyxDQUFYQSxZQUFVLENBQUMsQ0FDWkcsTUFBVSxDQUFWQSxXQUFTLENBQUMsQ0FDSkUsWUFBZ0IsQ0FBaEJBLGlCQUFlLENBQUMsQ0FDaEJFLFlBQWdCLENBQWhCQSxpQkFBZSxDQUFDLEtBQzFCbkMsS0FBSyxFQUVScUMsUUFBTSxDQUNULEVBYkMsR0FBRyxDQWFFO0lBQUF2QyxDQUFBLE9BQUFOLFNBQUE7SUFBQU0sQ0FBQSxPQUFBdUMsT0FBQTtJQUFBdkMsQ0FBQSxPQUFBMkIsV0FBQTtJQUFBM0IsQ0FBQSxPQUFBd0IsYUFBQTtJQUFBeEIsQ0FBQSxPQUFBVCxHQUFBO0lBQUFTLENBQUEsT0FBQUUsS0FBQTtJQUFBRixDQUFBLE9BQUFQLFFBQUE7SUFBQU8sQ0FBQSxPQUFBd0MsR0FBQTtFQUFBO0lBQUFBLEdBQUEsR0FBQXhDLENBQUE7RUFBQTtFQUFBLE9BYk53QyxHQWFNO0FBQUE7QUF0RVYsU0FBQWpCLE1BQUFrQixNQUFBO0VBQUEsT0E0Qm9CQSxNQUFNLENBQUMsS0FBSyxDQUFDO0FBQUE7QUE4Q2pDLGVBQWUzQyxNQUFNO0FBQ3JCLGNBQWNaLFdBQVciLCJpZ25vcmVMaXN0IjpbXX0=
+
+export default Button
+export type { ButtonState }

--- a/packages/renderer/src/components/ClockContext.tsx
+++ b/packages/renderer/src/components/ClockContext.tsx
@@ -1,112 +1,99 @@
-import { c as _c } from "react/compiler-runtime";
-import React, { createContext, useEffect, useState } from 'react';
-import { FRAME_INTERVAL_MS } from '../constants';
-import { useTerminalFocus } from '../hooks/use-terminal-focus';
+import React, { createContext, useEffect, useState } from 'react'
+import { FRAME_INTERVAL_MS } from '../constants.js'
+import { useTerminalFocus } from '../hooks/use-terminal-focus.js'
+
 export type Clock = {
-  subscribe: (onChange: () => void, keepAlive: boolean) => () => void;
-  now: () => number;
-  setTickInterval: (ms: number) => void;
-};
+  subscribe: (onChange: () => void, keepAlive: boolean) => () => void
+  now: () => number
+  setTickInterval: (ms: number) => void
+}
+
 export function createClock(tickIntervalMs: number): Clock {
-  const subscribers = new Map<() => void, boolean>();
-  let interval: ReturnType<typeof setInterval> | null = null;
-  let currentTickIntervalMs = tickIntervalMs;
-  let startTime = 0;
+  const subscribers = new Map<() => void, boolean>()
+  let interval: ReturnType<typeof setInterval> | null = null
+  let currentTickIntervalMs = tickIntervalMs
+  let startTime = 0
   // Snapshot of the current tick's time, ensuring all subscribers in the same
   // tick see the same value (keeps animations synchronized)
-  let tickTime = 0;
+  let tickTime = 0
+
   function tick(): void {
-    tickTime = Date.now() - startTime;
+    tickTime = Date.now() - startTime
     for (const onChange of subscribers.keys()) {
-      onChange();
+      onChange()
     }
   }
+
   function updateInterval(): void {
-    const anyKeepAlive = [...subscribers.values()].some(Boolean);
+    const anyKeepAlive = [...subscribers.values()].some(Boolean)
+
     if (anyKeepAlive) {
       if (interval) {
-        clearInterval(interval);
-        interval = null;
+        clearInterval(interval)
+        interval = null
       }
       if (startTime === 0) {
-        startTime = Date.now();
+        startTime = Date.now()
       }
-      interval = setInterval(tick, currentTickIntervalMs);
+      interval = setInterval(tick, currentTickIntervalMs)
     } else if (interval) {
-      clearInterval(interval);
-      interval = null;
+      clearInterval(interval)
+      interval = null
     }
   }
+
   return {
     subscribe(onChange, keepAlive) {
-      subscribers.set(onChange, keepAlive);
-      updateInterval();
+      subscribers.set(onChange, keepAlive)
+      updateInterval()
       return () => {
-        subscribers.delete(onChange);
-        updateInterval();
-      };
+        subscribers.delete(onChange)
+        updateInterval()
+      }
     },
+
     now() {
       if (startTime === 0) {
-        startTime = Date.now();
+        startTime = Date.now()
       }
       // When the clock interval is running, return the synchronized tickTime
       // so all subscribers in the same tick see the same value.
       // When paused (no keepAlive subscribers), return real-time to avoid
       // returning a stale tickTime from the last tick before the pause.
       if (interval && tickTime) {
-        return tickTime;
+        return tickTime
       }
-      return Date.now() - startTime;
+      return Date.now() - startTime
     },
+
     setTickInterval(ms) {
-      if (ms === currentTickIntervalMs) return;
-      currentTickIntervalMs = ms;
-      updateInterval();
-    }
-  };
+      if (ms === currentTickIntervalMs) return
+      currentTickIntervalMs = ms
+      updateInterval()
+    },
+  }
 }
-export const ClockContext = createContext<Clock | null>(null);
-const BLURRED_TICK_INTERVAL_MS = FRAME_INTERVAL_MS * 2;
+
+export const ClockContext = createContext<Clock | null>(null)
+
+const BLURRED_TICK_INTERVAL_MS = FRAME_INTERVAL_MS * 2
 
 // Own component so App.tsx doesn't re-render when the clock is created.
 // The clock value is stable (created once via useState), so the provider
 // never causes consumer re-renders on its own.
-export function ClockProvider(t0: { children: React.ReactNode }) {
-  const $ = _c(7);
-  const {
-    children
-  } = t0;
-  const [clock] = useState(_temp);
-  const focused = useTerminalFocus();
-  let t1;
-  let t2;
-  if ($[0] !== clock || $[1] !== focused) {
-    t1 = () => {
-      clock.setTickInterval(focused ? FRAME_INTERVAL_MS : BLURRED_TICK_INTERVAL_MS);
-    };
-    t2 = [clock, focused];
-    $[0] = clock;
-    $[1] = focused;
-    $[2] = t1;
-    $[3] = t2;
-  } else {
-    t1 = $[2];
-    t2 = $[3];
-  }
-  useEffect(t1, t2);
-  let t3;
-  if ($[4] !== children || $[5] !== clock) {
-    t3 = <ClockContext.Provider value={clock}>{children}</ClockContext.Provider>;
-    $[4] = children;
-    $[5] = clock;
-    $[6] = t3;
-  } else {
-    t3 = $[6];
-  }
-  return t3;
+export function ClockProvider({
+  children,
+}: {
+  children: React.ReactNode
+}): React.ReactNode {
+  const [clock] = useState(() => createClock(FRAME_INTERVAL_MS))
+  const focused = useTerminalFocus()
+
+  useEffect(() => {
+    clock.setTickInterval(
+      focused ? FRAME_INTERVAL_MS : BLURRED_TICK_INTERVAL_MS,
+    )
+  }, [clock, focused])
+
+  return <ClockContext.Provider value={clock}>{children}</ClockContext.Provider>
 }
-function _temp() {
-  return createClock(FRAME_INTERVAL_MS);
-}
-//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJuYW1lcyI6WyJSZWFjdCIsImNyZWF0ZUNvbnRleHQiLCJ1c2VFZmZlY3QiLCJ1c2VTdGF0ZSIsIkZSQU1FX0lOVEVSVkFMX01TIiwidXNlVGVybWluYWxGb2N1cyIsIkNsb2NrIiwic3Vic2NyaWJlIiwib25DaGFuZ2UiLCJrZWVwQWxpdmUiLCJub3ciLCJzZXRUaWNrSW50ZXJ2YWwiLCJtcyIsImNyZWF0ZUNsb2NrIiwidGlja0ludGVydmFsTXMiLCJzdWJzY3JpYmVycyIsIk1hcCIsImludGVydmFsIiwiUmV0dXJuVHlwZSIsInNldEludGVydmFsIiwiY3VycmVudFRpY2tJbnRlcnZhbE1zIiwic3RhcnRUaW1lIiwidGlja1RpbWUiLCJ0aWNrIiwiRGF0ZSIsImtleXMiLCJ1cGRhdGVJbnRlcnZhbCIsImFueUtlZXBBbGl2ZSIsInZhbHVlcyIsInNvbWUiLCJCb29sZWFuIiwiY2xlYXJJbnRlcnZhbCIsInNldCIsImRlbGV0ZSIsIkNsb2NrQ29udGV4dCIsIkJMVVJSRURfVElDS19JTlRFUlZBTF9NUyIsIkNsb2NrUHJvdmlkZXIiLCJ0MCIsIiQiLCJfYyIsImNoaWxkcmVuIiwiY2xvY2siLCJfdGVtcCIsImZvY3VzZWQiLCJ0MSIsInQyIiwidDMiXSwic291cmNlcyI6WyJDbG9ja0NvbnRleHQudHN4Il0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBSZWFjdCwgeyBjcmVhdGVDb250ZXh0LCB1c2VFZmZlY3QsIHVzZVN0YXRlIH0gZnJvbSAncmVhY3QnXG5pbXBvcnQgeyBGUkFNRV9JTlRFUlZBTF9NUyB9IGZyb20gJy4uL2NvbnN0YW50cy5qcydcbmltcG9ydCB7IHVzZVRlcm1pbmFsRm9jdXMgfSBmcm9tICcuLi9ob29rcy91c2UtdGVybWluYWwtZm9jdXMuanMnXG5cbmV4cG9ydCB0eXBlIENsb2NrID0ge1xuICBzdWJzY3JpYmU6IChvbkNoYW5nZTogKCkgPT4gdm9pZCwga2VlcEFsaXZlOiBib29sZWFuKSA9PiAoKSA9PiB2b2lkXG4gIG5vdzogKCkgPT4gbnVtYmVyXG4gIHNldFRpY2tJbnRlcnZhbDogKG1zOiBudW1iZXIpID0+IHZvaWRcbn1cblxuZXhwb3J0IGZ1bmN0aW9uIGNyZWF0ZUNsb2NrKHRpY2tJbnRlcnZhbE1zOiBudW1iZXIpOiBDbG9jayB7XG4gIGNvbnN0IHN1YnNjcmliZXJzID0gbmV3IE1hcDwoKSA9PiB2b2lkLCBib29sZWFuPigpXG4gIGxldCBpbnRlcnZhbDogUmV0dXJuVHlwZTx0eXBlb2Ygc2V0SW50ZXJ2YWw+IHwgbnVsbCA9IG51bGxcbiAgbGV0IGN1cnJlbnRUaWNrSW50ZXJ2YWxNcyA9IHRpY2tJbnRlcnZhbE1zXG4gIGxldCBzdGFydFRpbWUgPSAwXG4gIC8vIFNuYXBzaG90IG9mIHRoZSBjdXJyZW50IHRpY2sncyB0aW1lLCBlbnN1cmluZyBhbGwgc3Vic2NyaWJlcnMgaW4gdGhlIHNhbWVcbiAgLy8gdGljayBzZWUgdGhlIHNhbWUgdmFsdWUgKGtlZXBzIGFuaW1hdGlvbnMgc3luY2hyb25pemVkKVxuICBsZXQgdGlja1RpbWUgPSAwXG5cbiAgZnVuY3Rpb24gdGljaygpOiB2b2lkIHtcbiAgICB0aWNrVGltZSA9IERhdGUubm93KCkgLSBzdGFydFRpbWVcbiAgICBmb3IgKGNvbnN0IG9uQ2hhbmdlIG9mIHN1YnNjcmliZXJzLmtleXMoKSkge1xuICAgICAgb25DaGFuZ2UoKVxuICAgIH1cbiAgfVxuXG4gIGZ1bmN0aW9uIHVwZGF0ZUludGVydmFsKCk6IHZvaWQge1xuICAgIGNvbnN0IGFueUtlZXBBbGl2ZSA9IFsuLi5zdWJzY3JpYmVycy52YWx1ZXMoKV0uc29tZShCb29sZWFuKVxuXG4gICAgaWYgKGFueUtlZXBBbGl2ZSkge1xuICAgICAgaWYgKGludGVydmFsKSB7XG4gICAgICAgIGNsZWFySW50ZXJ2YWwoaW50ZXJ2YWwpXG4gICAgICAgIGludGVydmFsID0gbnVsbFxuICAgICAgfVxuICAgICAgaWYgKHN0YXJ0VGltZSA9PT0gMCkge1xuICAgICAgICBzdGFydFRpbWUgPSBEYXRlLm5vdygpXG4gICAgICB9XG4gICAgICBpbnRlcnZhbCA9IHNldEludGVydmFsKHRpY2ssIGN1cnJlbnRUaWNrSW50ZXJ2YWxNcylcbiAgICB9IGVsc2UgaWYgKGludGVydmFsKSB7XG4gICAgICBjbGVhckludGVydmFsKGludGVydmFsKVxuICAgICAgaW50ZXJ2YWwgPSBudWxsXG4gICAgfVxuICB9XG5cbiAgcmV0dXJuIHtcbiAgICBzdWJzY3JpYmUob25DaGFuZ2UsIGtlZXBBbGl2ZSkge1xuICAgICAgc3Vic2NyaWJlcnMuc2V0KG9uQ2hhbmdlLCBrZWVwQWxpdmUpXG4gICAgICB1cGRhdGVJbnRlcnZhbCgpXG4gICAgICByZXR1cm4gKCkgPT4ge1xuICAgICAgICBzdWJzY3JpYmVycy5kZWxldGUob25DaGFuZ2UpXG4gICAgICAgIHVwZGF0ZUludGVydmFsKClcbiAgICAgIH1cbiAgICB9LFxuXG4gICAgbm93KCkge1xuICAgICAgaWYgKHN0YXJ0VGltZSA9PT0gMCkge1xuICAgICAgICBzdGFydFRpbWUgPSBEYXRlLm5vdygpXG4gICAgICB9XG4gICAgICAvLyBXaGVuIHRoZSBjbG9jayBpbnRlcnZhbCBpcyBydW5uaW5nLCByZXR1cm4gdGhlIHN5bmNocm9uaXplZCB0aWNrVGltZVxuICAgICAgLy8gc28gYWxsIHN1YnNjcmliZXJzIGluIHRoZSBzYW1lIHRpY2sgc2VlIHRoZSBzYW1lIHZhbHVlLlxuICAgICAgLy8gV2hlbiBwYXVzZWQgKG5vIGtlZXBBbGl2ZSBzdWJzY3JpYmVycyksIHJldHVybiByZWFsLXRpbWUgdG8gYXZvaWRcbiAgICAgIC8vIHJldHVybmluZyBhIHN0YWxlIHRpY2tUaW1lIGZyb20gdGhlIGxhc3QgdGljayBiZWZvcmUgdGhlIHBhdXNlLlxuICAgICAgaWYgKGludGVydmFsICYmIHRpY2tUaW1lKSB7XG4gICAgICAgIHJldHVybiB0aWNrVGltZVxuICAgICAgfVxuICAgICAgcmV0dXJuIERhdGUubm93KCkgLSBzdGFydFRpbWVcbiAgICB9LFxuXG4gICAgc2V0VGlja0ludGVydmFsKG1zKSB7XG4gICAgICBpZiAobXMgPT09IGN1cnJlbnRUaWNrSW50ZXJ2YWxNcykgcmV0dXJuXG4gICAgICBjdXJyZW50VGlja0ludGVydmFsTXMgPSBtc1xuICAgICAgdXBkYXRlSW50ZXJ2YWwoKVxuICAgIH0sXG4gIH1cbn1cblxuZXhwb3J0IGNvbnN0IENsb2NrQ29udGV4dCA9IGNyZWF0ZUNvbnRleHQ8Q2xvY2sgfCBudWxsPihudWxsKVxuXG5jb25zdCBCTFVSUkVEX1RJQ0tfSU5URVJWQUxfTVMgPSBGUkFNRV9JTlRFUlZBTF9NUyAqIDJcblxuLy8gT3duIGNvbXBvbmVudCBzbyBBcHAudHN4IGRvZXNuJ3QgcmUtcmVuZGVyIHdoZW4gdGhlIGNsb2NrIGlzIGNyZWF0ZWQuXG4vLyBUaGUgY2xvY2sgdmFsdWUgaXMgc3RhYmxlIChjcmVhdGVkIG9uY2UgdmlhIHVzZVN0YXRlKSwgc28gdGhlIHByb3ZpZGVyXG4vLyBuZXZlciBjYXVzZXMgY29uc3VtZXIgcmUtcmVuZGVycyBvbiBpdHMgb3duLlxuZXhwb3J0IGZ1bmN0aW9uIENsb2NrUHJvdmlkZXIoe1xuICBjaGlsZHJlbixcbn06IHtcbiAgY2hpbGRyZW46IFJlYWN0LlJlYWN0Tm9kZVxufSk6IFJlYWN0LlJlYWN0Tm9kZSB7XG4gIGNvbnN0IFtjbG9ja10gPSB1c2VTdGF0ZSgoKSA9PiBjcmVhdGVDbG9jayhGUkFNRV9JTlRFUlZBTF9NUykpXG4gIGNvbnN0IGZvY3VzZWQgPSB1c2VUZXJtaW5hbEZvY3VzKClcblxuICB1c2VFZmZlY3QoKCkgPT4ge1xuICAgIGNsb2NrLnNldFRpY2tJbnRlcnZhbChcbiAgICAgIGZvY3VzZWQgPyBGUkFNRV9JTlRFUlZBTF9NUyA6IEJMVVJSRURfVElDS19JTlRFUlZBTF9NUyxcbiAgICApXG4gIH0sIFtjbG9jaywgZm9jdXNlZF0pXG5cbiAgcmV0dXJuIDxDbG9ja0NvbnRleHQuUHJvdmlkZXIgdmFsdWU9e2Nsb2NrfT57Y2hpbGRyZW59PC9DbG9ja0NvbnRleHQuUHJvdmlkZXI+XG59XG4iXSwibWFwcGluZ3MiOiI7QUFBQSxPQUFPQSxLQUFLLElBQUlDLGFBQWEsRUFBRUMsU0FBUyxFQUFFQyxRQUFRLFFBQVEsT0FBTztBQUNqRSxTQUFTQyxpQkFBaUIsUUFBUSxpQkFBaUI7QUFDbkQsU0FBU0MsZ0JBQWdCLFFBQVEsZ0NBQWdDO0FBRWpFLE9BQU8sS0FBS0MsS0FBSyxHQUFHO0VBQ2xCQyxTQUFTLEVBQUUsQ0FBQ0MsUUFBUSxFQUFFLEdBQUcsR0FBRyxJQUFJLEVBQUVDLFNBQVMsRUFBRSxPQUFPLEVBQUUsR0FBRyxHQUFHLEdBQUcsSUFBSTtFQUNuRUMsR0FBRyxFQUFFLEdBQUcsR0FBRyxNQUFNO0VBQ2pCQyxlQUFlLEVBQUUsQ0FBQ0MsRUFBRSxFQUFFLE1BQU0sRUFBRSxHQUFHLElBQUk7QUFDdkMsQ0FBQztBQUVELE9BQU8sU0FBU0MsV0FBV0EsQ0FBQ0MsY0FBYyxFQUFFLE1BQU0sQ0FBQyxFQUFFUixLQUFLLENBQUM7RUFDekQsTUFBTVMsV0FBVyxHQUFHLElBQUlDLEdBQUcsQ0FBQyxHQUFHLEdBQUcsSUFBSSxFQUFFLE9BQU8sQ0FBQyxDQUFDLENBQUM7RUFDbEQsSUFBSUMsUUFBUSxFQUFFQyxVQUFVLENBQUMsT0FBT0MsV0FBVyxDQUFDLEdBQUcsSUFBSSxHQUFHLElBQUk7RUFDMUQsSUFBSUMscUJBQXFCLEdBQUdOLGNBQWM7RUFDMUMsSUFBSU8sU0FBUyxHQUFHLENBQUM7RUFDakI7RUFDQTtFQUNBLElBQUlDLFFBQVEsR0FBRyxDQUFDO0VBRWhCLFNBQVNDLElBQUlBLENBQUEsQ0FBRSxFQUFFLElBQUksQ0FBQztJQUNwQkQsUUFBUSxHQUFHRSxJQUFJLENBQUNkLEdBQUcsQ0FBQyxDQUFDLEdBQUdXLFNBQVM7SUFDakMsS0FBSyxNQUFNYixRQUFRLElBQUlPLFdBQVcsQ0FBQ1UsSUFBSSxDQUFDLENBQUMsRUFBRTtNQUN6Q2pCLFFBQVEsQ0FBQyxDQUFDO0lBQ1o7RUFDRjtFQUVBLFNBQVNrQixjQUFjQSxDQUFBLENBQUUsRUFBRSxJQUFJLENBQUM7SUFDOUIsTUFBTUMsWUFBWSxHQUFHLENBQUMsR0FBR1osV0FBVyxDQUFDYSxNQUFNLENBQUMsQ0FBQyxDQUFDLENBQUNDLElBQUksQ0FBQ0MsT0FBTyxDQUFDO0lBRTVELElBQUlILFlBQVksRUFBRTtNQUNoQixJQUFJVixRQUFRLEVBQUU7UUFDWmMsYUFBYSxDQUFDZCxRQUFRLENBQUM7UUFDdkJBLFFBQVEsR0FBRyxJQUFJO01BQ2pCO01BQ0EsSUFBSUksU0FBUyxLQUFLLENBQUMsRUFBRTtRQUNuQkEsU0FBUyxHQUFHRyxJQUFJLENBQUNkLEdBQUcsQ0FBQyxDQUFDO01BQ3hCO01BQ0FPLFFBQVEsR0FBR0UsV0FBVyxDQUFDSSxJQUFJLEVBQUVILHFCQUFxQixDQUFDO0lBQ3JELENBQUMsTUFBTSxJQUFJSCxRQUFRLEVBQUU7TUFDbkJjLGFBQWEsQ0FBQ2QsUUFBUSxDQUFDO01BQ3ZCQSxRQUFRLEdBQUcsSUFBSTtJQUNqQjtFQUNGO0VBRUEsT0FBTztJQUNMVixTQUFTQSxDQUFDQyxRQUFRLEVBQUVDLFNBQVMsRUFBRTtNQUM3Qk0sV0FBVyxDQUFDaUIsR0FBRyxDQUFDeEIsUUFBUSxFQUFFQyxTQUFTLENBQUM7TUFDcENpQixjQUFjLENBQUMsQ0FBQztNQUNoQixPQUFPLE1BQU07UUFDWFgsV0FBVyxDQUFDa0IsTUFBTSxDQUFDekIsUUFBUSxDQUFDO1FBQzVCa0IsY0FBYyxDQUFDLENBQUM7TUFDbEIsQ0FBQztJQUNILENBQUM7SUFFRGhCLEdBQUdBLENBQUEsRUFBRztNQUNKLElBQUlXLFNBQVMsS0FBSyxDQUFDLEVBQUU7UUFDbkJBLFNBQVMsR0FBR0csSUFBSSxDQUFDZCxHQUFHLENBQUMsQ0FBQztNQUN4QjtNQUNBO01BQ0E7TUFDQTtNQUNBO01BQ0EsSUFBSU8sUUFBUSxJQUFJSyxRQUFRLEVBQUU7UUFDeEIsT0FBT0EsUUFBUTtNQUNqQjtNQUNBLE9BQU9FLElBQUksQ0FBQ2QsR0FBRyxDQUFDLENBQUMsR0FBR1csU0FBUztJQUMvQixDQUFDO0lBRURWLGVBQWVBLENBQUNDLEVBQUUsRUFBRTtNQUNsQixJQUFJQSxFQUFFLEtBQUtRLHFCQUFxQixFQUFFO01BQ2xDQSxxQkFBcUIsR0FBR1IsRUFBRTtNQUMxQmMsY0FBYyxDQUFDLENBQUM7SUFDbEI7RUFDRixDQUFDO0FBQ0g7QUFFQSxPQUFPLE1BQU1RLFlBQVksR0FBR2pDLGFBQWEsQ0FBQ0ssS0FBSyxHQUFHLElBQUksQ0FBQyxDQUFDLElBQUksQ0FBQztBQUU3RCxNQUFNNkIsd0JBQXdCLEdBQUcvQixpQkFBaUIsR0FBRyxDQUFDOztBQUV0RDtBQUNBO0FBQ0E7QUFDQSxPQUFPLFNBQUFnQyxjQUFBQyxFQUFBO0VBQUEsTUFBQUMsQ0FBQSxHQUFBQyxFQUFBO0VBQXVCO0lBQUFDO0VBQUEsSUFBQUgsRUFJN0I7RUFDQyxPQUFBSSxLQUFBLElBQWdCdEMsUUFBUSxDQUFDdUMsS0FBb0MsQ0FBQztFQUM5RCxNQUFBQyxPQUFBLEdBQWdCdEMsZ0JBQWdCLENBQUMsQ0FBQztFQUFBLElBQUF1QyxFQUFBO0VBQUEsSUFBQUMsRUFBQTtFQUFBLElBQUFQLENBQUEsUUFBQUcsS0FBQSxJQUFBSCxDQUFBLFFBQUFLLE9BQUE7SUFFeEJDLEVBQUEsR0FBQUEsQ0FBQTtNQUNSSCxLQUFLLENBQUE5QixlQUFnQixDQUNuQmdDLE9BQU8sR0FBUHZDLGlCQUFzRCxHQUF0RCtCLHdCQUNGLENBQUM7SUFBQSxDQUNGO0lBQUVVLEVBQUEsSUFBQ0osS0FBSyxFQUFFRSxPQUFPLENBQUM7SUFBQUwsQ0FBQSxNQUFBRyxLQUFBO0lBQUFILENBQUEsTUFBQUssT0FBQTtJQUFBTCxDQUFBLE1BQUFNLEVBQUE7SUFBQU4sQ0FBQSxNQUFBTyxFQUFBO0VBQUE7SUFBQUQsRUFBQSxHQUFBTixDQUFBO0lBQUFPLEVBQUEsR0FBQVAsQ0FBQTtFQUFBO0VBSm5CcEMsU0FBUyxDQUFDMEMsRUFJVCxFQUFFQyxFQUFnQixDQUFDO0VBQUEsSUFBQUMsRUFBQTtFQUFBLElBQUFSLENBQUEsUUFBQUUsUUFBQSxJQUFBRixDQUFBLFFBQUFHLEtBQUE7SUFFYkssRUFBQSwwQkFBOEJMLEtBQUssQ0FBTEEsTUFBSSxDQUFDLENBQUdELFNBQU8sQ0FBRSx3QkFBd0I7SUFBQUYsQ0FBQSxNQUFBRSxRQUFBO0lBQUFGLENBQUEsTUFBQUcsS0FBQTtJQUFBSCxDQUFBLE1BQUFRLEVBQUE7RUFBQTtJQUFBQSxFQUFBLEdBQUFSLENBQUE7RUFBQTtFQUFBLE9BQXZFUSxFQUF1RTtBQUFBO0FBZHpFLFNBQUFKLE1BQUE7RUFBQSxPQUswQjdCLFdBQVcsQ0FBQ1QsaUJBQWlCLENBQUM7QUFBQSIsImlnbm9yZUxpc3QiOltdfQ==

--- a/packages/renderer/src/components/Link.tsx
+++ b/packages/renderer/src/components/Link.tsx
@@ -1,42 +1,31 @@
-import { c as _c } from "react/compiler-runtime";
-import type { ReactNode } from 'react';
-import React from 'react';
-import { supportsHyperlinks } from '../supports-hyperlinks';
-import Text from './Text';
+import type { ReactNode } from 'react'
+import React from 'react'
+import { supportsHyperlinks } from '../supports-hyperlinks.js'
+import Text from './Text.js'
+
 export type Props = {
-  readonly children?: ReactNode;
-  readonly url: string;
-  readonly fallback?: ReactNode;
-};
-export default function Link(t0: Props) {
-  const $ = _c(5);
-  const {
-    children,
-    url,
-    fallback
-  } = t0;
-  const content = children ?? url;
-  if (supportsHyperlinks()) {
-    let t1;
-    if ($[0] !== content || $[1] !== url) {
-      t1 = <Text><ink-link href={url}>{content}</ink-link></Text>;
-      $[0] = content;
-      $[1] = url;
-      $[2] = t1;
-    } else {
-      t1 = $[2];
-    }
-    return t1;
-  }
-  const t1 = fallback ?? content;
-  let t2;
-  if ($[3] !== t1) {
-    t2 = <Text>{t1}</Text>;
-    $[3] = t1;
-    $[4] = t2;
-  } else {
-    t2 = $[4];
-  }
-  return t2;
+  readonly children?: ReactNode
+  readonly url: string
+  readonly fallback?: ReactNode
 }
-//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJuYW1lcyI6WyJSZWFjdE5vZGUiLCJSZWFjdCIsInN1cHBvcnRzSHlwZXJsaW5rcyIsIlRleHQiLCJQcm9wcyIsImNoaWxkcmVuIiwidXJsIiwiZmFsbGJhY2siLCJMaW5rIiwidDAiLCIkIiwiX2MiLCJjb250ZW50IiwidDEiLCJ0MiJdLCJzb3VyY2VzIjpbIkxpbmsudHN4Il0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCB0eXBlIHsgUmVhY3ROb2RlIH0gZnJvbSAncmVhY3QnXG5pbXBvcnQgUmVhY3QgZnJvbSAncmVhY3QnXG5pbXBvcnQgeyBzdXBwb3J0c0h5cGVybGlua3MgfSBmcm9tICcuLi9zdXBwb3J0cy1oeXBlcmxpbmtzLmpzJ1xuaW1wb3J0IFRleHQgZnJvbSAnLi9UZXh0LmpzJ1xuXG5leHBvcnQgdHlwZSBQcm9wcyA9IHtcbiAgcmVhZG9ubHkgY2hpbGRyZW4/OiBSZWFjdE5vZGVcbiAgcmVhZG9ubHkgdXJsOiBzdHJpbmdcbiAgcmVhZG9ubHkgZmFsbGJhY2s/OiBSZWFjdE5vZGVcbn1cblxuZXhwb3J0IGRlZmF1bHQgZnVuY3Rpb24gTGluayh7XG4gIGNoaWxkcmVuLFxuICB1cmwsXG4gIGZhbGxiYWNrLFxufTogUHJvcHMpOiBSZWFjdC5SZWFjdE5vZGUge1xuICAvLyBVc2UgY2hpbGRyZW4gaWYgcHJvdmlkZWQsIG90aGVyd2lzZSBkaXNwbGF5IHRoZSBVUkxcbiAgY29uc3QgY29udGVudCA9IGNoaWxkcmVuID8/IHVybFxuXG4gIGlmIChzdXBwb3J0c0h5cGVybGlua3MoKSkge1xuICAgIC8vIFdyYXAgaW4gVGV4dCB0byBlbnN1cmUgd2UncmUgaW4gYSB0ZXh0IGNvbnRleHRcbiAgICAvLyAoaW5rLWxpbmsgaXMgYSB0ZXh0IGVsZW1lbnQgbGlrZSBpbmstdGV4dClcbiAgICByZXR1cm4gKFxuICAgICAgPFRleHQ+XG4gICAgICAgIDxpbmstbGluayBocmVmPXt1cmx9Pntjb250ZW50fTwvaW5rLWxpbms+XG4gICAgICA8L1RleHQ+XG4gICAgKVxuICB9XG5cbiAgcmV0dXJuIDxUZXh0PntmYWxsYmFjayA/PyBjb250ZW50fTwvVGV4dD5cbn1cbiJdLCJtYXBwaW5ncyI6IjtBQUFBLGNBQWNBLFNBQVMsUUFBUSxPQUFPO0FBQ3RDLE9BQU9DLEtBQUssTUFBTSxPQUFPO0FBQ3pCLFNBQVNDLGtCQUFrQixRQUFRLDJCQUEyQjtBQUM5RCxPQUFPQyxJQUFJLE1BQU0sV0FBVztBQUU1QixPQUFPLEtBQUtDLEtBQUssR0FBRztFQUNsQixTQUFTQyxRQUFRLENBQUMsRUFBRUwsU0FBUztFQUM3QixTQUFTTSxHQUFHLEVBQUUsTUFBTTtFQUNwQixTQUFTQyxRQUFRLENBQUMsRUFBRVAsU0FBUztBQUMvQixDQUFDO0FBRUQsZUFBZSxTQUFBUSxLQUFBQyxFQUFBO0VBQUEsTUFBQUMsQ0FBQSxHQUFBQyxFQUFBO0VBQWM7SUFBQU4sUUFBQTtJQUFBQyxHQUFBO0lBQUFDO0VBQUEsSUFBQUUsRUFJckI7RUFFTixNQUFBRyxPQUFBLEdBQWdCUCxRQUFlLElBQWZDLEdBQWU7RUFFL0IsSUFBSUosa0JBQWtCLENBQUMsQ0FBQztJQUFBLElBQUFXLEVBQUE7SUFBQSxJQUFBSCxDQUFBLFFBQUFFLE9BQUEsSUFBQUYsQ0FBQSxRQUFBSixHQUFBO01BSXBCTyxFQUFBLElBQUMsSUFBSSxDQUNILFNBQXlDLENBQXpCUCxJQUFHLENBQUhBLElBQUUsQ0FBQyxDQUFHTSxRQUFNLENBQUUsRUFBOUIsUUFBeUMsQ0FDM0MsRUFGQyxJQUFJLENBRUU7TUFBQUYsQ0FBQSxNQUFBRSxPQUFBO01BQUFGLENBQUEsTUFBQUosR0FBQTtNQUFBSSxDQUFBLE1BQUFHLEVBQUE7SUFBQTtNQUFBQSxFQUFBLEdBQUFILENBQUE7SUFBQTtJQUFBLE9BRlBHLEVBRU87RUFBQTtFQUlHLE1BQUFBLEVBQUEsR0FBQU4sUUFBbUIsSUFBbkJLLE9BQW1CO0VBQUEsSUFBQUUsRUFBQTtFQUFBLElBQUFKLENBQUEsUUFBQUcsRUFBQTtJQUExQkMsRUFBQSxJQUFDLElBQUksQ0FBRSxDQUFBRCxFQUFrQixDQUFFLEVBQTFCLElBQUksQ0FBNkI7SUFBQUgsQ0FBQSxNQUFBRyxFQUFBO0lBQUFILENBQUEsTUFBQUksRUFBQTtFQUFBO0lBQUFBLEVBQUEsR0FBQUosQ0FBQTtFQUFBO0VBQUEsT0FBbENJLEVBQWtDO0FBQUEiLCJpZ25vcmVMaXN0IjpbXX0=
+
+export default function Link({
+  children,
+  url,
+  fallback,
+}: Props): React.ReactNode {
+  // Use children if provided, otherwise display the URL
+  const content = children ?? url
+
+  if (supportsHyperlinks()) {
+    // Wrap in Text to ensure we're in a text context
+    // (ink-link is a text element like ink-text)
+    return (
+      <Text>
+        <ink-link href={url}>{content}</ink-link>
+      </Text>
+    )
+  }
+
+  return <Text>{fallback ?? content}</Text>
+}

--- a/packages/renderer/src/components/Newline.tsx
+++ b/packages/renderer/src/components/Newline.tsx
@@ -1,39 +1,17 @@
-import { c as _c } from "react/compiler-runtime";
-import React from 'react';
+import React from 'react'
+
 export type Props = {
   /**
    * Number of newlines to insert.
    *
    * @default 1
    */
-  readonly count?: number;
-};
+  readonly count?: number
+}
 
 /**
  * Adds one or more newline (\n) characters. Must be used within <Text> components.
  */
-export default function Newline(t0: Props) {
-  const $ = _c(4);
-  const {
-    count: t1
-  } = t0;
-  const count = t1 === undefined ? 1 : t1;
-  let t2;
-  if ($[0] !== count) {
-    t2 = "\n".repeat(count);
-    $[0] = count;
-    $[1] = t2;
-  } else {
-    t2 = $[1];
-  }
-  let t3;
-  if ($[2] !== t2) {
-    t3 = <ink-text>{t2}</ink-text>;
-    $[2] = t2;
-    $[3] = t3;
-  } else {
-    t3 = $[3];
-  }
-  return t3;
+export default function Newline({ count = 1 }: Props) {
+  return <ink-text>{'\n'.repeat(count)}</ink-text>
 }
-//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJuYW1lcyI6WyJSZWFjdCIsIlByb3BzIiwiY291bnQiLCJOZXdsaW5lIiwidDAiLCIkIiwiX2MiLCJ0MSIsInVuZGVmaW5lZCIsInQyIiwicmVwZWF0IiwidDMiXSwic291cmNlcyI6WyJOZXdsaW5lLnRzeCJdLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgUmVhY3QgZnJvbSAncmVhY3QnXG5cbmV4cG9ydCB0eXBlIFByb3BzID0ge1xuICAvKipcbiAgICogTnVtYmVyIG9mIG5ld2xpbmVzIHRvIGluc2VydC5cbiAgICpcbiAgICogQGRlZmF1bHQgMVxuICAgKi9cbiAgcmVhZG9ubHkgY291bnQ/OiBudW1iZXJcbn1cblxuLyoqXG4gKiBBZGRzIG9uZSBvciBtb3JlIG5ld2xpbmUgKFxcbikgY2hhcmFjdGVycy4gTXVzdCBiZSB1c2VkIHdpdGhpbiA8VGV4dD4gY29tcG9uZW50cy5cbiAqL1xuZXhwb3J0IGRlZmF1bHQgZnVuY3Rpb24gTmV3bGluZSh7IGNvdW50ID0gMSB9OiBQcm9wcykge1xuICByZXR1cm4gPGluay10ZXh0PnsnXFxuJy5yZXBlYXQoY291bnQpfTwvaW5rLXRleHQ+XG59XG4iXSwibWFwcGluZ3MiOiI7QUFBQSxPQUFPQSxLQUFLLE1BQU0sT0FBTztBQUV6QixPQUFPLEtBQUtDLEtBQUssR0FBRztFQUNsQjtBQUNGO0FBQ0E7QUFDQTtBQUNBO0VBQ0UsU0FBU0MsS0FBSyxDQUFDLEVBQUUsTUFBTTtBQUN6QixDQUFDOztBQUVEO0FBQ0E7QUFDQTtBQUNBLGVBQWUsU0FBQUMsUUFBQUMsRUFBQTtFQUFBLE1BQUFDLENBQUEsR0FBQUMsRUFBQTtFQUFpQjtJQUFBSixLQUFBLEVBQUFLO0VBQUEsSUFBQUgsRUFBb0I7RUFBbEIsTUFBQUYsS0FBQSxHQUFBSyxFQUFTLEtBQVRDLFNBQVMsR0FBVCxDQUFTLEdBQVRELEVBQVM7RUFBQSxJQUFBRSxFQUFBO0VBQUEsSUFBQUosQ0FBQSxRQUFBSCxLQUFBO0lBQ3ZCTyxFQUFBLE9BQUksQ0FBQUMsTUFBTyxDQUFDUixLQUFLLENBQUM7SUFBQUcsQ0FBQSxNQUFBSCxLQUFBO0lBQUFHLENBQUEsTUFBQUksRUFBQTtFQUFBO0lBQUFBLEVBQUEsR0FBQUosQ0FBQTtFQUFBO0VBQUEsSUFBQU0sRUFBQTtFQUFBLElBQUFOLENBQUEsUUFBQUksRUFBQTtJQUE3QkUsRUFBQSxZQUF5QyxDQUE5QixDQUFBRixFQUFpQixDQUFFLEVBQTlCLFFBQXlDO0lBQUFKLENBQUEsTUFBQUksRUFBQTtJQUFBSixDQUFBLE1BQUFNLEVBQUE7RUFBQTtJQUFBQSxFQUFBLEdBQUFOLENBQUE7RUFBQTtFQUFBLE9BQXpDTSxFQUF5QztBQUFBIiwiaWdub3JlTGlzdCI6W119

--- a/packages/renderer/src/components/NoSelect.tsx
+++ b/packages/renderer/src/components/NoSelect.tsx
@@ -1,6 +1,6 @@
-import { c as _c } from "react/compiler-runtime";
-import React, { type PropsWithChildren } from 'react';
-import Box, { type Props as BoxProps } from './Box';
+import React, { type PropsWithChildren } from 'react'
+import Box, { type Props as BoxProps } from './Box.js'
+
 type Props = Omit<BoxProps, 'noSelect'> & {
   /**
    * Extend the exclusion zone from column 0 to this box's right edge,
@@ -11,8 +11,8 @@ type Props = Omit<BoxProps, 'noSelect'> & {
    *
    * @default false
    */
-  fromLeftEdge?: boolean;
-};
+  fromLeftEdge?: boolean
+}
 
 /**
  * Marks its contents as non-selectable in fullscreen text selection.
@@ -32,37 +32,14 @@ type Props = Omit<BoxProps, 'noSelect'> & {
  * tracking). No-op in the main-screen scrollback render where the
  * terminal's native selection is used instead.
  */
-export function NoSelect(t0: PropsWithChildren<Props>) {
-  const $ = _c(8);
-  let boxProps;
-  let children;
-  let fromLeftEdge;
-  if ($[0] !== t0) {
-    ({
-      children,
-      fromLeftEdge,
-      ...boxProps
-    } = t0);
-    $[0] = t0;
-    $[1] = boxProps;
-    $[2] = children;
-    $[3] = fromLeftEdge;
-  } else {
-    boxProps = $[1];
-    children = $[2];
-    fromLeftEdge = $[3];
-  }
-  const t1 = fromLeftEdge ? "from-left-edge" : true;
-  let t2;
-  if ($[4] !== boxProps || $[5] !== children || $[6] !== t1) {
-    t2 = <Box {...boxProps} noSelect={t1}>{children}</Box>;
-    $[4] = boxProps;
-    $[5] = children;
-    $[6] = t1;
-    $[7] = t2;
-  } else {
-    t2 = $[7];
-  }
-  return t2;
+export function NoSelect({
+  children,
+  fromLeftEdge,
+  ...boxProps
+}: PropsWithChildren<Props>): React.ReactNode {
+  return (
+    <Box {...boxProps} noSelect={fromLeftEdge ? 'from-left-edge' : true}>
+      {children}
+    </Box>
+  )
 }
-//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJuYW1lcyI6WyJSZWFjdCIsIlByb3BzV2l0aENoaWxkcmVuIiwiQm94IiwiUHJvcHMiLCJCb3hQcm9wcyIsIk9taXQiLCJmcm9tTGVmdEVkZ2UiLCJOb1NlbGVjdCIsInQwIiwiJCIsIl9jIiwiYm94UHJvcHMiLCJjaGlsZHJlbiIsInQxIiwidDIiXSwic291cmNlcyI6WyJOb1NlbGVjdC50c3giXSwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IFJlYWN0LCB7IHR5cGUgUHJvcHNXaXRoQ2hpbGRyZW4gfSBmcm9tICdyZWFjdCdcbmltcG9ydCBCb3gsIHsgdHlwZSBQcm9wcyBhcyBCb3hQcm9wcyB9IGZyb20gJy4vQm94LmpzJ1xuXG50eXBlIFByb3BzID0gT21pdDxCb3hQcm9wcywgJ25vU2VsZWN0Jz4gJiB7XG4gIC8qKlxuICAgKiBFeHRlbmQgdGhlIGV4Y2x1c2lvbiB6b25lIGZyb20gY29sdW1uIDAgdG8gdGhpcyBib3gncyByaWdodCBlZGdlLFxuICAgKiBmb3IgZXZlcnkgcm93IHRoaXMgYm94IG9jY3VwaWVzLiBVc2UgZm9yIGd1dHRlcnMgcmVuZGVyZWQgaW5zaWRlIGFcbiAgICogd2lkZXIgaW5kZW50ZWQgY29udGFpbmVyIChlLmcuIGEgZGlmZiBpbnNpZGUgYSB0b29sIG1lc3NhZ2Ugcm93KTpcbiAgICogd2l0aG91dCB0aGlzLCBhIG11bHRpLXJvdyBkcmFnIHBpY2tzIHVwIHRoZSBjb250YWluZXIncyBsZWFkaW5nXG4gICAqIGluZGVudCBvbiByb3dzIGJlbG93IHRoZSBwcmVmaXguXG4gICAqXG4gICAqIEBkZWZhdWx0IGZhbHNlXG4gICAqL1xuICBmcm9tTGVmdEVkZ2U/OiBib29sZWFuXG59XG5cbi8qKlxuICogTWFya3MgaXRzIGNvbnRlbnRzIGFzIG5vbi1zZWxlY3RhYmxlIGluIGZ1bGxzY3JlZW4gdGV4dCBzZWxlY3Rpb24uXG4gKiBDZWxscyBpbnNpZGUgdGhpcyBib3ggYXJlIHNraXBwZWQgYnkgYm90aCB0aGUgc2VsZWN0aW9uIGhpZ2hsaWdodCBhbmRcbiAqIHRoZSBjb3BpZWQgdGV4dCDigJQgdGhlIGd1dHRlciBzdGF5cyB2aXN1YWxseSB1bmNoYW5nZWQgd2hpbGUgdGhlIHVzZXJcbiAqIGRyYWdzLCBtYWtpbmcgaXQgY2xlYXIgd2hhdCB3aWxsIGJlIGNvcGllZC5cbiAqXG4gKiBVc2UgdG8gZmVuY2Ugb2ZmIGd1dHRlcnMgKGxpbmUgbnVtYmVycywgZGlmZiArLy0gc2lnaWxzLCBsaXN0IGJ1bGxldHMpXG4gKiBzbyBjbGljay1kcmFnIG92ZXIgcmVuZGVyZWQgY29kZSB5aWVsZHMgY2xlYW4gcGFzdGVhYmxlIGNvbnRlbnQ6XG4gKlxuICogICA8Qm94IGZsZXhEaXJlY3Rpb249XCJyb3dcIj5cbiAqICAgICA8Tm9TZWxlY3QgZnJvbUxlZnRFZGdlPjxUZXh0IGRpbUNvbG9yPiA0MiArPC9UZXh0PjwvTm9TZWxlY3Q+XG4gKiAgICAgPFRleHQ+Y29uc3QgeCA9IDE8L1RleHQ+XG4gKiAgIDwvQm94PlxuICpcbiAqIE9ubHkgYWZmZWN0cyBhbHQtc2NyZWVuIHRleHQgc2VsZWN0aW9uICg8QWx0ZXJuYXRlU2NyZWVuPiB3aXRoIG1vdXNlXG4gKiB0cmFja2luZykuIE5vLW9wIGluIHRoZSBtYWluLXNjcmVlbiBzY3JvbGxiYWNrIHJlbmRlciB3aGVyZSB0aGVcbiAqIHRlcm1pbmFsJ3MgbmF0aXZlIHNlbGVjdGlvbiBpcyB1c2VkIGluc3RlYWQuXG4gKi9cbmV4cG9ydCBmdW5jdGlvbiBOb1NlbGVjdCh7XG4gIGNoaWxkcmVuLFxuICBmcm9tTGVmdEVkZ2UsXG4gIC4uLmJveFByb3BzXG59OiBQcm9wc1dpdGhDaGlsZHJlbjxQcm9wcz4pOiBSZWFjdC5SZWFjdE5vZGUge1xuICByZXR1cm4gKFxuICAgIDxCb3ggey4uLmJveFByb3BzfSBub1NlbGVjdD17ZnJvbUxlZnRFZGdlID8gJ2Zyb20tbGVmdC1lZGdlJyA6IHRydWV9PlxuICAgICAge2NoaWxkcmVufVxuICAgIDwvQm94PlxuICApXG59XG4iXSwibWFwcGluZ3MiOiI7QUFBQSxPQUFPQSxLQUFLLElBQUksS0FBS0MsaUJBQWlCLFFBQVEsT0FBTztBQUNyRCxPQUFPQyxHQUFHLElBQUksS0FBS0MsS0FBSyxJQUFJQyxRQUFRLFFBQVEsVUFBVTtBQUV0RCxLQUFLRCxLQUFLLEdBQUdFLElBQUksQ0FBQ0QsUUFBUSxFQUFFLFVBQVUsQ0FBQyxHQUFHO0VBQ3hDO0FBQ0Y7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtFQUNFRSxZQUFZLENBQUMsRUFBRSxPQUFPO0FBQ3hCLENBQUM7O0FBRUQ7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0EsT0FBTyxTQUFBQyxTQUFBQyxFQUFBO0VBQUEsTUFBQUMsQ0FBQSxHQUFBQyxFQUFBO0VBQUEsSUFBQUMsUUFBQTtFQUFBLElBQUFDLFFBQUE7RUFBQSxJQUFBTixZQUFBO0VBQUEsSUFBQUcsQ0FBQSxRQUFBRCxFQUFBO0lBQWtCO01BQUFJLFFBQUE7TUFBQU4sWUFBQTtNQUFBLEdBQUFLO0lBQUEsSUFBQUgsRUFJRTtJQUFBQyxDQUFBLE1BQUFELEVBQUE7SUFBQUMsQ0FBQSxNQUFBRSxRQUFBO0lBQUFGLENBQUEsTUFBQUcsUUFBQTtJQUFBSCxDQUFBLE1BQUFILFlBQUE7RUFBQTtJQUFBSyxRQUFBLEdBQUFGLENBQUE7SUFBQUcsUUFBQSxHQUFBSCxDQUFBO0lBQUFILFlBQUEsR0FBQUcsQ0FBQTtFQUFBO0VBRU0sTUFBQUksRUFBQSxHQUFBUCxZQUFZLEdBQVosZ0JBQXNDLEdBQXRDLElBQXNDO0VBQUEsSUFBQVEsRUFBQTtFQUFBLElBQUFMLENBQUEsUUFBQUUsUUFBQSxJQUFBRixDQUFBLFFBQUFHLFFBQUEsSUFBQUgsQ0FBQSxRQUFBSSxFQUFBO0lBQW5FQyxFQUFBLElBQUMsR0FBRyxLQUFLSCxRQUFRLEVBQVksUUFBc0MsQ0FBdEMsQ0FBQUUsRUFBcUMsQ0FBQyxDQUNoRUQsU0FBTyxDQUNWLEVBRkMsR0FBRyxDQUVFO0lBQUFILENBQUEsTUFBQUUsUUFBQTtJQUFBRixDQUFBLE1BQUFHLFFBQUE7SUFBQUgsQ0FBQSxNQUFBSSxFQUFBO0lBQUFKLENBQUEsTUFBQUssRUFBQTtFQUFBO0lBQUFBLEVBQUEsR0FBQUwsQ0FBQTtFQUFBO0VBQUEsT0FGTkssRUFFTTtBQUFBIiwiaWdub3JlTGlzdCI6W119

--- a/packages/renderer/src/components/RawAnsi.tsx
+++ b/packages/renderer/src/components/RawAnsi.tsx
@@ -1,14 +1,14 @@
-import { c as _c } from "react/compiler-runtime";
-import React from 'react';
+import React from 'react'
+
 type Props = {
   /**
    * Pre-rendered ANSI lines. Each element must be exactly one terminal row
    * (already wrapped to `width` by the producer) with ANSI escape codes inline.
    */
-  lines: string[];
+  lines: string[]
   /** Column width the producer wrapped to. Sent to Yoga as the fixed leaf width. */
-  width: number;
-};
+  width: number
+}
 
 /**
  * Bypass the <Ansi> → React tree → Yoga → squash → re-serialize roundtrip for
@@ -25,33 +25,15 @@ type Props = {
  * (width × lines.length) and hands the joined string straight to output.write(),
  * which already splits on '\n' and parses ANSI into the screen buffer.
  */
-export function RawAnsi(t0: Props) {
-  const $ = _c(6);
-  const {
-    lines,
-    width
-  } = t0;
+export function RawAnsi({ lines, width }: Props): React.ReactNode {
   if (lines.length === 0) {
-    return null;
+    return null
   }
-  let t1;
-  if ($[0] !== lines) {
-    t1 = lines.join("\n");
-    $[0] = lines;
-    $[1] = t1;
-  } else {
-    t1 = $[1];
-  }
-  let t2;
-  if ($[2] !== lines.length || $[3] !== t1 || $[4] !== width) {
-    t2 = <ink-raw-ansi rawText={t1} rawWidth={width} rawHeight={lines.length} />;
-    $[2] = lines.length;
-    $[3] = t1;
-    $[4] = width;
-    $[5] = t2;
-  } else {
-    t2 = $[5];
-  }
-  return t2;
+  return (
+    <ink-raw-ansi
+      rawText={lines.join('\n')}
+      rawWidth={width}
+      rawHeight={lines.length}
+    />
+  )
 }
-//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJuYW1lcyI6WyJSZWFjdCIsIlByb3BzIiwibGluZXMiLCJ3aWR0aCIsIlJhd0Fuc2kiLCJ0MCIsIiQiLCJfYyIsImxlbmd0aCIsInQxIiwiam9pbiIsInQyIl0sInNvdXJjZXMiOlsiUmF3QW5zaS50c3giXSwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IFJlYWN0IGZyb20gJ3JlYWN0J1xuXG50eXBlIFByb3BzID0ge1xuICAvKipcbiAgICogUHJlLXJlbmRlcmVkIEFOU0kgbGluZXMuIEVhY2ggZWxlbWVudCBtdXN0IGJlIGV4YWN0bHkgb25lIHRlcm1pbmFsIHJvd1xuICAgKiAoYWxyZWFkeSB3cmFwcGVkIHRvIGB3aWR0aGAgYnkgdGhlIHByb2R1Y2VyKSB3aXRoIEFOU0kgZXNjYXBlIGNvZGVzIGlubGluZS5cbiAgICovXG4gIGxpbmVzOiBzdHJpbmdbXVxuICAvKiogQ29sdW1uIHdpZHRoIHRoZSBwcm9kdWNlciB3cmFwcGVkIHRvLiBTZW50IHRvIFlvZ2EgYXMgdGhlIGZpeGVkIGxlYWYgd2lkdGguICovXG4gIHdpZHRoOiBudW1iZXJcbn1cblxuLyoqXG4gKiBCeXBhc3MgdGhlIDxBbnNpPiDihpIgUmVhY3QgdHJlZSDihpIgWW9nYSDihpIgc3F1YXNoIOKGkiByZS1zZXJpYWxpemUgcm91bmR0cmlwIGZvclxuICogY29udGVudCB0aGF0IGlzIGFscmVhZHkgdGVybWluYWwtcmVhZHkuXG4gKlxuICogVXNlIHRoaXMgd2hlbiBhbiBleHRlcm5hbCByZW5kZXJlciAoZS5nLiB0aGUgQ29sb3JEaWZmIE5BUEkgbW9kdWxlKSBoYXNcbiAqIGFscmVhZHkgcHJvZHVjZWQgQU5TSS1lc2NhcGVkLCB3aWR0aC13cmFwcGVkIG91dHB1dC4gQSBub3JtYWwgPEFuc2k+IG1vdW50XG4gKiByZXBhcnNlcyB0aGF0IG91dHB1dCBpbnRvIG9uZSBSZWFjdCA8VGV4dD4gcGVyIHN0eWxlIHNwYW4sIGxheXMgb3V0IGVhY2hcbiAqIHNwYW4gYXMgYSBZb2dhIGZsZXggY2hpbGQsIHRoZW4gd2Fsa3MgdGhlIHRyZWUgdG8gcmUtZW1pdCB0aGUgc2FtZSBlc2NhcGVcbiAqIGNvZGVzIGl0IHdhcyBnaXZlbi4gRm9yIGEgbG9uZyB0cmFuc2NyaXB0IGZ1bGwgb2Ygc3ludGF4LWhpZ2hsaWdodGVkIGRpZmZzXG4gKiB0aGF0IHJvdW5kdHJpcCBpcyB0aGUgZG9taW5hbnQgY29zdCBvZiB0aGUgcmVuZGVyLlxuICpcbiAqIFRoaXMgY29tcG9uZW50IGVtaXRzIGEgc2luZ2xlIFlvZ2EgbGVhZiB3aXRoIGEgY29uc3RhbnQtdGltZSBtZWFzdXJlIGZ1bmNcbiAqICh3aWR0aCDDlyBsaW5lcy5sZW5ndGgpIGFuZCBoYW5kcyB0aGUgam9pbmVkIHN0cmluZyBzdHJhaWdodCB0byBvdXRwdXQud3JpdGUoKSxcbiAqIHdoaWNoIGFscmVhZHkgc3BsaXRzIG9uICdcXG4nIGFuZCBwYXJzZXMgQU5TSSBpbnRvIHRoZSBzY3JlZW4gYnVmZmVyLlxuICovXG5leHBvcnQgZnVuY3Rpb24gUmF3QW5zaSh7IGxpbmVzLCB3aWR0aCB9OiBQcm9wcyk6IFJlYWN0LlJlYWN0Tm9kZSB7XG4gIGlmIChsaW5lcy5sZW5ndGggPT09IDApIHtcbiAgICByZXR1cm4gbnVsbFxuICB9XG4gIHJldHVybiAoXG4gICAgPGluay1yYXctYW5zaVxuICAgICAgcmF3VGV4dD17bGluZXMuam9pbignXFxuJyl9XG4gICAgICByYXdXaWR0aD17d2lkdGh9XG4gICAgICByYXdIZWlnaHQ9e2xpbmVzLmxlbmd0aH1cbiAgICAvPlxuICApXG59XG4iXSwibWFwcGluZ3MiOiI7QUFBQSxPQUFPQSxLQUFLLE1BQU0sT0FBTztBQUV6QixLQUFLQyxLQUFLLEdBQUc7RUFDWDtBQUNGO0FBQ0E7QUFDQTtFQUNFQyxLQUFLLEVBQUUsTUFBTSxFQUFFO0VBQ2Y7RUFDQUMsS0FBSyxFQUFFLE1BQU07QUFDZixDQUFDOztBQUVEO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBLE9BQU8sU0FBQUMsUUFBQUMsRUFBQTtFQUFBLE1BQUFDLENBQUEsR0FBQUMsRUFBQTtFQUFpQjtJQUFBTCxLQUFBO0lBQUFDO0VBQUEsSUFBQUUsRUFBdUI7RUFDN0MsSUFBSUgsS0FBSyxDQUFBTSxNQUFPLEtBQUssQ0FBQztJQUFBLE9BQ2IsSUFBSTtFQUFBO0VBQ1osSUFBQUMsRUFBQTtFQUFBLElBQUFILENBQUEsUUFBQUosS0FBQTtJQUdZTyxFQUFBLEdBQUFQLEtBQUssQ0FBQVEsSUFBSyxDQUFDLElBQUksQ0FBQztJQUFBSixDQUFBLE1BQUFKLEtBQUE7SUFBQUksQ0FBQSxNQUFBRyxFQUFBO0VBQUE7SUFBQUEsRUFBQSxHQUFBSCxDQUFBO0VBQUE7RUFBQSxJQUFBSyxFQUFBO0VBQUEsSUFBQUwsQ0FBQSxRQUFBSixLQUFBLENBQUFNLE1BQUEsSUFBQUYsQ0FBQSxRQUFBRyxFQUFBLElBQUFILENBQUEsUUFBQUgsS0FBQTtJQUQzQlEsRUFBQSxnQkFJRSxDQUhTLE9BQWdCLENBQWhCLENBQUFGLEVBQWUsQ0FBQyxDQUNmTixRQUFLLENBQUxBLE1BQUksQ0FBQyxDQUNKLFNBQVksQ0FBWixDQUFBRCxLQUFLLENBQUFNLE1BQU0sQ0FBQyxHQUN2QjtJQUFBRixDQUFBLE1BQUFKLEtBQUEsQ0FBQU0sTUFBQTtJQUFBRixDQUFBLE1BQUFHLEVBQUE7SUFBQUgsQ0FBQSxNQUFBSCxLQUFBO0lBQUFHLENBQUEsTUFBQUssRUFBQTtFQUFBO0lBQUFBLEVBQUEsR0FBQUwsQ0FBQTtFQUFBO0VBQUEsT0FKRkssRUFJRTtBQUFBIiwiaWdub3JlTGlzdCI6W119

--- a/packages/renderer/src/components/Spacer.tsx
+++ b/packages/renderer/src/components/Spacer.tsx
@@ -1,21 +1,10 @@
-import { c as _c } from "react/compiler-runtime";
-import React from 'react';
-import Box from './Box';
-
+import React from 'react'
+import Box from './Box.js'
 
 /**
  * A flexible space that expands along the major axis of its containing layout.
  * It's useful as a shortcut for filling all the available spaces between elements.
  */
 export default function Spacer() {
-  const $ = _c(1);
-  let t0;
-  if ($[0] === Symbol.for("react.memo_cache_sentinel")) {
-    t0 = <Box flexGrow={1} />;
-    $[0] = t0;
-  } else {
-    t0 = $[0];
-  }
-  return t0;
+  return <Box flexGrow={1} />
 }
-//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJuYW1lcyI6WyJSZWFjdCIsIkJveCIsIlNwYWNlciIsIiQiLCJfYyIsInQwIiwiU3ltYm9sIiwiZm9yIl0sInNvdXJjZXMiOlsiU3BhY2VyLnRzeCJdLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgUmVhY3QgZnJvbSAncmVhY3QnXG5pbXBvcnQgQm94IGZyb20gJy4vQm94LmpzJ1xuXG4vKipcbiAqIEEgZmxleGlibGUgc3BhY2UgdGhhdCBleHBhbmRzIGFsb25nIHRoZSBtYWpvciBheGlzIG9mIGl0cyBjb250YWluaW5nIGxheW91dC5cbiAqIEl0J3MgdXNlZnVsIGFzIGEgc2hvcnRjdXQgZm9yIGZpbGxpbmcgYWxsIHRoZSBhdmFpbGFibGUgc3BhY2VzIGJldHdlZW4gZWxlbWVudHMuXG4gKi9cbmV4cG9ydCBkZWZhdWx0IGZ1bmN0aW9uIFNwYWNlcigpIHtcbiAgcmV0dXJuIDxCb3ggZmxleEdyb3c9ezF9IC8+XG59XG4iXSwibWFwcGluZ3MiOiI7QUFBQSxPQUFPQSxLQUFLLE1BQU0sT0FBTztBQUN6QixPQUFPQyxHQUFHLE1BQU0sVUFBVTs7QUFFMUI7QUFDQTtBQUNBO0FBQ0E7QUFDQSxlQUFlLFNBQUFDLE9BQUE7RUFBQSxNQUFBQyxDQUFBLEdBQUFDLEVBQUE7RUFBQSxJQUFBQyxFQUFBO0VBQUEsSUFBQUYsQ0FBQSxRQUFBRyxNQUFBLENBQUFDLEdBQUE7SUFDTkYsRUFBQSxJQUFDLEdBQUcsQ0FBVyxRQUFDLENBQUQsR0FBQyxHQUFJO0lBQUFGLENBQUEsTUFBQUUsRUFBQTtFQUFBO0lBQUFBLEVBQUEsR0FBQUYsQ0FBQTtFQUFBO0VBQUEsT0FBcEJFLEVBQW9CO0FBQUEiLCJpZ25vcmVMaXN0IjpbXX0=

--- a/packages/renderer/src/components/TerminalFocusContext.tsx
+++ b/packages/renderer/src/components/TerminalFocusContext.tsx
@@ -1,52 +1,53 @@
-import { c as _c } from "react/compiler-runtime";
-import React, { createContext, useMemo, useSyncExternalStore } from 'react';
-import { getTerminalFocused, getTerminalFocusState, subscribeTerminalFocus, type TerminalFocusState } from '../terminal-focus-state';
-export type { TerminalFocusState };
+import React, { createContext, useMemo, useSyncExternalStore } from 'react'
+import {
+  getTerminalFocused,
+  getTerminalFocusState,
+  subscribeTerminalFocus,
+  type TerminalFocusState,
+} from '../terminal-focus-state.js'
+
+export type { TerminalFocusState }
+
 export type TerminalFocusContextProps = {
-  readonly isTerminalFocused: boolean;
-  readonly terminalFocusState: TerminalFocusState;
-};
+  readonly isTerminalFocused: boolean
+  readonly terminalFocusState: TerminalFocusState
+}
+
 const TerminalFocusContext = createContext<TerminalFocusContextProps>({
   isTerminalFocused: true,
-  terminalFocusState: 'unknown'
-});
+  terminalFocusState: 'unknown',
+})
 
 // eslint-disable-next-line custom-rules/no-top-level-side-effects
-TerminalFocusContext.displayName = 'TerminalFocusContext';
+TerminalFocusContext.displayName = 'TerminalFocusContext'
 
 // Separate component so App.tsx doesn't re-render on focus changes.
 // Children are a stable prop reference, so they don't re-render either —
 // only components that consume the context will re-render.
-export function TerminalFocusProvider(t0: { children: React.ReactNode }) {
-  const $ = _c(6);
-  const {
-    children
-  } = t0;
-  const isTerminalFocused = useSyncExternalStore(subscribeTerminalFocus, getTerminalFocused);
-  const terminalFocusState = useSyncExternalStore(subscribeTerminalFocus, getTerminalFocusState);
-  let t1;
-  if ($[0] !== isTerminalFocused || $[1] !== terminalFocusState) {
-    t1 = {
-      isTerminalFocused,
-      terminalFocusState
-    };
-    $[0] = isTerminalFocused;
-    $[1] = terminalFocusState;
-    $[2] = t1;
-  } else {
-    t1 = $[2];
-  }
-  const value = t1;
-  let t2;
-  if ($[3] !== children || $[4] !== value) {
-    t2 = <TerminalFocusContext.Provider value={value}>{children}</TerminalFocusContext.Provider>;
-    $[3] = children;
-    $[4] = value;
-    $[5] = t2;
-  } else {
-    t2 = $[5];
-  }
-  return t2;
+export function TerminalFocusProvider({
+  children,
+}: {
+  children: React.ReactNode
+}): React.ReactNode {
+  const isTerminalFocused = useSyncExternalStore(
+    subscribeTerminalFocus,
+    getTerminalFocused,
+  )
+  const terminalFocusState = useSyncExternalStore(
+    subscribeTerminalFocus,
+    getTerminalFocusState,
+  )
+
+  const value = useMemo(
+    () => ({ isTerminalFocused, terminalFocusState }),
+    [isTerminalFocused, terminalFocusState],
+  )
+
+  return (
+    <TerminalFocusContext.Provider value={value}>
+      {children}
+    </TerminalFocusContext.Provider>
+  )
 }
-export default TerminalFocusContext;
-//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJuYW1lcyI6WyJSZWFjdCIsImNyZWF0ZUNvbnRleHQiLCJ1c2VNZW1vIiwidXNlU3luY0V4dGVybmFsU3RvcmUiLCJnZXRUZXJtaW5hbEZvY3VzZWQiLCJnZXRUZXJtaW5hbEZvY3VzU3RhdGUiLCJzdWJzY3JpYmVUZXJtaW5hbEZvY3VzIiwiVGVybWluYWxGb2N1c1N0YXRlIiwiVGVybWluYWxGb2N1c0NvbnRleHRQcm9wcyIsImlzVGVybWluYWxGb2N1c2VkIiwidGVybWluYWxGb2N1c1N0YXRlIiwiVGVybWluYWxGb2N1c0NvbnRleHQiLCJkaXNwbGF5TmFtZSIsIlRlcm1pbmFsRm9jdXNQcm92aWRlciIsInQwIiwiJCIsIl9jIiwiY2hpbGRyZW4iLCJ0MSIsInZhbHVlIiwidDIiXSwic291cmNlcyI6WyJUZXJtaW5hbEZvY3VzQ29udGV4dC50c3giXSwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IFJlYWN0LCB7IGNyZWF0ZUNvbnRleHQsIHVzZU1lbW8sIHVzZVN5bmNFeHRlcm5hbFN0b3JlIH0gZnJvbSAncmVhY3QnXG5pbXBvcnQge1xuICBnZXRUZXJtaW5hbEZvY3VzZWQsXG4gIGdldFRlcm1pbmFsRm9jdXNTdGF0ZSxcbiAgc3Vic2NyaWJlVGVybWluYWxGb2N1cyxcbiAgdHlwZSBUZXJtaW5hbEZvY3VzU3RhdGUsXG59IGZyb20gJy4uL3Rlcm1pbmFsLWZvY3VzLXN0YXRlLmpzJ1xuXG5leHBvcnQgdHlwZSB7IFRlcm1pbmFsRm9jdXNTdGF0ZSB9XG5cbmV4cG9ydCB0eXBlIFRlcm1pbmFsRm9jdXNDb250ZXh0UHJvcHMgPSB7XG4gIHJlYWRvbmx5IGlzVGVybWluYWxGb2N1c2VkOiBib29sZWFuXG4gIHJlYWRvbmx5IHRlcm1pbmFsRm9jdXNTdGF0ZTogVGVybWluYWxGb2N1c1N0YXRlXG59XG5cbmNvbnN0IFRlcm1pbmFsRm9jdXNDb250ZXh0ID0gY3JlYXRlQ29udGV4dDxUZXJtaW5hbEZvY3VzQ29udGV4dFByb3BzPih7XG4gIGlzVGVybWluYWxGb2N1c2VkOiB0cnVlLFxuICB0ZXJtaW5hbEZvY3VzU3RhdGU6ICd1bmtub3duJyxcbn0pXG5cbi8vIGVzbGludC1kaXNhYmxlLW5leHQtbGluZSBjdXN0b20tcnVsZXMvbm8tdG9wLWxldmVsLXNpZGUtZWZmZWN0c1xuVGVybWluYWxGb2N1c0NvbnRleHQuZGlzcGxheU5hbWUgPSAnVGVybWluYWxGb2N1c0NvbnRleHQnXG5cbi8vIFNlcGFyYXRlIGNvbXBvbmVudCBzbyBBcHAudHN4IGRvZXNuJ3QgcmUtcmVuZGVyIG9uIGZvY3VzIGNoYW5nZXMuXG4vLyBDaGlsZHJlbiBhcmUgYSBzdGFibGUgcHJvcCByZWZlcmVuY2UsIHNvIHRoZXkgZG9uJ3QgcmUtcmVuZGVyIGVpdGhlciDigJRcbi8vIG9ubHkgY29tcG9uZW50cyB0aGF0IGNvbnN1bWUgdGhlIGNvbnRleHQgd2lsbCByZS1yZW5kZXIuXG5leHBvcnQgZnVuY3Rpb24gVGVybWluYWxGb2N1c1Byb3ZpZGVyKHtcbiAgY2hpbGRyZW4sXG59OiB7XG4gIGNoaWxkcmVuOiBSZWFjdC5SZWFjdE5vZGVcbn0pOiBSZWFjdC5SZWFjdE5vZGUge1xuICBjb25zdCBpc1Rlcm1pbmFsRm9jdXNlZCA9IHVzZVN5bmNFeHRlcm5hbFN0b3JlKFxuICAgIHN1YnNjcmliZVRlcm1pbmFsRm9jdXMsXG4gICAgZ2V0VGVybWluYWxGb2N1c2VkLFxuICApXG4gIGNvbnN0IHRlcm1pbmFsRm9jdXNTdGF0ZSA9IHVzZVN5bmNFeHRlcm5hbFN0b3JlKFxuICAgIHN1YnNjcmliZVRlcm1pbmFsRm9jdXMsXG4gICAgZ2V0VGVybWluYWxGb2N1c1N0YXRlLFxuICApXG5cbiAgY29uc3QgdmFsdWUgPSB1c2VNZW1vKFxuICAgICgpID0+ICh7IGlzVGVybWluYWxGb2N1c2VkLCB0ZXJtaW5hbEZvY3VzU3RhdGUgfSksXG4gICAgW2lzVGVybWluYWxGb2N1c2VkLCB0ZXJtaW5hbEZvY3VzU3RhdGVdLFxuICApXG5cbiAgcmV0dXJuIChcbiAgICA8VGVybWluYWxGb2N1c0NvbnRleHQuUHJvdmlkZXIgdmFsdWU9e3ZhbHVlfT5cbiAgICAgIHtjaGlsZHJlbn1cbiAgICA8L1Rlcm1pbmFsRm9jdXNDb250ZXh0LlByb3ZpZGVyPlxuICApXG59XG5cbmV4cG9ydCBkZWZhdWx0IFRlcm1pbmFsRm9jdXNDb250ZXh0XG4iXSwibWFwcGluZ3MiOiI7QUFBQSxPQUFPQSxLQUFLLElBQUlDLGFBQWEsRUFBRUMsT0FBTyxFQUFFQyxvQkFBb0IsUUFBUSxPQUFPO0FBQzNFLFNBQ0VDLGtCQUFrQixFQUNsQkMscUJBQXFCLEVBQ3JCQyxzQkFBc0IsRUFDdEIsS0FBS0Msa0JBQWtCLFFBQ2xCLDRCQUE0QjtBQUVuQyxjQUFjQSxrQkFBa0I7QUFFaEMsT0FBTyxLQUFLQyx5QkFBeUIsR0FBRztFQUN0QyxTQUFTQyxpQkFBaUIsRUFBRSxPQUFPO0VBQ25DLFNBQVNDLGtCQUFrQixFQUFFSCxrQkFBa0I7QUFDakQsQ0FBQztBQUVELE1BQU1JLG9CQUFvQixHQUFHVixhQUFhLENBQUNPLHlCQUF5QixDQUFDLENBQUM7RUFDcEVDLGlCQUFpQixFQUFFLElBQUk7RUFDdkJDLGtCQUFrQixFQUFFO0FBQ3RCLENBQUMsQ0FBQzs7QUFFRjtBQUNBQyxvQkFBb0IsQ0FBQ0MsV0FBVyxHQUFHLHNCQUFzQjs7QUFFekQ7QUFDQTtBQUNBO0FBQ0EsT0FBTyxTQUFBQyxzQkFBQUMsRUFBQTtFQUFBLE1BQUFDLENBQUEsR0FBQUMsRUFBQTtFQUErQjtJQUFBQztFQUFBLElBQUFILEVBSXJDO0VBQ0MsTUFBQUwsaUJBQUEsR0FBMEJOLG9CQUFvQixDQUM1Q0csc0JBQXNCLEVBQ3RCRixrQkFDRixDQUFDO0VBQ0QsTUFBQU0sa0JBQUEsR0FBMkJQLG9CQUFvQixDQUM3Q0csc0JBQXNCLEVBQ3RCRCxxQkFDRixDQUFDO0VBQUEsSUFBQWEsRUFBQTtFQUFBLElBQUFILENBQUEsUUFBQU4saUJBQUEsSUFBQU0sQ0FBQSxRQUFBTCxrQkFBQTtJQUdRUSxFQUFBO01BQUFULGlCQUFBO01BQUFDO0lBQXdDLENBQUM7SUFBQUssQ0FBQSxNQUFBTixpQkFBQTtJQUFBTSxDQUFBLE1BQUFMLGtCQUFBO0lBQUFLLENBQUEsTUFBQUcsRUFBQTtFQUFBO0lBQUFBLEVBQUEsR0FBQUgsQ0FBQTtFQUFBO0VBRGxELE1BQUFJLEtBQUEsR0FDU0QsRUFBeUM7RUFFakQsSUFBQUUsRUFBQTtFQUFBLElBQUFMLENBQUEsUUFBQUUsUUFBQSxJQUFBRixDQUFBLFFBQUFJLEtBQUE7SUFHQ0MsRUFBQSxrQ0FBc0NELEtBQUssQ0FBTEEsTUFBSSxDQUFDLENBQ3hDRixTQUFPLENBQ1YsZ0NBQWdDO0lBQUFGLENBQUEsTUFBQUUsUUFBQTtJQUFBRixDQUFBLE1BQUFJLEtBQUE7SUFBQUosQ0FBQSxNQUFBSyxFQUFBO0VBQUE7SUFBQUEsRUFBQSxHQUFBTCxDQUFBO0VBQUE7RUFBQSxPQUZoQ0ssRUFFZ0M7QUFBQTtBQUlwQyxlQUFlVCxvQkFBb0IiLCJpZ25vcmVMaXN0IjpbXX0=
+
+export default TerminalFocusContext

--- a/packages/renderer/src/components/Text.tsx
+++ b/packages/renderer/src/components/Text.tsx
@@ -1,252 +1,144 @@
-import { c as _c } from "react/compiler-runtime";
-import type { ReactNode } from 'react';
-import React from 'react';
-import type { Color, Styles, TextStyles } from '../styles';
+import type { ReactNode } from 'react'
+import React from 'react'
+import type { Color, Styles, TextStyles } from '../styles.js'
+
 type BaseProps = {
   /**
    * Change text color. Accepts a raw color value (rgb, hex, ansi).
    */
-  readonly color?: Color;
+  readonly color?: Color
 
   /**
    * Same as `color`, but for background.
    */
-  readonly backgroundColor?: Color;
+  readonly backgroundColor?: Color
 
   /**
    * Make the text italic.
    */
-  readonly italic?: boolean;
+  readonly italic?: boolean
 
   /**
    * Make the text underlined.
    */
-  readonly underline?: boolean;
+  readonly underline?: boolean
 
   /**
    * Make the text crossed with a line.
    */
-  readonly strikethrough?: boolean;
+  readonly strikethrough?: boolean
 
   /**
    * Inverse background and foreground colors.
    */
-  readonly inverse?: boolean;
+  readonly inverse?: boolean
 
   /**
    * This property tells Ink to wrap or truncate text if its width is larger than container.
    * If `wrap` is passed (by default), Ink will wrap text and split it into multiple lines.
    * If `truncate-*` is passed, Ink will truncate text instead, which will result in one line of text with the rest cut off.
    */
-  readonly wrap?: Styles['textWrap'];
-  readonly children?: ReactNode;
-};
+  readonly wrap?: Styles['textWrap']
+
+  readonly children?: ReactNode
+}
 
 /**
  * Bold and dim are mutually exclusive in terminals.
  * This type ensures you can use one or the other, but not both.
- * `dimColor` is an alias for `dim` (compatibility with ink v3 API).
  */
-type WeightProps = {
-  bold?: boolean;
-  dim?: boolean;
-  dimColor?: boolean;
-};
-export type Props = BaseProps & WeightProps;
+type WeightProps =
+  | { bold?: never; dim?: never }
+  | { bold: boolean; dim?: never }
+  | { dim: boolean; bold?: never }
+
+export type Props = BaseProps & WeightProps
+
 const memoizedStylesForWrap: Record<NonNullable<Styles['textWrap']>, Styles> = {
   wrap: {
     flexGrow: 0,
     flexShrink: 1,
     flexDirection: 'row',
-    textWrap: 'wrap'
+    textWrap: 'wrap',
   },
   'wrap-trim': {
     flexGrow: 0,
     flexShrink: 1,
     flexDirection: 'row',
-    textWrap: 'wrap-trim'
+    textWrap: 'wrap-trim',
   },
   end: {
     flexGrow: 0,
     flexShrink: 1,
     flexDirection: 'row',
-    textWrap: 'end'
+    textWrap: 'end',
   },
   middle: {
     flexGrow: 0,
     flexShrink: 1,
     flexDirection: 'row',
-    textWrap: 'middle'
+    textWrap: 'middle',
   },
   'truncate-end': {
     flexGrow: 0,
     flexShrink: 1,
     flexDirection: 'row',
-    textWrap: 'truncate-end'
+    textWrap: 'truncate-end',
   },
   truncate: {
     flexGrow: 0,
     flexShrink: 1,
     flexDirection: 'row',
-    textWrap: 'truncate'
+    textWrap: 'truncate',
   },
   'truncate-middle': {
     flexGrow: 0,
     flexShrink: 1,
     flexDirection: 'row',
-    textWrap: 'truncate-middle'
+    textWrap: 'truncate-middle',
   },
   'truncate-start': {
     flexGrow: 0,
     flexShrink: 1,
     flexDirection: 'row',
-    textWrap: 'truncate-start'
-  }
-} as const;
+    textWrap: 'truncate-start',
+  },
+} as const
 
 /**
  * This component can display text, and change its style to make it colorful, bold, underline, italic or strikethrough.
  */
-export default function Text(t0: Props) {
-  const $ = _c(29);
-  const {
-    color,
-    backgroundColor,
-    bold,
-    dim: dimProp,
-    dimColor,
-    italic: t1,
-    underline: t2,
-    strikethrough: t3,
-    inverse: t4,
-    wrap: t5,
-    children
-  } = t0;
-  const dim = dimProp || dimColor;
-  const italic = t1 === undefined ? false : t1;
-  const underline = t2 === undefined ? false : t2;
-  const strikethrough = t3 === undefined ? false : t3;
-  const inverse = t4 === undefined ? false : t4;
-  const wrap = t5 === undefined ? "wrap" : t5;
+export default function Text({
+  color,
+  backgroundColor,
+  bold,
+  dim,
+  italic = false,
+  underline = false,
+  strikethrough = false,
+  inverse = false,
+  wrap = 'wrap',
+  children,
+}: Props): React.ReactNode {
   if (children === undefined || children === null) {
-    return null;
+    return null
   }
-  let t6;
-  if ($[0] !== color) {
-    t6 = color && {
-      color
-    };
-    $[0] = color;
-    $[1] = t6;
-  } else {
-    t6 = $[1];
+
+  // Build textStyles object with only the properties that are set
+  const textStyles: TextStyles = {
+    ...(color && { color }),
+    ...(backgroundColor && { backgroundColor }),
+    ...(dim && { dim }),
+    ...(bold && { bold }),
+    ...(italic && { italic }),
+    ...(underline && { underline }),
+    ...(strikethrough && { strikethrough }),
+    ...(inverse && { inverse }),
   }
-  let t7;
-  if ($[2] !== backgroundColor) {
-    t7 = backgroundColor && {
-      backgroundColor
-    };
-    $[2] = backgroundColor;
-    $[3] = t7;
-  } else {
-    t7 = $[3];
-  }
-  let t8;
-  if ($[4] !== dim) {
-    t8 = dim && {
-      dim
-    };
-    $[4] = dim;
-    $[5] = t8;
-  } else {
-    t8 = $[5];
-  }
-  let t9;
-  if ($[6] !== bold) {
-    t9 = bold && {
-      bold
-    };
-    $[6] = bold;
-    $[7] = t9;
-  } else {
-    t9 = $[7];
-  }
-  let t10;
-  if ($[8] !== italic) {
-    t10 = italic && {
-      italic
-    };
-    $[8] = italic;
-    $[9] = t10;
-  } else {
-    t10 = $[9];
-  }
-  let t11;
-  if ($[10] !== underline) {
-    t11 = underline && {
-      underline
-    };
-    $[10] = underline;
-    $[11] = t11;
-  } else {
-    t11 = $[11];
-  }
-  let t12;
-  if ($[12] !== strikethrough) {
-    t12 = strikethrough && {
-      strikethrough
-    };
-    $[12] = strikethrough;
-    $[13] = t12;
-  } else {
-    t12 = $[13];
-  }
-  let t13;
-  if ($[14] !== inverse) {
-    t13 = inverse && {
-      inverse
-    };
-    $[14] = inverse;
-    $[15] = t13;
-  } else {
-    t13 = $[15];
-  }
-  let t14;
-  if ($[16] !== t10 || $[17] !== t11 || $[18] !== t12 || $[19] !== t13 || $[20] !== t6 || $[21] !== t7 || $[22] !== t8 || $[23] !== t9) {
-    t14 = {
-      ...t6,
-      ...t7,
-      ...t8,
-      ...t9,
-      ...t10,
-      ...t11,
-      ...t12,
-      ...t13
-    };
-    $[16] = t10;
-    $[17] = t11;
-    $[18] = t12;
-    $[19] = t13;
-    $[20] = t6;
-    $[21] = t7;
-    $[22] = t8;
-    $[23] = t9;
-    $[24] = t14;
-  } else {
-    t14 = $[24];
-  }
-  const textStyles = t14;
-  const t15 = memoizedStylesForWrap[wrap];
-  let t16;
-  if ($[25] !== children || $[26] !== t15 || $[27] !== textStyles) {
-    t16 = <ink-text style={t15} textStyles={textStyles}>{children}</ink-text>;
-    $[25] = children;
-    $[26] = t15;
-    $[27] = textStyles;
-    $[28] = t16;
-  } else {
-    t16 = $[28];
-  }
-  return t16;
+
+  return (
+    <ink-text style={memoizedStylesForWrap[wrap]} textStyles={textStyles}>
+      {children}
+    </ink-text>
+  )
 }
-//# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJuYW1lcyI6WyJSZWFjdE5vZGUiLCJSZWFjdCIsIkNvbG9yIiwiU3R5bGVzIiwiVGV4dFN0eWxlcyIsIkJhc2VQcm9wcyIsImNvbG9yIiwiYmFja2dyb3VuZENvbG9yIiwiaXRhbGljIiwidW5kZXJsaW5lIiwic3RyaWtldGhyb3VnaCIsImludmVyc2UiLCJ3cmFwIiwiY2hpbGRyZW4iLCJXZWlnaHRQcm9wcyIsImJvbGQiLCJkaW0iLCJQcm9wcyIsIm1lbW9pemVkU3R5bGVzRm9yV3JhcCIsIlJlY29yZCIsIk5vbk51bGxhYmxlIiwiZmxleEdyb3ciLCJmbGV4U2hyaW5rIiwiZmxleERpcmVjdGlvbiIsInRleHRXcmFwIiwiZW5kIiwibWlkZGxlIiwidHJ1bmNhdGUiLCJjb25zdCIsIlRleHQiLCJ0MCIsIiQiLCJfYyIsInQxIiwidDIiLCJ0MyIsInQ0IiwidDUiLCJ1bmRlZmluZWQiLCJ0NiIsInQ3IiwidDgiLCJ0OSIsInQxMCIsInQxMSIsInQxMiIsInQxMyIsInQxNCIsInRleHRTdHlsZXMiLCJ0MTUiLCJ0MTYiXSwic291cmNlcyI6WyJUZXh0LnRzeCJdLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgdHlwZSB7IFJlYWN0Tm9kZSB9IGZyb20gJ3JlYWN0J1xuaW1wb3J0IFJlYWN0IGZyb20gJ3JlYWN0J1xuaW1wb3J0IHR5cGUgeyBDb2xvciwgU3R5bGVzLCBUZXh0U3R5bGVzIH0gZnJvbSAnLi4vc3R5bGVzLmpzJ1xuXG50eXBlIEJhc2VQcm9wcyA9IHtcbiAgLyoqXG4gICAqIENoYW5nZSB0ZXh0IGNvbG9yLiBBY2NlcHRzIGEgcmF3IGNvbG9yIHZhbHVlIChyZ2IsIGhleCwgYW5zaSkuXG4gICAqL1xuICByZWFkb25seSBjb2xvcj86IENvbG9yXG5cbiAgLyoqXG4gICAqIFNhbWUgYXMgYGNvbG9yYCwgYnV0IGZvciBiYWNrZ3JvdW5kLlxuICAgKi9cbiAgcmVhZG9ubHkgYmFja2dyb3VuZENvbG9yPzogQ29sb3JcblxuICAvKipcbiAgICogTWFrZSB0aGUgdGV4dCBpdGFsaWMuXG4gICAqL1xuICByZWFkb25seSBpdGFsaWM/OiBib29sZWFuXG5cbiAgLyoqXG4gICAqIE1ha2UgdGhlIHRleHQgdW5kZXJsaW5lZC5cbiAgICovXG4gIHJlYWRvbmx5IHVuZGVybGluZT86IGJvb2xlYW5cblxuICAvKipcbiAgICogTWFrZSB0aGUgdGV4dCBjcm9zc2VkIHdpdGggYSBsaW5lLlxuICAgKi9cbiAgcmVhZG9ubHkgc3RyaWtldGhyb3VnaD86IGJvb2xlYW5cblxuICAvKipcbiAgICogSW52ZXJzZSBiYWNrZ3JvdW5kIGFuZCBmb3JlZ3JvdW5kIGNvbG9ycy5cbiAgICovXG4gIHJlYWRvbmx5IGludmVyc2U/OiBib29sZWFuXG5cbiAgLyoqXG4gICAqIFRoaXMgcHJvcGVydHkgdGVsbHMgSW5rIHRvIHdyYXAgb3IgdHJ1bmNhdGUgdGV4dCBpZiBpdHMgd2lkdGggaXMgbGFyZ2VyIHRoYW4gY29udGFpbmVyLlxuICAgKiBJZiBgd3JhcGAgaXMgcGFzc2VkIChieSBkZWZhdWx0KSwgSW5rIHdpbGwgd3JhcCB0ZXh0IGFuZCBzcGxpdCBpdCBpbnRvIG11bHRpcGxlIGxpbmVzLlxuICAgKiBJZiBgdHJ1bmNhdGUtKmAgaXMgcGFzc2VkLCBJbmsgd2lsbCB0cnVuY2F0ZSB0ZXh0IGluc3RlYWQsIHdoaWNoIHdpbGwgcmVzdWx0IGluIG9uZSBsaW5lIG9mIHRleHQgd2l0aCB0aGUgcmVzdCBjdXQgb2ZmLlxuICAgKi9cbiAgcmVhZG9ubHkgd3JhcD86IFN0eWxlc1sndGV4dFdyYXAnXVxuXG4gIHJlYWRvbmx5IGNoaWxkcmVuPzogUmVhY3ROb2RlXG59XG5cbi8qKlxuICogQm9sZCBhbmQgZGltIGFyZSBtdXR1YWxseSBleGNsdXNpdmUgaW4gdGVybWluYWxzLlxuICogVGhpcyB0eXBlIGVuc3VyZXMgeW91IGNhbiB1c2Ugb25lIG9yIHRoZSBvdGhlciwgYnV0IG5vdCBib3RoLlxuICovXG50eXBlIFdlaWdodFByb3BzID1cbiAgfCB7IGJvbGQ/OiBuZXZlcjsgZGltPzogbmV2ZXIgfVxuICB8IHsgYm9sZDogYm9vbGVhbjsgZGltPzogbmV2ZXIgfVxuICB8IHsgZGltOiBib29sZWFuOyBib2xkPzogbmV2ZXIgfVxuXG5leHBvcnQgdHlwZSBQcm9wcyA9IEJhc2VQcm9wcyAmIFdlaWdodFByb3BzXG5cbmNvbnN0IG1lbW9pemVkU3R5bGVzRm9yV3JhcDogUmVjb3JkPE5vbk51bGxhYmxlPFN0eWxlc1sndGV4dFdyYXAnXT4sIFN0eWxlcz4gPSB7XG4gIHdyYXA6IHtcbiAgICBmbGV4R3JvdzogMCxcbiAgICBmbGV4U2hyaW5rOiAxLFxuICAgIGZsZXhEaXJlY3Rpb246ICdyb3cnLFxuICAgIHRleHRXcmFwOiAnd3JhcCcsXG4gIH0sXG4gICd3cmFwLXRyaW0nOiB7XG4gICAgZmxleEdyb3c6IDAsXG4gICAgZmxleFNocmluazogMSxcbiAgICBmbGV4RGlyZWN0aW9uOiAncm93JyxcbiAgICB0ZXh0V3JhcDogJ3dyYXAtdHJpbScsXG4gIH0sXG4gIGVuZDoge1xuICAgIGZsZXhHcm93OiAwLFxuICAgIGZsZXhTaHJpbms6IDEsXG4gICAgZmxleERpcmVjdGlvbjogJ3JvdycsXG4gICAgdGV4dFdyYXA6ICdlbmQnLFxuICB9LFxuICBtaWRkbGU6IHtcbiAgICBmbGV4R3JvdzogMCxcbiAgICBmbGV4U2hyaW5rOiAxLFxuICAgIGZsZXhEaXJlY3Rpb246ICdyb3cnLFxuICAgIHRleHRXcmFwOiAnbWlkZGxlJyxcbiAgfSxcbiAgJ3RydW5jYXRlLWVuZCc6IHtcbiAgICBmbGV4R3JvdzogMCxcbiAgICBmbGV4U2hyaW5rOiAxLFxuICAgIGZsZXhEaXJlY3Rpb246ICdyb3cnLFxuICAgIHRleHRXcmFwOiAndHJ1bmNhdGUtZW5kJyxcbiAgfSxcbiAgdHJ1bmNhdGU6IHtcbiAgICBmbGV4R3JvdzogMCxcbiAgICBmbGV4U2hyaW5rOiAxLFxuICAgIGZsZXhEaXJlY3Rpb246ICdyb3cnLFxuICAgIHRleHRXcmFwOiAndHJ1bmNhdGUnLFxuICB9LFxuICAndHJ1bmNhdGUtbWlkZGxlJzoge1xuICAgIGZsZXhHcm93OiAwLFxuICAgIGZsZXhTaHJpbms6IDEsXG4gICAgZmxleERpcmVjdGlvbjogJ3JvdycsXG4gICAgdGV4dFdyYXA6ICd0cnVuY2F0ZS1taWRkbGUnLFxuICB9LFxuICAndHJ1bmNhdGUtc3RhcnQnOiB7XG4gICAgZmxleEdyb3c6IDAsXG4gICAgZmxleFNocmluazogMSxcbiAgICBmbGV4RGlyZWN0aW9uOiAncm93JyxcbiAgICB0ZXh0V3JhcDogJ3RydW5jYXRlLXN0YXJ0JyxcbiAgfSxcbn0gYXMgY29uc3RcblxuLyoqXG4gKiBUaGlzIGNvbXBvbmVudCBjYW4gZGlzcGxheSB0ZXh0LCBhbmQgY2hhbmdlIGl0cyBzdHlsZSB0byBtYWtlIGl0IGNvbG9yZnVsLCBib2xkLCB1bmRlcmxpbmUsIGl0YWxpYyBvciBzdHJpa2V0aHJvdWdoLlxuICovXG5leHBvcnQgZGVmYXVsdCBmdW5jdGlvbiBUZXh0KHtcbiAgY29sb3IsXG4gIGJhY2tncm91bmRDb2xvcixcbiAgYm9sZCxcbiAgZGltLFxuICBpdGFsaWMgPSBmYWxzZSxcbiAgdW5kZXJsaW5lID0gZmFsc2UsXG4gIHN0cmlrZXRocm91Z2ggPSBmYWxzZSxcbiAgaW52ZXJzZSA9IGZhbHNlLFxuICB3cmFwID0gJ3dyYXAnLFxuICBjaGlsZHJlbixcbn06IFByb3BzKTogUmVhY3QuUmVhY3ROb2RlIHtcbiAgaWYgKGNoaWxkcmVuID09PSB1bmRlZmluZWQgfHwgY2hpbGRyZW4gPT09IG51bGwpIHtcbiAgICByZXR1cm4gbnVsbFxuICB9XG5cbiAgLy8gQnVpbGQgdGV4dFN0eWxlcyBvYmplY3Qgd2l0aCBvbmx5IHRoZSBwcm9wZXJ0aWVzIHRoYXQgYXJlIHNldFxuICBjb25zdCB0ZXh0U3R5bGVzOiBUZXh0U3R5bGVzID0ge1xuICAgIC4uLihjb2xvciAmJiB7IGNvbG9yIH0pLFxuICAgIC4uLihiYWNrZ3JvdW5kQ29sb3IgJiYgeyBiYWNrZ3JvdW5kQ29sb3IgfSksXG4gICAgLi4uKGRpbSAmJiB7IGRpbSB9KSxcbiAgICAuLi4oYm9sZCAmJiB7IGJvbGQgfSksXG4gICAgLi4uKGl0YWxpYyAmJiB7IGl0YWxpYyB9KSxcbiAgICAuLi4odW5kZXJsaW5lICYmIHsgdW5kZXJsaW5lIH0pLFxuICAgIC4uLihzdHJpa2V0aHJvdWdoICYmIHsgc3RyaWtldGhyb3VnaCB9KSxcbiAgICAuLi4oaW52ZXJzZSAmJiB7IGludmVyc2UgfSksXG4gIH1cblxuICByZXR1cm4gKFxuICAgIDxpbmstdGV4dCBzdHlsZT17bWVtb2l6ZWRTdHlsZXNGb3JXcmFwW3dyYXBdfSB0ZXh0U3R5bGVzPXt0ZXh0U3R5bGVzfT5cbiAgICAgIHtjaGlsZHJlbn1cbiAgICA8L2luay10ZXh0PlxuICApXG59XG4iXSwibWFwcGluZ3MiOiI7QUFBQSxjQUFjQSxTQUFTLFFBQVEsT0FBTztBQUN0QyxPQUFPQyxLQUFLLE1BQU0sT0FBTztBQUN6QixjQUFjQyxLQUFLLEVBQUVDLE1BQU0sRUFBRUMsVUFBVSxRQUFRLGNBQWM7QUFFN0QsS0FBS0MsU0FBUyxHQUFHO0VBQ2Y7QUFDRjtBQUNBO0VBQ0UsU0FBU0MsS0FBSyxDQUFDLEVBQUVKLEtBQUs7O0VBRXRCO0FBQ0Y7QUFDQTtFQUNFLFNBQVNLLGVBQWUsQ0FBQyxFQUFFTCxLQUFLOztFQUVoQztBQUNGO0FBQ0E7RUFDRSxTQUFTTSxNQUFNLENBQUMsRUFBRSxPQUFPOztFQUV6QjtBQUNGO0FBQ0E7RUFDRSxTQUFTQyxTQUFTLENBQUMsRUFBRSxPQUFPOztFQUU1QjtBQUNGO0FBQ0E7RUFDRSxTQUFTQyxhQUFhLENBQUMsRUFBRSxPQUFPOztFQUVoQztBQUNGO0FBQ0E7RUFDRSxTQUFTQyxPQUFPLENBQUMsRUFBRSxPQUFPOztFQUUxQjtBQUNGO0FBQ0E7QUFDQTtBQUNBO0VBQ0UsU0FBU0MsSUFBSSxDQUFDLEVBQUVULE1BQU0sQ0FBQyxVQUFVLENBQUM7RUFFbEMsU0FBU1UsUUFBUSxDQUFDLEVBQUViLFNBQVM7QUFDL0IsQ0FBQzs7QUFFRDtBQUNBO0FBQ0E7QUFDQTtBQUNBLEtBQUtjLFdBQVcsR0FDWjtFQUFFQyxJQUFJLENBQUMsRUFBRSxLQUFLO0VBQUVDLEdBQUcsQ0FBQyxFQUFFLEtBQUs7QUFBQyxDQUFDLEdBQzdCO0VBQUVELElBQUksRUFBRSxPQUFPO0VBQUVDLEdBQUcsQ0FBQyxFQUFFLEtBQUs7QUFBQyxDQUFDLEdBQzlCO0VBQUVBLEdBQUcsRUFBRSxPQUFPO0VBQUVELElBQUksQ0FBQyxFQUFFLEtBQUs7QUFBQyxDQUFDO0FBRWxDLE9BQU8sS0FBS0UsS0FBSyxHQUFHWixTQUFTLEdBQUdTLFdBQVc7QUFFM0MsTUFBTUkscUJBQXFCLEVBQUVDLE1BQU0sQ0FBQ0MsV0FBVyxDQUFDakIsTUFBTSxDQUFDLFVBQVUsQ0FBQyxDQUFDLEVBQUVBLE1BQU0sQ0FBQyxHQUFHO0VBQzdFUyxJQUFJLEVBQUU7SUFDSlMsUUFBUSxFQUFFLENBQUM7SUFDWEMsVUFBVSxFQUFFLENBQUM7SUFDYkMsYUFBYSxFQUFFLEtBQUs7SUFDcEJDLFFBQVEsRUFBRTtFQUNaLENBQUM7RUFDRCxXQUFXLEVBQUU7SUFDWEgsUUFBUSxFQUFFLENBQUM7SUFDWEMsVUFBVSxFQUFFLENBQUM7SUFDYkMsYUFBYSxFQUFFLEtBQUs7SUFDcEJDLFFBQVEsRUFBRTtFQUNaLENBQUM7RUFDREMsR0FBRyxFQUFFO0lBQ0hKLFFBQVEsRUFBRSxDQUFDO0lBQ1hDLFVBQVUsRUFBRSxDQUFDO0lBQ2JDLGFBQWEsRUFBRSxLQUFLO0lBQ3BCQyxRQUFRLEVBQUU7RUFDWixDQUFDO0VBQ0RFLE1BQU0sRUFBRTtJQUNOTCxRQUFRLEVBQUUsQ0FBQztJQUNYQyxVQUFVLEVBQUUsQ0FBQztJQUNiQyxhQUFhLEVBQUUsS0FBSztJQUNwQkMsUUFBUSxFQUFFO0VBQ1osQ0FBQztFQUNELGNBQWMsRUFBRTtJQUNkSCxRQUFRLEVBQUUsQ0FBQztJQUNYQyxVQUFVLEVBQUUsQ0FBQztJQUNiQyxhQUFhLEVBQUUsS0FBSztJQUNwQkMsUUFBUSxFQUFFO0VBQ1osQ0FBQztFQUNERyxRQUFRLEVBQUU7SUFDUk4sUUFBUSxFQUFFLENBQUM7SUFDWEMsVUFBVSxFQUFFLENBQUM7SUFDYkMsYUFBYSxFQUFFLEtBQUs7SUFDcEJDLFFBQVEsRUFBRTtFQUNaLENBQUM7RUFDRCxpQkFBaUIsRUFBRTtJQUNqQkgsUUFBUSxFQUFFLENBQUM7SUFDWEMsVUFBVSxFQUFFLENBQUM7SUFDYkMsYUFBYSxFQUFFLEtBQUs7SUFDcEJDLFFBQVEsRUFBRTtFQUNaLENBQUM7RUFDRCxnQkFBZ0IsRUFBRTtJQUNoQkgsUUFBUSxFQUFFLENBQUM7SUFDWEMsVUFBVSxFQUFFLENBQUM7SUFDYkMsYUFBYSxFQUFFLEtBQUs7SUFDcEJDLFFBQVEsRUFBRTtFQUNaO0FBQ0YsQ0FBQyxJQUFJSSxLQUFLOztBQUVWO0FBQ0E7QUFDQTtBQUNBLGVBQWUsU0FBQUMsS0FBQUMsRUFBQTtFQUFBLE1BQUFDLENBQUEsR0FBQUMsRUFBQTtFQUFjO0lBQUExQixLQUFBO0lBQUFDLGVBQUE7SUFBQVEsSUFBQTtJQUFBQyxHQUFBO0lBQUFSLE1BQUEsRUFBQXlCLEVBQUE7SUFBQXhCLFNBQUEsRUFBQXlCLEVBQUE7SUFBQXhCLGFBQUEsRUFBQXlCLEVBQUE7SUFBQXhCLE9BQUEsRUFBQXlCLEVBQUE7SUFBQXhCLElBQUEsRUFBQXlCLEVBQUE7SUFBQXhCO0VBQUEsSUFBQWlCLEVBV3JCO0VBTk4sTUFBQXRCLE1BQUEsR0FBQXlCLEVBQWMsS0FBZEssU0FBYyxHQUFkLEtBQWMsR0FBZEwsRUFBYztFQUNkLE1BQUF4QixTQUFBLEdBQUF5QixFQUFpQixLQUFqQkksU0FBaUIsR0FBakIsS0FBaUIsR0FBakJKLEVBQWlCO0VBQ2pCLE1BQUF4QixhQUFBLEdBQUF5QixFQUFxQixLQUFyQkcsU0FBcUIsR0FBckIsS0FBcUIsR0FBckJILEVBQXFCO0VBQ3JCLE1BQUF4QixPQUFBLEdBQUF5QixFQUFlLEtBQWZFLFNBQWUsR0FBZixLQUFlLEdBQWZGLEVBQWU7RUFDZixNQUFBeEIsSUFBQSxHQUFBeUIsRUFBYSxLQUFiQyxTQUFhLEdBQWIsTUFBYSxHQUFiRCxFQUFhO0VBR2IsSUFBSXhCLFFBQVEsS0FBS3lCLFNBQThCLElBQWpCekIsUUFBUSxLQUFLLElBQUk7SUFBQSxPQUN0QyxJQUFJO0VBQUE7RUFDWixJQUFBMEIsRUFBQTtFQUFBLElBQUFSLENBQUEsUUFBQXpCLEtBQUE7SUFJS2lDLEVBQUEsR0FBQWpDLEtBQWtCLElBQWxCO01BQUFBO0lBQWlCLENBQUM7SUFBQXlCLENBQUEsTUFBQXpCLEtBQUE7SUFBQXlCLENBQUEsTUFBQVEsRUFBQTtFQUFBO0lBQUFBLEVBQUEsR0FBQVIsQ0FBQTtFQUFBO0VBQUEsSUFBQVMsRUFBQTtFQUFBLElBQUFULENBQUEsUUFBQXhCLGVBQUE7SUFDbEJpQyxFQUFBLEdBQUFqQyxlQUFzQyxJQUF0QztNQUFBQTtJQUFxQyxDQUFDO0lBQUF3QixDQUFBLE1BQUF4QixlQUFBO0lBQUF3QixDQUFBLE1BQUFTLEVBQUE7RUFBQTtJQUFBQSxFQUFBLEdBQUFULENBQUE7RUFBQTtFQUFBLElBQUFVLEVBQUE7RUFBQSxJQUFBVixDQUFBLFFBQUFmLEdBQUE7SUFDdEN5QixFQUFBLEdBQUF6QixHQUFjLElBQWQ7TUFBQUE7SUFBYSxDQUFDO0lBQUFlLENBQUEsTUFBQWYsR0FBQTtJQUFBZSxDQUFBLE1BQUFVLEVBQUE7RUFBQTtJQUFBQSxFQUFBLEdBQUFWLENBQUE7RUFBQTtFQUFBLElBQUFXLEVBQUE7RUFBQSxJQUFBWCxDQUFBLFFBQUFoQixJQUFBO0lBQ2QyQixFQUFBLEdBQUEzQixJQUFnQixJQUFoQjtNQUFBQTtJQUFlLENBQUM7SUFBQWdCLENBQUEsTUFBQWhCLElBQUE7SUFBQWdCLENBQUEsTUFBQVcsRUFBQTtFQUFBO0lBQUFBLEVBQUEsR0FBQVgsQ0FBQTtFQUFBO0VBQUEsSUFBQVksR0FBQTtFQUFBLElBQUFaLENBQUEsUUFBQXZCLE1BQUE7SUFDaEJtQyxHQUFBLEdBQUFuQyxNQUFvQixJQUFwQjtNQUFBQTtJQUFtQixDQUFDO0lBQUF1QixDQUFBLE1BQUF2QixNQUFBO0lBQUF1QixDQUFBLE1BQUFZLEdBQUE7RUFBQTtJQUFBQSxHQUFBLEdBQUFaLENBQUE7RUFBQTtFQUFBLElBQUFhLEdBQUE7RUFBQSxJQUFBYixDQUFBLFNBQUF0QixTQUFBO0lBQ3BCbUMsR0FBQSxHQUFBbkMsU0FBMEIsSUFBMUI7TUFBQUE7SUFBeUIsQ0FBQztJQUFBc0IsQ0FBQSxPQUFBdEIsU0FBQTtJQUFBc0IsQ0FBQSxPQUFBYSxHQUFBO0VBQUE7SUFBQUEsR0FBQSxHQUFBYixDQUFBO0VBQUE7RUFBQSxJQUFBYyxHQUFBO0VBQUEsSUFBQWQsQ0FBQSxTQUFBckIsYUFBQTtJQUMxQm1DLEdBQUEsR0FBQW5DLGFBQWtDLElBQWxDO01BQUFBO0lBQWlDLENBQUM7SUFBQXFCLENBQUEsT0FBQXJCLGFBQUE7SUFBQXFCLENBQUEsT0FBQWMsR0FBQTtFQUFBO0lBQUFBLEdBQUEsR0FBQWQsQ0FBQTtFQUFBO0VBQUEsSUFBQWUsR0FBQTtFQUFBLElBQUFmLENBQUEsU0FBQXBCLE9BQUE7SUFDbENtQyxHQUFBLEdBQUFuQyxPQUFzQixJQUF0QjtNQUFBQTtJQUFxQixDQUFDO0lBQUFvQixDQUFBLE9BQUFwQixPQUFBO0lBQUFvQixDQUFBLE9BQUFlLEdBQUE7RUFBQTtJQUFBQSxHQUFBLEdBQUFmLENBQUE7RUFBQTtFQUFBLElBQUFnQixHQUFBO0VBQUEsSUFBQWhCLENBQUEsU0FBQVksR0FBQSxJQUFBWixDQUFBLFNBQUFhLEdBQUEsSUFBQWIsQ0FBQSxTQUFBYyxHQUFBLElBQUFkLENBQUEsU0FBQWUsR0FBQSxJQUFBZixDQUFBLFNBQUFRLEVBQUEsSUFBQVIsQ0FBQSxTQUFBUyxFQUFBLElBQUFULENBQUEsU0FBQVUsRUFBQSxJQUFBVixDQUFBLFNBQUFXLEVBQUE7SUFSR0ssR0FBQTtNQUFBLEdBQ3pCUixFQUFrQjtNQUFBLEdBQ2xCQyxFQUFzQztNQUFBLEdBQ3RDQyxFQUFjO01BQUEsR0FDZEMsRUFBZ0I7TUFBQSxHQUNoQkMsR0FBb0I7TUFBQSxHQUNwQkMsR0FBMEI7TUFBQSxHQUMxQkMsR0FBa0M7TUFBQSxHQUNsQ0M7SUFDTixDQUFDO0lBQUFmLENBQUEsT0FBQVksR0FBQTtJQUFBWixDQUFBLE9BQUFhLEdBQUE7SUFBQWIsQ0FBQSxPQUFBYyxHQUFBO0lBQUFkLENBQUEsT0FBQWUsR0FBQTtJQUFBZixDQUFBLE9BQUFRLEVBQUE7SUFBQVIsQ0FBQSxPQUFBUyxFQUFBO0lBQUFULENBQUEsT0FBQVUsRUFBQTtJQUFBVixDQUFBLE9BQUFXLEVBQUE7SUFBQVgsQ0FBQSxPQUFBZ0IsR0FBQTtFQUFBO0lBQUFBLEdBQUEsR0FBQWhCLENBQUE7RUFBQTtFQVRELE1BQUFpQixVQUFBLEdBQStCRCxHQVM5QjtFQUdrQixNQUFBRSxHQUFBLEdBQUEvQixxQkFBcUIsQ0FBQ04sSUFBSSxDQUFDO0VBQUEsSUFBQXNDLEdBQUE7RUFBQSxJQUFBbkIsQ0FBQSxTQUFBbEIsUUFBQSxJQUFBa0IsQ0FBQSxTQUFBa0IsR0FBQSxJQUFBbEIsQ0FBQSxTQUFBaUIsVUFBQTtJQUE1Q0UsR0FBQSxZQUVXLENBRk0sS0FBMkIsQ0FBM0IsQ0FBQUQsR0FBMEIsQ0FBQyxDQUFjRCxVQUFVLENBQVZBLFdBQVMsQ0FBQyxDQUNqRW5DLFNBQU8sQ0FDVixFQUZBLFFBRVc7SUFBQWtCLENBQUEsT0FBQWxCLFFBQUE7SUFBQWtCLENBQUEsT0FBQWtCLEdBQUE7SUFBQWxCLENBQUEsT0FBQWlCLFVBQUE7SUFBQWpCLENBQUEsT0FBQW1CLEdBQUE7RUFBQTtJQUFBQSxHQUFBLEdBQUFuQixDQUFBO0VBQUE7RUFBQSxPQUZYbUIsR0FFVztBQUFBIiwiaWdub3JlTGlzdCI6W119

--- a/scripts/extract-react-compiler-sources.mjs
+++ b/scripts/extract-react-compiler-sources.mjs
@@ -1,0 +1,87 @@
+#!/usr/bin/env node
+/**
+ * One-time recovery tool: restore authored source from inline sourcemaps.
+ *
+ * Background: at some point, React Compiler output was generated and
+ * committed in place of the authored .tsx sources in packages/renderer/src.
+ * Each compiled file had its original source preserved as a base64-encoded
+ * inline sourcemap (`sourceMappingURL=data:application/json;...`) at the
+ * end of the file. This script walks every .tsx that imports from
+ * `react/compiler-runtime`, decodes the sourcemap's `sourcesContent[0]`,
+ * and writes it back over the file.
+ *
+ * Idempotent: a file with no `react/compiler-runtime` import (i.e. already
+ * authored source) is skipped silently. Re-running has no effect once
+ * recovery is complete.
+ *
+ * Safety: refuses to overwrite if the sourcemap is missing, empty, or
+ * fails to parse. Logs every action.
+ *
+ * Usage: node scripts/extract-react-compiler-sources.mjs [target-dir]
+ *   target-dir defaults to packages/renderer/src
+ */
+
+import { readFileSync, writeFileSync, readdirSync, statSync } from 'node:fs'
+import { join } from 'node:path'
+
+const COMPILER_IMPORT = 'react/compiler-runtime'
+const SM_RE = /\/\/# sourceMappingURL=data:application\/json;charset=utf-8;base64,([A-Za-z0-9+/=]+)\s*$/m
+
+function walk(dir) {
+  const out = []
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    const st = statSync(full)
+    if (st.isDirectory()) out.push(...walk(full))
+    else if (entry.endsWith('.tsx')) out.push(full)
+  }
+  return out
+}
+
+function restore(file) {
+  const content = readFileSync(file, 'utf8')
+  if (!content.includes(COMPILER_IMPORT)) return { file, status: 'skip-not-compiled' }
+
+  const m = content.match(SM_RE)
+  if (!m) return { file, status: 'error-no-sourcemap' }
+
+  let sm
+  try {
+    sm = JSON.parse(Buffer.from(m[1], 'base64').toString('utf8'))
+  } catch (e) {
+    return { file, status: 'error-corrupt-sourcemap', detail: e.message }
+  }
+
+  if (!sm.sourcesContent || !sm.sourcesContent[0]) {
+    return { file, status: 'error-empty-sourcemap' }
+  }
+
+  const original = sm.sourcesContent[0]
+  // Trailing newline normalization: the embedded source may or may not end
+  // with one. Force exactly one final newline for POSIX-correctness.
+  const normalized = original.endsWith('\n') ? original : original + '\n'
+  writeFileSync(file, normalized, 'utf8')
+  return { file, status: 'restored', bytes: normalized.length }
+}
+
+const targetDir = process.argv[2] ?? 'packages/renderer/src'
+const files = walk(targetDir)
+
+let restored = 0
+let skipped = 0
+let errors = 0
+for (const f of files) {
+  const r = restore(f)
+  if (r.status === 'restored') {
+    restored++
+    console.log(`restored: ${r.file} (${r.bytes} bytes)`)
+  } else if (r.status === 'skip-not-compiled') {
+    skipped++
+  } else {
+    errors++
+    console.error(`ERROR ${r.status}: ${r.file}${r.detail ? ' — ' + r.detail : ''}`)
+  }
+}
+
+console.log(`\n${restored} restored, ${skipped} skipped (already source), ${errors} errors`)
+process.exit(errors > 0 ? 1 : 0)


### PR DESCRIPTION
## Summary

Twelve \`.tsx\` files in \`packages/renderer/src\` were committed as **React Compiler output**, not as their original source. The visible code in those files was machine-generated — \`_c()\` memoization scaffold, anonymous \`let t2; let t3; let t5;\` scratch vars, no comments. The original authored source survived inside each file as a base64-encoded inline sourcemap (\`sourceMappingURL=data:application/json;...\`) appended at the end.

This PR recovers all 12 sources back into the files. After this lands, contributors can actually read and edit \`Box.tsx\`, \`Link.tsx\`, \`AlternateScreen.tsx\`, etc.

## Approach

Three commits:

**1. \`tools: add script to recover authored sources from inline sourcemaps\`**
\`scripts/extract-react-compiler-sources.mjs\` walks \`packages/renderer/src\`, finds every \`.tsx\` importing from \`react/compiler-runtime\`, decodes the inline sourcemap's \`sourcesContent[0]\`, and writes it back over the file. Idempotent (skips files without the compiler-runtime import — i.e. files already authored). Refuses to overwrite if a sourcemap is missing/empty/corrupt. Kept in the repo as documentation of what we did.

**2. \`chore(renderer): restore authored sources for 12 components\`**
Output of running the script. 12 files restored, 696 lines added, 1043 deleted (net reduction because the compiler scaffold is verbose).

**3. \`fix(box): drop stale side-effect import of ../global.d.ts\`**
The recovered \`Box.tsx\` source begins with \`import '../global.d.ts'\` — that file no longer exists; the JSX intrinsic-element types (ink-box, ink-text, etc.) live in \`src/types/jsx.d.ts\` now and load via TypeScript's source-tree include. Caught by typecheck immediately after the restoration commit, so it gets its own atomic fix.

## Behavior

- **Typecheck**: passes
- **Build**: passes. Dist size went from 350 KB to 338 KB CJS / 341 KB to 330 KB ESM. The delta is the React Compiler's memoization scaffold (the \`_c()\` cache and \`useMemoCache\` wrappers).
- **Functional**: unchanged. React's normal reconciliation handles re-renders without the compiler optimization. The optimization is a perf nice-to-have, not a correctness requirement.

## Follow-up

A separate PR will add \`babel-plugin-react-compiler\` to the renderer's \`tsup\` build pipeline. That way \`dist\` regains the compiler's memoization scaffold without committing the compiler output as source. Splitting it out keeps this PR focused on "make the code editable again" — a self-contained, mechanical change.

## Test plan

- [x] \`pnpm install --frozen-lockfile\` succeeds
- [x] \`pnpm -r typecheck\` succeeds
- [x] \`pnpm build\` succeeds for both packages
- [x] \`pnpm test\` succeeds (no tests yet, \`--passWithNoTests\`)
- [x] Spot-checked recovered sources (\`AlternateScreen.tsx\`) — clean original code, all comments preserved
- [ ] CI green on this PR

## Notes

Per the workflow rule: must be merged with a **normal merge commit**. Three commits to preserve.