### PR TITLE
test: scaffold vitest with real test coverage

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build": "pnpm --filter @yokai/shared build && pnpm --filter @yokai/renderer build",
     "typecheck": "pnpm -r typecheck",
     "lint": "pnpm -r lint",
-    "test": "vitest run --passWithNoTests"
+    "test": "vitest run"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/packages/renderer/src/selection.test.ts
+++ b/packages/renderer/src/selection.test.ts
@@ -1,0 +1,216 @@
+import { describe, expect, it } from 'vitest'
+import {
+  clearSelection,
+  createSelectionState,
+  finishSelection,
+  hasSelection,
+  selectionBounds,
+  shiftAnchor,
+  shiftSelectionForFollow,
+  startSelection,
+  updateSelection,
+} from './selection.js'
+
+describe('selection state machine', () => {
+  describe('lifecycle', () => {
+    it('starts empty', () => {
+      const s = createSelectionState()
+      expect(hasSelection(s)).toBe(false)
+      expect(s.anchor).toBeNull()
+      expect(s.focus).toBeNull()
+      expect(s.isDragging).toBe(false)
+    })
+
+    it('a bare click (start without update) leaves no selection', () => {
+      const s = createSelectionState()
+      startSelection(s, 5, 3)
+      // Anchor recorded, but focus stays null until first drag motion.
+      // hasSelection requires both anchor AND focus to be set, so a
+      // mouse-down + mouse-up with no motion should not highlight.
+      expect(s.anchor).toEqual({ col: 5, row: 3 })
+      expect(s.focus).toBeNull()
+      expect(s.isDragging).toBe(true)
+      expect(hasSelection(s)).toBe(false)
+    })
+
+    it('finishSelection ends drag mode but keeps the selection visible', () => {
+      const s = createSelectionState()
+      startSelection(s, 5, 3)
+      updateSelection(s, 7, 3)
+      finishSelection(s)
+      expect(s.isDragging).toBe(false)
+      // Anchor + focus preserved so the highlight stays on screen and
+      // the text is still copyable until clearSelection() runs.
+      expect(s.anchor).toEqual({ col: 5, row: 3 })
+      expect(s.focus).toEqual({ col: 7, row: 3 })
+      expect(hasSelection(s)).toBe(true)
+    })
+
+    it('clearSelection resets everything', () => {
+      const s = createSelectionState()
+      startSelection(s, 5, 3)
+      updateSelection(s, 7, 5)
+      clearSelection(s)
+      expect(s.anchor).toBeNull()
+      expect(s.focus).toBeNull()
+      expect(s.isDragging).toBe(false)
+      expect(hasSelection(s)).toBe(false)
+    })
+  })
+
+  describe('updateSelection', () => {
+    it('ignores a no-op motion at the anchor cell before any real drag', () => {
+      // Mode-1002 terminals can fire a drag event at the same cell as
+      // mouse-down (sub-pixel tremor). We must not turn that into a
+      // 1-cell selection that would clobber the clipboard.
+      const s = createSelectionState()
+      startSelection(s, 5, 3)
+      updateSelection(s, 5, 3)
+      expect(s.focus).toBeNull()
+      expect(hasSelection(s)).toBe(false)
+    })
+
+    it('sets focus on real motion away from anchor', () => {
+      const s = createSelectionState()
+      startSelection(s, 5, 3)
+      updateSelection(s, 8, 3)
+      expect(s.focus).toEqual({ col: 8, row: 3 })
+      expect(hasSelection(s)).toBe(true)
+    })
+
+    it('tracks back-to-anchor motion once focus has been set', () => {
+      const s = createSelectionState()
+      startSelection(s, 5, 3)
+      updateSelection(s, 8, 3) // first real motion
+      updateSelection(s, 5, 3) // dragged back to anchor — now valid
+      expect(s.focus).toEqual({ col: 5, row: 3 })
+    })
+
+    it('clears virtualFocusRow when the user moves the mouse', () => {
+      // Regression guard for the drag→follow transition bug. During
+      // drag-to-scroll, the dragging branch in ink.tsx populates
+      // virtualFocusRow to track focus's text-relative position.
+      // When the user then moves the mouse to a new screen position,
+      // that text-tracking debt no longer applies and must be cleared,
+      // or the next shiftSelectionForFollow will start from a stale row.
+      const s = createSelectionState()
+      startSelection(s, 5, 10)
+      updateSelection(s, 10, 10)
+      s.virtualFocusRow = 7 // simulate drag-phase tracking
+      updateSelection(s, 12, 12) // user moves the mouse
+      expect(s.virtualFocusRow).toBeUndefined()
+      expect(s.focus).toEqual({ col: 12, row: 12 })
+    })
+  })
+
+  describe('selectionBounds normalization', () => {
+    it('returns null with no anchor', () => {
+      const s = createSelectionState()
+      expect(selectionBounds(s)).toBeNull()
+    })
+
+    it('returns anchor before focus when reading order matches', () => {
+      const s = createSelectionState()
+      startSelection(s, 2, 1)
+      updateSelection(s, 8, 4)
+      expect(selectionBounds(s)).toEqual({
+        start: { col: 2, row: 1 },
+        end: { col: 8, row: 4 },
+      })
+    })
+
+    it('swaps anchor and focus when focus is earlier in reading order', () => {
+      const s = createSelectionState()
+      startSelection(s, 8, 4) // anchor low-right
+      updateSelection(s, 2, 1) // dragged up-left
+      // Bounds normalize so start always precedes end in reading order.
+      expect(selectionBounds(s)).toEqual({
+        start: { col: 2, row: 1 },
+        end: { col: 8, row: 4 },
+      })
+    })
+  })
+
+  describe('shiftAnchor (drag-to-scroll)', () => {
+    it('moves anchor by the given dRow within bounds', () => {
+      const s = createSelectionState()
+      startSelection(s, 5, 10)
+      updateSelection(s, 8, 12)
+      shiftAnchor(s, -3, 0, 22)
+      expect(s.anchor).toEqual({ col: 5, row: 7 })
+      // Focus stays at the mouse screen position during drag.
+      expect(s.focus).toEqual({ col: 8, row: 12 })
+    })
+
+    it('clamps anchor at the top edge and records virtualAnchorRow', () => {
+      const s = createSelectionState()
+      startSelection(s, 5, 2)
+      updateSelection(s, 8, 12)
+      shiftAnchor(s, -5, 0, 22) // would go to row -3
+      expect(s.anchor).toEqual({ col: 5, row: 0 })
+      // Virtual row records the pre-clamp position so a reverse scroll
+      // can restore the true row exactly. Without this the round-trip
+      // would land at row 0 + delta instead of -3 + delta.
+      expect(s.virtualAnchorRow).toBe(-3)
+    })
+
+    it('clears virtualAnchorRow when the anchor returns to in-bounds', () => {
+      const s = createSelectionState()
+      startSelection(s, 5, 2)
+      updateSelection(s, 8, 12)
+      shiftAnchor(s, -5, 0, 22) // virtualAnchorRow = -3
+      shiftAnchor(s, 5, 0, 22) // back to row 2 in-bounds
+      expect(s.anchor).toEqual({ col: 5, row: 2 })
+      expect(s.virtualAnchorRow).toBeUndefined()
+    })
+  })
+
+  describe('shiftSelectionForFollow (sticky-scroll follow)', () => {
+    it('moves both endpoints by the delta', () => {
+      const s = createSelectionState()
+      startSelection(s, 5, 10)
+      updateSelection(s, 8, 14)
+      finishSelection(s)
+      const cleared = shiftSelectionForFollow(s, -3, 0, 22)
+      expect(cleared).toBe(false)
+      expect(s.anchor).toEqual({ col: 5, row: 7 })
+      expect(s.focus).toEqual({ col: 8, row: 11 })
+    })
+
+    it('returns true and clears the selection when both ends overshoot the top', () => {
+      // When the selected text scrolls entirely off the viewport top,
+      // the highlight has nothing to attach to. Returning true tells
+      // ink.tsx to notify React-land subscribers (so the footer "copy"
+      // hint disappears).
+      const s = createSelectionState()
+      startSelection(s, 5, 1)
+      updateSelection(s, 8, 2)
+      finishSelection(s)
+      const cleared = shiftSelectionForFollow(s, -10, 0, 22)
+      expect(cleared).toBe(true)
+      expect(s.anchor).toBeNull()
+      expect(s.focus).toBeNull()
+    })
+
+    it('reads virtualAnchorRow from a prior shiftAnchor (drag→follow handoff)', () => {
+      // This is the actual bridge between the two scroll paths:
+      //   - shiftAnchor (during drag) leaves virtualAnchorRow = pre-clamp row
+      //   - shiftSelectionForFollow (after release) reads it as the
+      //     starting point for the next delta, otherwise the follow
+      //     starts from the clamped row and undercount accumulates.
+      const s = createSelectionState()
+      startSelection(s, 5, 2)
+      updateSelection(s, 8, 12)
+      shiftAnchor(s, -5, 0, 22) // virtualAnchorRow = -3, anchor clamped to 0
+      finishSelection(s)
+      // Now follow-scroll continues by -2 more.
+      shiftSelectionForFollow(s, -2, 0, 22)
+      // anchor's true position: -3 + -2 = -5 (still clamped to 0,
+      // virtualAnchorRow updated). If virtualAnchorRow had NOT been
+      // honored, anchor would have started from row 0 and gone to -2,
+      // losing 3 rows of accumulated drift.
+      expect(s.anchor).toEqual({ col: 5, row: 0 })
+      expect(s.virtualAnchorRow).toBe(-5)
+    })
+  })
+})

--- a/packages/shared/src/stringWidth.test.ts
+++ b/packages/shared/src/stringWidth.test.ts
@@ -1,0 +1,111 @@
+import { describe, expect, it } from 'vitest'
+import { stringWidth } from './stringWidth.js'
+
+describe('stringWidth', () => {
+  describe('basic strings', () => {
+    it('returns 0 for empty string', () => {
+      expect(stringWidth('')).toBe(0)
+    })
+
+    it('counts each ASCII character as width 1', () => {
+      expect(stringWidth('hello')).toBe(5)
+      expect(stringWidth('a')).toBe(1)
+      expect(stringWidth('hello world')).toBe(11)
+    })
+
+    it('returns 0 for non-string inputs', () => {
+      // The signature claims string, but the runtime guard handles
+      // anything React might flatten through JSX children.
+      // biome-ignore lint/suspicious/noExplicitAny: testing the runtime guard
+      expect(stringWidth(undefined as any)).toBe(0)
+      // biome-ignore lint/suspicious/noExplicitAny: testing the runtime guard
+      expect(stringWidth(null as any)).toBe(0)
+    })
+  })
+
+  describe('control characters', () => {
+    it('skips control characters in pure-ASCII fast path', () => {
+      // Tab, backspace, etc. are 0-width in terminal display.
+      expect(stringWidth('a\tb')).toBe(2)
+      expect(stringWidth('\x00\x01\x02')).toBe(0)
+    })
+  })
+
+  describe('ANSI escape sequences', () => {
+    it('strips ANSI codes before counting', () => {
+      // ESC[31m = red, ESC[0m = reset. Both are 0-width.
+      expect(stringWidth('\x1b[31mred\x1b[0m')).toBe(3)
+    })
+
+    it('returns 0 for a string that is only ANSI codes', () => {
+      expect(stringWidth('\x1b[31m\x1b[0m')).toBe(0)
+    })
+  })
+
+  describe('wide characters (East Asian)', () => {
+    it('counts CJK characters as width 2', () => {
+      expect(stringWidth('你好')).toBe(4)
+      expect(stringWidth('日本語')).toBe(6)
+    })
+
+    it('mixes ASCII and CJK correctly', () => {
+      expect(stringWidth('hi 你好')).toBe(7) // 'hi ' = 3, '你好' = 4
+    })
+
+    it('treats true-ambiguous BMP characters as narrow', () => {
+      // U+2030 (per mille sign) is east-asian-ambiguous and not in any
+      // emoji range — eastAsianWidth(ambiguousAsWide: false) → 1.
+      expect(stringWidth('‰')).toBe(1)
+    })
+
+    it('treats symbols in the emoji-symbol range as wide', () => {
+      // U+26A0 (⚠ warning sign) is *also* east-asian-ambiguous, but it
+      // sits in U+2600-U+27BF which needsSegmentation() flags for emoji
+      // processing. Modern terminals render it at width 2 with a colored
+      // glyph; matching that is the right call for visual alignment.
+      expect(stringWidth('⚠')).toBe(2)
+    })
+  })
+
+  describe('emoji', () => {
+    it('counts simple emoji as width 2', () => {
+      expect(stringWidth('🎉')).toBe(2)
+    })
+
+    it('counts a single regional indicator as width 1', () => {
+      // A lone regional indicator (e.g. U+1F1FA without a pair) is
+      // intentionally narrow — only flag pairs render at width 2.
+      expect(stringWidth('\u{1F1FA}')).toBe(1)
+    })
+
+    it('counts a flag (regional indicator pair) as width 2', () => {
+      // U+1F1FA + U+1F1F8 = 🇺🇸
+      expect(stringWidth('\u{1F1FA}\u{1F1F8}')).toBe(2)
+    })
+
+    it('counts ZWJ-joined family emoji as a single grapheme', () => {
+      // 👨‍👩‍👧 = man + ZWJ + woman + ZWJ + girl. Renders as one cluster.
+      expect(stringWidth('\u{1F468}\u{200D}\u{1F469}\u{200D}\u{1F467}')).toBe(2)
+    })
+  })
+
+  describe('zero-width and combining marks', () => {
+    it('treats combining diacritics as 0-width', () => {
+      // 'a' + combining acute accent (U+0301) = á, width 1
+      expect(stringWidth('á')).toBe(1)
+    })
+
+    it('treats variation selectors as 0-width', () => {
+      // VS-16 (U+FE0F) is the emoji presentation selector
+      expect(stringWidth('️')).toBe(0)
+    })
+
+    it('treats zero-width joiner as 0-width', () => {
+      expect(stringWidth('‍')).toBe(0)
+    })
+
+    it('treats BOM as 0-width', () => {
+      expect(stringWidth('﻿')).toBe(0)
+    })
+  })
+})

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,7 +1,14 @@
-import { defineConfig } from "vitest/config";
+import { defineConfig } from 'vitest/config'
 
 export default defineConfig({
   test: {
-    exclude: ["node_modules/**"],
+    // **/node_modules — not just root — because pnpm symlinks workspace
+    // packages into each consumer's node_modules, and a test in
+    // packages/shared/src/foo.test.ts would otherwise also be discovered
+    // through packages/renderer/node_modules/@yokai/shared/src/foo.test.ts
+    // and run twice.
+    exclude: ['**/node_modules/**', '**/dist/**'],
+    include: ['packages/*/src/**/*.test.ts'],
   },
-});
+})
+


### PR DESCRIPTION
## Summary

The previous setup had vitest installed and a config file but **zero tests** — the test job ran with \`--passWithNoTests\` and only verified the toolchain loaded. CI couldn't catch any regression because no behavior was being asserted.

This PR puts the test job to work with **35 passing tests** across both packages.

## Changes

### \`vitest.config.ts\`
- Tests live co-located with source as \`packages/*/src/**/*.test.ts\`. Modern testing convention; no separate \`tests/\` tree to keep in sync.
- Excludes \`**/node_modules/**\` (recursive — pnpm symlinks workspace deps so a test in \`packages/shared/src/foo.test.ts\` was being discovered twice through \`packages/renderer/node_modules/@yokai/shared/src/foo.test.ts\`).
- Excludes \`**/dist/**\`.

### \`packages/shared/src/stringWidth.test.ts\` (18 tests)

Covers every documented branch of \`stringWidthJavaScript\`:
- Empty/non-string inputs (the runtime guard for React's JSX child flattening)
- ASCII fast path
- Control character skip
- ANSI strip
- CJK wide chars
- Ambiguous-width handling (caught the surprising case where \`⚠\` gets emoji-path width 2 because U+2600-U+27BF triggers \`needsSegmentation\` — now documented inline)
- Simple emoji, regional indicators (single vs flag pair)
- ZWJ-joined family emoji
- Combining diacritics, variation selectors, ZWJ, BOM

### \`packages/renderer/src/selection.test.ts\` (17 tests)

State machine coverage:
- Lifecycle: \`startSelection\` → \`updateSelection\` → \`finishSelection\` → \`clearSelection\`
- Bare-click guard (no focus until real motion)
- Tremor protection (no-op motion at the anchor cell ignored — mode-1002 sub-pixel jitter)
- Back-to-anchor tracking once focus is set
- \`selectionBounds\` normalization for forward and reverse drags
- \`shiftAnchor\`: in-bounds dRow, top-edge clamp recording \`virtualAnchorRow\`, virtual row clears on return-to-bounds
- \`shiftSelectionForFollow\`: both-end shift, both-overshoot clear with return value, drag→follow handoff via \`virtualAnchorRow\`
- **Regression guard for the \`virtualFocusRow\` bug fix** (commit \`6fadbb3\`): when the user moves the mouse to a new screen position, \`virtualFocusRow\` must clear so the next \`shiftSelectionForFollow\` starts from the new focus row, not stale drag-phase debt.

### \`package.json\`
Dropped \`--passWithNoTests\` from the root \`test\` script. CI now fails if a test file is removed and not replaced, which is the desired signal.

## Test plan

- [x] \`pnpm test\` reports 35 passed across 2 files in <1s
- [x] \`pnpm -r typecheck\` passes (test files type-checked alongside source)
- [x] \`pnpm build\` doesn't include \`.test.ts\` files in dist (tsup only bundles what's reachable from \`entry: src/index.ts\`)
- [ ] CI green on this PR

## Notes

- Single commit. Per workflow rule: must be merged with a normal merge commit.
- Independent of #3, #4, #5 — branches from main, only adds two new files and tweaks two configs. Mergeable in any order.
- Test files use the codebase's authored convention (single quotes, no semis) — matches what PR #4 establishes via biome config. On main without #4 merged yet, the advisory lint reports format diffs in the test files; that resolves on its own when #4 lands.