### PR TITLE
chore: lint cleanup — bring biome to zero violations and enforce in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,14 +36,8 @@ jobs:
       - name: Typecheck
         run: pnpm -r typecheck
 
-      # Lint is reported but not enforced yet. The codebase has pre-existing
-      # violations (mostly stylistic + a few intentional patterns biome flags
-      # as suspicious, e.g. `x !== x` for NaN detection in the Yoga port).
-      # Cleanup is its own deliberate PR — see follow-up. Until then, surface
-      # the report in CI logs without failing the build.
-      - name: Lint (advisory)
+      - name: Lint
         run: pnpm -r lint
-        continue-on-error: true
 
       - name: Build renderer
         run: pnpm --filter @yokai/renderer build

--- a/biome.json
+++ b/biome.json
@@ -20,6 +20,15 @@
     "indentWidth": 2,
     "lineWidth": 100
   },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "jsxQuoteStyle": "double",
+      "semicolons": "asNeeded",
+      "trailingCommas": "all",
+      "arrowParentheses": "always"
+    }
+  },
   "files": {
     "ignore": ["node_modules", "dist", ".turbo", "*.d.ts"]
   }

--- a/biome.json
+++ b/biome.json
@@ -31,5 +31,38 @@
   },
   "files": {
     "ignore": ["node_modules", "dist", ".turbo", "*.d.ts"]
-  }
+  },
+  "overrides": [
+    {
+      "include": ["**/parse-keypress.ts"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noControlCharactersInRegex": "off",
+            "noAssignInExpressions": "off"
+          }
+        }
+      }
+    },
+    {
+      "include": ["**/components/Box.tsx"],
+      "linter": {
+        "rules": {
+          "a11y": {
+            "noAutofocus": "off"
+          }
+        }
+      }
+    },
+    {
+      "include": ["**/lodash-replacements.ts"],
+      "linter": {
+        "rules": {
+          "suspicious": {
+            "noEmptyBlockStatements": "off"
+          }
+        }
+      }
+    }
+  ]
 }

--- a/biome.json
+++ b/biome.json
@@ -63,6 +63,29 @@
           }
         }
       }
+    },
+    {
+      "include": ["**/screen.ts"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noParameterAssign": "off"
+          }
+        }
+      }
+    },
+    {
+      "include": ["**/ink.tsx"],
+      "linter": {
+        "rules": {
+          "style": {
+            "useTemplate": "off"
+          },
+          "suspicious": {
+            "noConsole": "off"
+          }
+        }
+      }
     }
   ]
 }

--- a/packages/renderer/src/Ansi.tsx
+++ b/packages/renderer/src/Ansi.tsx
@@ -2,12 +2,7 @@ import React from 'react'
 import Link from './components/Link.js'
 import Text from './components/Text.js'
 import type { Color } from './styles.js'
-import {
-  type NamedColor,
-  Parser,
-  type Color as TermioColor,
-  type TextStyle,
-} from './termio.js'
+import { type NamedColor, Parser, type Color as TermioColor, type TextStyle } from './termio.js'
 
 type Props = {
   children: string
@@ -35,16 +30,9 @@ type SpanProps = {
  *
  * Memoized to prevent re-renders when parent changes but children string is the same.
  */
-export const Ansi = React.memo(function Ansi({
-  children,
-  dimColor,
-}: Props): React.ReactNode {
+export const Ansi = React.memo(function Ansi({ children, dimColor }: Props): React.ReactNode {
   if (typeof children !== 'string') {
-    return dimColor ? (
-      <Text dim>{String(children)}</Text>
-    ) : (
-      <Text>{String(children)}</Text>
-    )
+    return dimColor ? <Text dim>{String(children)}</Text> : <Text>{String(children)}</Text>
   }
 
   if (children === '') {
@@ -58,11 +46,7 @@ export const Ansi = React.memo(function Ansi({
   }
 
   if (spans.length === 1 && !hasAnyProps(spans[0]!.props)) {
-    return dimColor ? (
-      <Text dim>{spans[0]!.text}</Text>
-    ) : (
-      <Text>{spans[0]!.text}</Text>
-    )
+    return dimColor ? <Text dim>{spans[0]!.text}</Text> : <Text>{spans[0]!.text}</Text>
   }
 
   const content = spans.map((span, i) => {
@@ -144,7 +128,7 @@ function parseToSpans(input: string): Span[] {
     }
 
     if (action.type === 'text') {
-      const text = action.graphemes.map(g => g.value).join('')
+      const text = action.graphemes.map((g) => g.value).join('')
       if (!text) continue
 
       const props = textStyleToSpanProps(action.style)

--- a/packages/renderer/src/Ansi.tsx
+++ b/packages/renderer/src/Ansi.tsx
@@ -57,8 +57,13 @@ export const Ansi = React.memo(function Ansi({ children, dimColor }: Props): Rea
     }
     const hasTextProps = hasAnyTextProps(span.props)
 
+    // Index keys are correct for ANSI-parsed spans: the array is derived
+    // freshly from `children` (the raw string) on every render, so when the
+    // input changes the whole array changes — there's no stable identity
+    // to track. biome's noArrayIndexKey is conservative; suppress per-site.
     if (hyperlink) {
       return hasTextProps ? (
+        // biome-ignore lint/suspicious/noArrayIndexKey: parsed spans, see comment above
         <Link key={i} url={hyperlink}>
           <StyledText
             color={span.props.color}
@@ -74,6 +79,7 @@ export const Ansi = React.memo(function Ansi({ children, dimColor }: Props): Rea
           </StyledText>
         </Link>
       ) : (
+        // biome-ignore lint/suspicious/noArrayIndexKey: parsed spans, see comment above
         <Link key={i} url={hyperlink}>
           {span.text}
         </Link>
@@ -82,6 +88,7 @@ export const Ansi = React.memo(function Ansi({ children, dimColor }: Props): Rea
 
     return hasTextProps ? (
       <StyledText
+        // biome-ignore lint/suspicious/noArrayIndexKey: parsed spans, see comment above
         key={i}
         color={span.props.color}
         backgroundColor={span.props.backgroundColor}

--- a/packages/renderer/src/bidi.ts
+++ b/packages/renderer/src/bidi.ts
@@ -30,8 +30,8 @@ function needsBidi(): boolean {
   if (needsSoftwareBidi === undefined) {
     needsSoftwareBidi =
       process.platform === 'win32' ||
-      typeof process.env['WT_SESSION'] === 'string' || // WSL in Windows Terminal
-      process.env['TERM_PROGRAM'] === 'vscode' // VS Code integrated terminal (xterm.js)
+      typeof process.env.WT_SESSION === 'string' || // WSL in Windows Terminal
+      process.env.TERM_PROGRAM === 'vscode' // VS Code integrated terminal (xterm.js)
   }
   return needsSoftwareBidi
 }

--- a/packages/renderer/src/bidi.ts
+++ b/packages/renderer/src/bidi.ts
@@ -56,7 +56,7 @@ export function reorderBidi(characters: ClusteredChar[]): ClusteredChar[] {
   }
 
   // Build a plain string from the clustered chars to run through bidi
-  const plainText = characters.map(c => c.value).join('')
+  const plainText = characters.map((c) => c.value).join('')
 
   // Check if there are any RTL characters — skip bidi if pure LTR
   if (!hasRTLCharacters(plainText)) {
@@ -137,4 +137,3 @@ function hasRTLCharacters(text: string): boolean {
     text,
   )
 }
-

--- a/packages/renderer/src/bidi.ts
+++ b/packages/renderer/src/bidi.ts
@@ -105,22 +105,26 @@ export function reorderBidi(characters: ClusteredChar[]): ClusteredChar[] {
 }
 
 function reverseRange<T>(arr: T[], start: number, end: number): void {
-  while (start < end) {
-    const temp = arr[start]!
-    arr[start] = arr[end]!
-    arr[end] = temp
-    start++
-    end--
+  let lo = start
+  let hi = end
+  while (lo < hi) {
+    const temp = arr[lo]!
+    arr[lo] = arr[hi]!
+    arr[hi] = temp
+    lo++
+    hi--
   }
 }
 
 function reverseRangeNumbers(arr: number[], start: number, end: number): void {
-  while (start < end) {
-    const temp = arr[start]!
-    arr[start] = arr[end]!
-    arr[end] = temp
-    start++
-    end--
+  let lo = start
+  let hi = end
+  while (lo < hi) {
+    const temp = arr[lo]!
+    arr[lo] = arr[hi]!
+    arr[hi] = temp
+    lo++
+    hi--
   }
 }
 

--- a/packages/renderer/src/clearTerminal.ts
+++ b/packages/renderer/src/clearTerminal.ts
@@ -55,10 +55,9 @@ export function getClearTerminalSequence(): string {
   if (process.platform === 'win32') {
     if (isModernWindowsTerminal()) {
       return ERASE_SCREEN + ERASE_SCROLLBACK + CURSOR_HOME
-    } else {
-      // Legacy Windows console - can't clear scrollback
-      return ERASE_SCREEN + CURSOR_HOME_WINDOWS
     }
+    // Legacy Windows console - can't clear scrollback
+    return ERASE_SCREEN + CURSOR_HOME_WINDOWS
   }
   return ERASE_SCREEN + ERASE_SCROLLBACK + CURSOR_HOME
 }

--- a/packages/renderer/src/clearTerminal.ts
+++ b/packages/renderer/src/clearTerminal.ts
@@ -3,12 +3,7 @@
  * Detects modern terminals that support ESC[3J for clearing scrollback.
  */
 
-import {
-  CURSOR_HOME,
-  csi,
-  ERASE_SCREEN,
-  ERASE_SCROLLBACK,
-} from './termio/csi'
+import { CURSOR_HOME, csi, ERASE_SCREEN, ERASE_SCROLLBACK } from './termio/csi'
 
 // HVP (Horizontal Vertical Position) - legacy Windows cursor home
 const CURSOR_HOME_WINDOWS = csi(0, 'f')
@@ -72,4 +67,3 @@ export function getClearTerminalSequence(): string {
  * Clears the terminal screen. On supported terminals, also clears scrollback.
  */
 export const clearTerminal = getClearTerminalSequence()
-

--- a/packages/renderer/src/clearTerminal.ts
+++ b/packages/renderer/src/clearTerminal.ts
@@ -3,7 +3,7 @@
  * Detects modern terminals that support ESC[3J for clearing scrollback.
  */
 
-import { CURSOR_HOME, csi, ERASE_SCREEN, ERASE_SCROLLBACK } from './termio/csi'
+import { CURSOR_HOME, ERASE_SCREEN, ERASE_SCROLLBACK, csi } from './termio/csi'
 
 // HVP (Horizontal Vertical Position) - legacy Windows cursor home
 const CURSOR_HOME_WINDOWS = csi(0, 'f')

--- a/packages/renderer/src/colorize.ts
+++ b/packages/renderer/src/colorize.ts
@@ -66,11 +66,7 @@ export type ColorType = 'foreground' | 'background'
 const RGB_REGEX = /^rgb\(\s?(\d+),\s?(\d+),\s?(\d+)\s?\)$/
 const ANSI_REGEX = /^ansi256\(\s?(\d+)\s?\)$/
 
-export const colorize = (
-  str: string,
-  color: string | undefined,
-  type: ColorType,
-): string => {
+export const colorize = (str: string, color: string | undefined, type: ColorType): string => {
   if (!color) {
     return str
   }
@@ -95,44 +91,26 @@ export const colorize = (
       case 'white':
         return type === 'foreground' ? chalk.white(str) : chalk.bgWhite(str)
       case 'blackBright':
-        return type === 'foreground'
-          ? chalk.blackBright(str)
-          : chalk.bgBlackBright(str)
+        return type === 'foreground' ? chalk.blackBright(str) : chalk.bgBlackBright(str)
       case 'redBright':
-        return type === 'foreground'
-          ? chalk.redBright(str)
-          : chalk.bgRedBright(str)
+        return type === 'foreground' ? chalk.redBright(str) : chalk.bgRedBright(str)
       case 'greenBright':
-        return type === 'foreground'
-          ? chalk.greenBright(str)
-          : chalk.bgGreenBright(str)
+        return type === 'foreground' ? chalk.greenBright(str) : chalk.bgGreenBright(str)
       case 'yellowBright':
-        return type === 'foreground'
-          ? chalk.yellowBright(str)
-          : chalk.bgYellowBright(str)
+        return type === 'foreground' ? chalk.yellowBright(str) : chalk.bgYellowBright(str)
       case 'blueBright':
-        return type === 'foreground'
-          ? chalk.blueBright(str)
-          : chalk.bgBlueBright(str)
+        return type === 'foreground' ? chalk.blueBright(str) : chalk.bgBlueBright(str)
       case 'magentaBright':
-        return type === 'foreground'
-          ? chalk.magentaBright(str)
-          : chalk.bgMagentaBright(str)
+        return type === 'foreground' ? chalk.magentaBright(str) : chalk.bgMagentaBright(str)
       case 'cyanBright':
-        return type === 'foreground'
-          ? chalk.cyanBright(str)
-          : chalk.bgCyanBright(str)
+        return type === 'foreground' ? chalk.cyanBright(str) : chalk.bgCyanBright(str)
       case 'whiteBright':
-        return type === 'foreground'
-          ? chalk.whiteBright(str)
-          : chalk.bgWhiteBright(str)
+        return type === 'foreground' ? chalk.whiteBright(str) : chalk.bgWhiteBright(str)
     }
   }
 
   if (color.startsWith('#')) {
-    return type === 'foreground'
-      ? chalk.hex(color)(str)
-      : chalk.bgHex(color)(str)
+    return type === 'foreground' ? chalk.hex(color)(str) : chalk.bgHex(color)(str)
   }
 
   if (color.startsWith('ansi256')) {
@@ -144,9 +122,7 @@ export const colorize = (
 
     const value = Number(matches[1])
 
-    return type === 'foreground'
-      ? chalk.ansi256(value)(str)
-      : chalk.bgAnsi256(value)(str)
+    return type === 'foreground' ? chalk.ansi256(value)(str) : chalk.bgAnsi256(value)(str)
   }
 
   if (color.startsWith('rgb')) {
@@ -248,4 +224,3 @@ export function applyColor(text: string, color: Color | undefined): string {
   }
   return colorize(text, color, 'foreground')
 }
-

--- a/packages/renderer/src/components/AlternateScreen.tsx
+++ b/packages/renderer/src/components/AlternateScreen.tsx
@@ -1,4 +1,5 @@
-import React, { type PropsWithChildren, useContext, useInsertionEffect } from 'react'
+import type React from 'react'
+import { type PropsWithChildren, useContext, useInsertionEffect } from 'react'
 import instances from '../instances.js'
 import {
   DISABLE_MOUSE_TRACKING,

--- a/packages/renderer/src/components/AlternateScreen.tsx
+++ b/packages/renderer/src/components/AlternateScreen.tsx
@@ -1,8 +1,4 @@
-import React, {
-  type PropsWithChildren,
-  useContext,
-  useInsertionEffect,
-} from 'react'
+import React, { type PropsWithChildren, useContext, useInsertionEffect } from 'react'
 import instances from '../instances.js'
 import {
   DISABLE_MOUSE_TRACKING,
@@ -39,10 +35,7 @@ type Props = PropsWithChildren<{
  * from scrolling content) and so signal-exit cleanup can exit the alt
  * screen if the component's own unmount doesn't run.
  */
-export function AlternateScreen({
-  children,
-  mouseTracking = true,
-}: Props): React.ReactNode {
+export function AlternateScreen({ children, mouseTracking = true }: Props): React.ReactNode {
   const size = useContext(TerminalSizeContext)
   const writeRaw = useContext(TerminalWriteContext)
 
@@ -60,11 +53,7 @@ export function AlternateScreen({
     const ink = instances.get(process.stdout)
     if (!writeRaw) return
 
-    writeRaw(
-      ENTER_ALT_SCREEN +
-        '\x1b[2J\x1b[H' +
-        (mouseTracking ? ENABLE_MOUSE_TRACKING : ''),
-    )
+    writeRaw(ENTER_ALT_SCREEN + '\x1b[2J\x1b[H' + (mouseTracking ? ENABLE_MOUSE_TRACKING : ''))
     ink?.setAltScreenActive(true, mouseTracking)
 
     return () => {
@@ -75,12 +64,7 @@ export function AlternateScreen({
   }, [writeRaw, mouseTracking])
 
   return (
-    <Box
-      flexDirection="column"
-      height={size?.rows ?? 24}
-      width="100%"
-      flexShrink={0}
-    >
+    <Box flexDirection="column" height={size?.rows ?? 24} width="100%" flexShrink={0}>
       {children}
     </Box>
   )

--- a/packages/renderer/src/components/AlternateScreen.tsx
+++ b/packages/renderer/src/components/AlternateScreen.tsx
@@ -54,7 +54,7 @@ export function AlternateScreen({ children, mouseTracking = true }: Props): Reac
     const ink = instances.get(process.stdout)
     if (!writeRaw) return
 
-    writeRaw(ENTER_ALT_SCREEN + '\x1b[2J\x1b[H' + (mouseTracking ? ENABLE_MOUSE_TRACKING : ''))
+    writeRaw(`${ENTER_ALT_SCREEN}\x1b[2J\x1b[H${mouseTracking ? ENABLE_MOUSE_TRACKING : ''}`)
     ink?.setAltScreenActive(true, mouseTracking)
 
     return () => {

--- a/packages/renderer/src/components/App.tsx
+++ b/packages/renderer/src/components/App.tsx
@@ -235,11 +235,10 @@ export default class App extends PureComponent<Props, State> {
         throw new Error(
           'Raw mode is not supported on the current process.stdin, which Ink uses as input stream by default.\nRead about how to prevent this error on https://github.com/vadimdemedes/ink/#israwmodesupported',
         )
-      } else {
-        throw new Error(
-          'Raw mode is not supported on the stdin provided to Ink.\nRead about how to prevent this error on https://github.com/vadimdemedes/ink/#israwmodesupported',
-        )
       }
+      throw new Error(
+        'Raw mode is not supported on the stdin provided to Ink.\nRead about how to prevent this error on https://github.com/vadimdemedes/ink/#israwmodesupported',
+      )
     }
     stdin.setEncoding('utf8')
     if (isEnabled) {

--- a/packages/renderer/src/components/App.tsx
+++ b/packages/renderer/src/components/App.tsx
@@ -1,5 +1,5 @@
-import React, { PureComponent, type ReactNode } from 'react'
-import { logForDebugging, isEnvTruthy, logError } from '@yokai/shared'
+import { isEnvTruthy, logError, logForDebugging } from '@yokai/shared'
+import { PureComponent, type ReactNode } from 'react'
 import { EventEmitter } from '../events/emitter'
 import { InputEvent } from '../events/input-event'
 import { TerminalFocusEvent } from '../events/terminal-focus-event'
@@ -11,7 +11,7 @@ import {
   parseMultipleKeypresses,
 } from '../parse-keypress'
 import reconciler from '../reconciler'
-import { finishSelection, hasSelection, type SelectionState, startSelection } from '../selection'
+import { type SelectionState, finishSelection, hasSelection, startSelection } from '../selection'
 import { isXtermJs, setXtversionName, supportsExtendedKeys } from '../terminal'
 import { getTerminalFocused, setTerminalFocused } from '../terminal-focus-state'
 import { TerminalQuerier, xtversion } from '../terminal-querier'

--- a/packages/renderer/src/components/App.tsx
+++ b/packages/renderer/src/components/App.tsx
@@ -365,8 +365,9 @@ export default class App extends PureComponent<Props, State> {
     }
     this.lastStdinTime = now
     try {
-      let chunk
-      while ((chunk = this.props.stdin.read() as string | null) !== null) {
+      while (true) {
+        const chunk = this.props.stdin.read() as string | null
+        if (chunk === null) break
         // Process the input chunk
         this.processInput(chunk)
       }

--- a/packages/renderer/src/components/App.tsx
+++ b/packages/renderer/src/components/App.tsx
@@ -1,218 +1,247 @@
-import React, { PureComponent, type ReactNode } from 'react';
-import { logForDebugging, isEnvTruthy, logError } from '@yokai/shared';
-import { EventEmitter } from '../events/emitter';
-import { InputEvent } from '../events/input-event';
-import { TerminalFocusEvent } from '../events/terminal-focus-event';
-import { INITIAL_STATE, type ParsedInput, type ParsedKey, type ParsedMouse, parseMultipleKeypresses } from '../parse-keypress';
-import reconciler from '../reconciler';
-import { finishSelection, hasSelection, type SelectionState, startSelection } from '../selection';
-import { isXtermJs, setXtversionName, supportsExtendedKeys } from '../terminal';
-import { getTerminalFocused, setTerminalFocused } from '../terminal-focus-state';
-import { TerminalQuerier, xtversion } from '../terminal-querier';
-import { DISABLE_KITTY_KEYBOARD, DISABLE_MODIFY_OTHER_KEYS, ENABLE_KITTY_KEYBOARD, ENABLE_MODIFY_OTHER_KEYS, FOCUS_IN, FOCUS_OUT } from '../termio/csi';
-import { DBP, DFE, DISABLE_MOUSE_TRACKING, EBP, EFE, HIDE_CURSOR, SHOW_CURSOR } from '../termio/dec';
-import AppContext from './AppContext';
-import { ClockProvider } from './ClockContext';
-import CursorDeclarationContext, { type CursorDeclarationSetter } from './CursorDeclarationContext';
-import ErrorOverview from './ErrorOverview';
-import StdinContext from './StdinContext';
-import { TerminalFocusProvider } from './TerminalFocusContext';
-import { TerminalSizeContext } from './TerminalSizeContext';
+import React, { PureComponent, type ReactNode } from 'react'
+import { logForDebugging, isEnvTruthy, logError } from '@yokai/shared'
+import { EventEmitter } from '../events/emitter'
+import { InputEvent } from '../events/input-event'
+import { TerminalFocusEvent } from '../events/terminal-focus-event'
+import {
+  INITIAL_STATE,
+  type ParsedInput,
+  type ParsedKey,
+  type ParsedMouse,
+  parseMultipleKeypresses,
+} from '../parse-keypress'
+import reconciler from '../reconciler'
+import { finishSelection, hasSelection, type SelectionState, startSelection } from '../selection'
+import { isXtermJs, setXtversionName, supportsExtendedKeys } from '../terminal'
+import { getTerminalFocused, setTerminalFocused } from '../terminal-focus-state'
+import { TerminalQuerier, xtversion } from '../terminal-querier'
+import {
+  DISABLE_KITTY_KEYBOARD,
+  DISABLE_MODIFY_OTHER_KEYS,
+  ENABLE_KITTY_KEYBOARD,
+  ENABLE_MODIFY_OTHER_KEYS,
+  FOCUS_IN,
+  FOCUS_OUT,
+} from '../termio/csi'
+import { DBP, DFE, DISABLE_MOUSE_TRACKING, EBP, EFE, HIDE_CURSOR, SHOW_CURSOR } from '../termio/dec'
+import AppContext from './AppContext'
+import { ClockProvider } from './ClockContext'
+import CursorDeclarationContext, { type CursorDeclarationSetter } from './CursorDeclarationContext'
+import ErrorOverview from './ErrorOverview'
+import StdinContext from './StdinContext'
+import { TerminalFocusProvider } from './TerminalFocusContext'
+import { TerminalSizeContext } from './TerminalSizeContext'
 
 // Platforms that support Unix-style process suspension (SIGSTOP/SIGCONT)
-const SUPPORTS_SUSPEND = process.platform !== 'win32';
+const SUPPORTS_SUSPEND = process.platform !== 'win32'
 
 // After this many milliseconds of stdin silence, the next chunk triggers
 // a terminal mode re-assert (mouse tracking). Catches tmux detach→attach,
 // ssh reconnect, and laptop wake — the terminal resets DEC private modes
 // but no signal reaches us. 5s is well above normal inter-keystroke gaps
 // but short enough that the first scroll after reattach works.
-const STDIN_RESUME_GAP_MS = 5000;
+const STDIN_RESUME_GAP_MS = 5000
 type Props = {
-  readonly children: ReactNode;
-  readonly stdin: NodeJS.ReadStream;
-  readonly stdout: NodeJS.WriteStream;
-  readonly stderr: NodeJS.WriteStream;
-  readonly exitOnCtrlC: boolean;
-  readonly onExit: (error?: Error) => void;
-  readonly terminalColumns: number;
-  readonly terminalRows: number;
+  readonly children: ReactNode
+  readonly stdin: NodeJS.ReadStream
+  readonly stdout: NodeJS.WriteStream
+  readonly stderr: NodeJS.WriteStream
+  readonly exitOnCtrlC: boolean
+  readonly onExit: (error?: Error) => void
+  readonly terminalColumns: number
+  readonly terminalRows: number
   // Text selection state. App mutates this directly from mouse events
   // and calls onSelectionChange to trigger a repaint. Mouse events only
   // arrive when <AlternateScreen> (or similar) enables mouse tracking,
   // so the handler is always wired but dormant until tracking is on.
-  readonly selection: SelectionState;
-  readonly onSelectionChange: () => void;
+  readonly selection: SelectionState
+  readonly onSelectionChange: () => void
   // Dispatch a click at (col, row) — hit-tests the DOM tree and bubbles
   // onClick handlers. Returns true if a DOM handler consumed the click.
   // No-op (returns false) outside fullscreen mode (Ink.dispatchClick
   // gates on altScreenActive).
-  readonly onClickAt: (col: number, row: number) => boolean;
+  readonly onClickAt: (col: number, row: number) => boolean
   // Dispatch hover (onMouseEnter/onMouseLeave) as the pointer moves over
   // DOM elements. Called for mode-1003 motion events with no button held.
   // No-op outside fullscreen (Ink.dispatchHover gates on altScreenActive).
-  readonly onHoverAt: (col: number, row: number) => void;
+  readonly onHoverAt: (col: number, row: number) => void
   // Look up the OSC 8 hyperlink at (col, row) synchronously at click
   // time. Returns the URL or undefined. The browser-open is deferred by
   // MULTI_CLICK_TIMEOUT_MS so double-click can cancel it.
-  readonly getHyperlinkAt: (col: number, row: number) => string | undefined;
+  readonly getHyperlinkAt: (col: number, row: number) => string | undefined
   // Open a hyperlink URL in the browser. Called after the timer fires.
-  readonly onOpenHyperlink: (url: string) => void;
+  readonly onOpenHyperlink: (url: string) => void
   // Called on double/triple-click PRESS at (col, row). count=2 selects
   // the word under the cursor; count=3 selects the line. Ink reads the
   // screen buffer to find word/line boundaries and mutates selection,
   // setting isDragging=true so a subsequent drag extends by word/line.
-  readonly onMultiClick: (col: number, row: number, count: 2 | 3) => void;
+  readonly onMultiClick: (col: number, row: number, count: 2 | 3) => void
   // Called on drag-motion. Mode-aware: char mode updates focus to the
   // exact cell; word/line mode snaps to word/line boundaries. Needs
   // screen-buffer access (word boundaries) so lives on Ink, not here.
-  readonly onSelectionDrag: (col: number, row: number) => void;
+  readonly onSelectionDrag: (col: number, row: number) => void
   // Called when stdin data arrives after a >STDIN_RESUME_GAP_MS gap.
   // Ink re-asserts terminal modes: extended key reporting, and (when in
   // fullscreen) re-enters alt-screen + mouse tracking. Idempotent on the
   // terminal side. Optional so testing.tsx doesn't need to stub it.
-  readonly onStdinResume?: () => void;
+  readonly onStdinResume?: () => void
   // Receives the declared native-cursor position from useDeclaredCursor
   // so ink.tsx can park the terminal cursor there after each frame.
   // Enables IME composition at the input caret and lets screen readers /
   // magnifiers track the input. Optional so testing.tsx doesn't stub it.
-  readonly onCursorDeclaration?: CursorDeclarationSetter;
+  readonly onCursorDeclaration?: CursorDeclarationSetter
   // Dispatch a keyboard event through the DOM tree. Called for each
   // parsed key alongside the legacy EventEmitter path.
-  readonly dispatchKeyboardEvent: (parsedKey: ParsedKey) => void;
-};
+  readonly dispatchKeyboardEvent: (parsedKey: ParsedKey) => void
+}
 
 // Multi-click detection thresholds. 500ms is the macOS default; a small
 // position tolerance allows for trackpad jitter between clicks.
-const MULTI_CLICK_TIMEOUT_MS = 500;
-const MULTI_CLICK_DISTANCE = 1;
+const MULTI_CLICK_TIMEOUT_MS = 500
+const MULTI_CLICK_DISTANCE = 1
 type State = {
-  readonly error?: Error;
-};
+  readonly error?: Error
+}
 
 // Root component for all Ink apps
 // It renders stdin and stdout contexts, so that children can access them if needed
 // It also handles Ctrl+C exiting and cursor visibility
 export default class App extends PureComponent<Props, State> {
-  static displayName = 'InternalApp';
+  static displayName = 'InternalApp'
   static getDerivedStateFromError(error: Error) {
     return {
-      error
-    };
+      error,
+    }
   }
   override state = {
-    error: undefined
-  };
+    error: undefined,
+  }
 
   // Count how many components enabled raw mode to avoid disabling
   // raw mode until all components don't need it anymore
-  rawModeEnabledCount = 0;
-  internal_eventEmitter = new EventEmitter();
-  keyParseState = INITIAL_STATE;
+  rawModeEnabledCount = 0
+  internal_eventEmitter = new EventEmitter()
+  keyParseState = INITIAL_STATE
   // Timer for flushing incomplete escape sequences
-  incompleteEscapeTimer: NodeJS.Timeout | null = null;
+  incompleteEscapeTimer: NodeJS.Timeout | null = null
   // Timeout durations for incomplete sequences (ms)
-  readonly NORMAL_TIMEOUT = 50; // Short timeout for regular esc sequences
-  readonly PASTE_TIMEOUT = 500; // Longer timeout for paste operations
+  readonly NORMAL_TIMEOUT = 50 // Short timeout for regular esc sequences
+  readonly PASTE_TIMEOUT = 500 // Longer timeout for paste operations
 
   // Terminal query/response dispatch. Responses arrive on stdin (parsed
   // out by parse-keypress) and are routed to pending promise resolvers.
-  querier = new TerminalQuerier(this.props.stdout);
+  querier = new TerminalQuerier(this.props.stdout)
 
   // Multi-click tracking for double/triple-click text selection. A click
   // within MULTI_CLICK_TIMEOUT_MS and MULTI_CLICK_DISTANCE of the previous
   // click increments clickCount; otherwise it resets to 1.
-  lastClickTime = 0;
-  lastClickCol = -1;
-  lastClickRow = -1;
-  clickCount = 0;
+  lastClickTime = 0
+  lastClickCol = -1
+  lastClickRow = -1
+  clickCount = 0
   // Deferred hyperlink-open timer — cancelled if a second click arrives
   // within MULTI_CLICK_TIMEOUT_MS (so double-clicking a hyperlink selects
   // the word without also opening the browser). DOM onClick dispatch is
   // NOT deferred — it returns true from onClickAt and skips this timer.
-  pendingHyperlinkTimer: ReturnType<typeof setTimeout> | null = null;
+  pendingHyperlinkTimer: ReturnType<typeof setTimeout> | null = null
   // Last mode-1003 motion position. Terminals already dedupe to cell
   // granularity but this also lets us skip dispatchHover entirely on
   // repeat events (drag-then-release at same cell, etc.).
-  lastHoverCol = -1;
-  lastHoverRow = -1;
+  lastHoverCol = -1
+  lastHoverRow = -1
 
   // Timestamp of last stdin chunk. Used to detect long gaps (tmux attach,
   // ssh reconnect, laptop wake) and trigger terminal mode re-assert.
   // Initialized to now so startup doesn't false-trigger.
-  lastStdinTime = Date.now();
+  lastStdinTime = Date.now()
 
   // Determines if TTY is supported on the provided stdin
   isRawModeSupported(): boolean {
-    return this.props.stdin.isTTY;
+    return this.props.stdin.isTTY
   }
   override render() {
-    return <TerminalSizeContext.Provider value={{
-      columns: this.props.terminalColumns,
-      rows: this.props.terminalRows
-    }}>
-        <AppContext.Provider value={{
-        exit: this.handleExit
-      }}>
-          <StdinContext.Provider value={{
-          stdin: this.props.stdin,
-          setRawMode: this.handleSetRawMode,
-          isRawModeSupported: this.isRawModeSupported(),
-          internal_exitOnCtrlC: this.props.exitOnCtrlC,
-          internal_eventEmitter: this.internal_eventEmitter,
-          internal_querier: this.querier
-        }}>
+    return (
+      <TerminalSizeContext.Provider
+        value={{
+          columns: this.props.terminalColumns,
+          rows: this.props.terminalRows,
+        }}
+      >
+        <AppContext.Provider
+          value={{
+            exit: this.handleExit,
+          }}
+        >
+          <StdinContext.Provider
+            value={{
+              stdin: this.props.stdin,
+              setRawMode: this.handleSetRawMode,
+              isRawModeSupported: this.isRawModeSupported(),
+              internal_exitOnCtrlC: this.props.exitOnCtrlC,
+              internal_eventEmitter: this.internal_eventEmitter,
+              internal_querier: this.querier,
+            }}
+          >
             <TerminalFocusProvider>
               <ClockProvider>
-                <CursorDeclarationContext.Provider value={this.props.onCursorDeclaration ?? (() => {})}>
-                  {this.state.error ? <ErrorOverview error={this.state.error as Error} /> : this.props.children}
+                <CursorDeclarationContext.Provider
+                  value={this.props.onCursorDeclaration ?? (() => {})}
+                >
+                  {this.state.error ? (
+                    <ErrorOverview error={this.state.error as Error} />
+                  ) : (
+                    this.props.children
+                  )}
                 </CursorDeclarationContext.Provider>
               </ClockProvider>
             </TerminalFocusProvider>
           </StdinContext.Provider>
         </AppContext.Provider>
-      </TerminalSizeContext.Provider>;
+      </TerminalSizeContext.Provider>
+    )
   }
   override componentDidMount() {
     // In accessibility mode, keep the native cursor visible for screen magnifiers and other tools
     if (this.props.stdout.isTTY && !isEnvTruthy(process.env.CLAUDE_CODE_ACCESSIBILITY)) {
-      this.props.stdout.write(HIDE_CURSOR);
+      this.props.stdout.write(HIDE_CURSOR)
     }
   }
   override componentWillUnmount() {
     if (this.props.stdout.isTTY) {
-      this.props.stdout.write(SHOW_CURSOR);
+      this.props.stdout.write(SHOW_CURSOR)
     }
 
     // Clear any pending timers
     if (this.incompleteEscapeTimer) {
-      clearTimeout(this.incompleteEscapeTimer);
-      this.incompleteEscapeTimer = null;
+      clearTimeout(this.incompleteEscapeTimer)
+      this.incompleteEscapeTimer = null
     }
     if (this.pendingHyperlinkTimer) {
-      clearTimeout(this.pendingHyperlinkTimer);
-      this.pendingHyperlinkTimer = null;
+      clearTimeout(this.pendingHyperlinkTimer)
+      this.pendingHyperlinkTimer = null
     }
     // ignore calling setRawMode on an handle stdin it cannot be called
     if (this.isRawModeSupported()) {
-      this.handleSetRawMode(false);
+      this.handleSetRawMode(false)
     }
   }
   override componentDidCatch(error: Error) {
-    this.handleExit(error);
+    this.handleExit(error)
   }
   handleSetRawMode = (isEnabled: boolean): void => {
-    const {
-      stdin
-    } = this.props;
+    const { stdin } = this.props
     if (!this.isRawModeSupported()) {
       if (stdin === process.stdin) {
-        throw new Error('Raw mode is not supported on the current process.stdin, which Ink uses as input stream by default.\nRead about how to prevent this error on https://github.com/vadimdemedes/ink/#israwmodesupported');
+        throw new Error(
+          'Raw mode is not supported on the current process.stdin, which Ink uses as input stream by default.\nRead about how to prevent this error on https://github.com/vadimdemedes/ink/#israwmodesupported',
+        )
       } else {
-        throw new Error('Raw mode is not supported on the stdin provided to Ink.\nRead about how to prevent this error on https://github.com/vadimdemedes/ink/#israwmodesupported');
+        throw new Error(
+          'Raw mode is not supported on the stdin provided to Ink.\nRead about how to prevent this error on https://github.com/vadimdemedes/ink/#israwmodesupported',
+        )
       }
     }
-    stdin.setEncoding('utf8');
+    stdin.setEncoding('utf8')
     if (isEnabled) {
       // Ensure raw mode is enabled only once
       if (this.rawModeEnabledCount === 0) {
@@ -220,21 +249,21 @@ export default class App extends PureComponent<Props, State> {
         // Both use the same stdin 'readable' + read() pattern, so they can't
         // coexist -- our handler would drain stdin before Ink's can see it.
         // The buffered text is preserved for REPL.tsx via consumeEarlyInput().
-        stdin.ref();
-        stdin.setRawMode(true);
-        stdin.addListener('readable', this.handleReadable);
+        stdin.ref()
+        stdin.setRawMode(true)
+        stdin.addListener('readable', this.handleReadable)
         // Enable bracketed paste mode
-        this.props.stdout.write(EBP);
+        this.props.stdout.write(EBP)
         // Enable terminal focus reporting (DECSET 1004)
-        this.props.stdout.write(EFE);
+        this.props.stdout.write(EFE)
         // Enable extended key reporting so ctrl+shift+<letter> is
         // distinguishable from ctrl+<letter>. We write both the kitty stack
         // push (CSI >1u) and xterm modifyOtherKeys level 2 (CSI >4;2m) —
         // terminals honor whichever they implement (tmux only accepts the
         // latter).
         if (supportsExtendedKeys()) {
-          this.props.stdout.write(ENABLE_KITTY_KEYBOARD);
-          this.props.stdout.write(ENABLE_MODIFY_OTHER_KEYS);
+          this.props.stdout.write(ENABLE_KITTY_KEYBOARD)
+          this.props.stdout.write(ENABLE_MODIFY_OTHER_KEYS)
         }
         // Probe terminal identity. XTVERSION survives SSH (query/reply goes
         // through the pty), unlike TERM_PROGRAM. Used for wheel-scroll base
@@ -247,39 +276,39 @@ export default class App extends PureComponent<Props, State> {
         setImmediate(() => {
           void Promise.all([this.querier.send(xtversion()), this.querier.flush()]).then(([r]) => {
             if (r) {
-              setXtversionName(r.name);
-              logForDebugging(`XTVERSION: terminal identified as "${r.name}"`);
+              setXtversionName(r.name)
+              logForDebugging(`XTVERSION: terminal identified as "${r.name}"`)
             } else {
-              logForDebugging('XTVERSION: no reply (terminal ignored query)');
+              logForDebugging('XTVERSION: no reply (terminal ignored query)')
             }
-          });
-        });
+          })
+        })
       }
-      this.rawModeEnabledCount++;
-      return;
+      this.rawModeEnabledCount++
+      return
     }
 
     // Disable raw mode only when no components left that are using it
     if (--this.rawModeEnabledCount === 0) {
-      this.props.stdout.write(DISABLE_MODIFY_OTHER_KEYS);
-      this.props.stdout.write(DISABLE_KITTY_KEYBOARD);
+      this.props.stdout.write(DISABLE_MODIFY_OTHER_KEYS)
+      this.props.stdout.write(DISABLE_KITTY_KEYBOARD)
       // Disable terminal focus reporting (DECSET 1004)
-      this.props.stdout.write(DFE);
+      this.props.stdout.write(DFE)
       // Disable bracketed paste mode
-      this.props.stdout.write(DBP);
-      stdin.setRawMode(false);
-      stdin.removeListener('readable', this.handleReadable);
-      stdin.unref();
+      this.props.stdout.write(DBP)
+      stdin.setRawMode(false)
+      stdin.removeListener('readable', this.handleReadable)
+      stdin.unref()
     }
-  };
+  }
 
   // Helper to flush incomplete escape sequences
   flushIncomplete = (): void => {
     // Clear the timer reference
-    this.incompleteEscapeTimer = null;
+    this.incompleteEscapeTimer = null
 
     // Only proceed if we have incomplete sequences
-    if (!this.keyParseState.incomplete) return;
+    if (!this.keyParseState.incomplete) return
 
     // Fullscreen: if stdin has data waiting, it's almost certainly the
     // continuation of the buffered sequence (e.g. `[<64;74;16M` after a
@@ -290,20 +319,20 @@ export default class App extends PureComponent<Props, State> {
     // drain stdin next and clear this timer. Prevents both the spurious
     // Escape key and the lost scroll event.
     if (this.props.stdin.readableLength > 0) {
-      this.incompleteEscapeTimer = setTimeout(this.flushIncomplete, this.NORMAL_TIMEOUT);
-      return;
+      this.incompleteEscapeTimer = setTimeout(this.flushIncomplete, this.NORMAL_TIMEOUT)
+      return
     }
 
     // Process incomplete as a flush operation (input=null)
     // This reuses all existing parsing logic
-    this.processInput(null);
-  };
+    this.processInput(null)
+  }
 
   // Process input through the parser and handle the results
   processInput = (input: string | Buffer | null): void => {
     // Parse input using our state machine
-    const [keys, newState] = parseMultipleKeypresses(this.keyParseState, input);
-    this.keyParseState = newState;
+    const [keys, newState] = parseMultipleKeypresses(this.keyParseState, input)
+    this.keyParseState = newState
 
     // Process ALL keys in a SINGLE discreteUpdates call to prevent
     // "Maximum update depth exceeded" error when many keys arrive at once
@@ -311,87 +340,94 @@ export default class App extends PureComponent<Props, State> {
     // This batches all state updates from handleInput and all useInput
     // listeners together within one high-priority update context.
     if (keys.length > 0) {
-      reconciler.discreteUpdates(processKeysInBatch, this, keys, undefined, undefined);
+      reconciler.discreteUpdates(processKeysInBatch, this, keys, undefined, undefined)
     }
 
     // If we have incomplete escape sequences, set a timer to flush them
     if (this.keyParseState.incomplete) {
       // Cancel any existing timer first
       if (this.incompleteEscapeTimer) {
-        clearTimeout(this.incompleteEscapeTimer);
+        clearTimeout(this.incompleteEscapeTimer)
       }
-      this.incompleteEscapeTimer = setTimeout(this.flushIncomplete, this.keyParseState.mode === 'IN_PASTE' ? this.PASTE_TIMEOUT : this.NORMAL_TIMEOUT);
+      this.incompleteEscapeTimer = setTimeout(
+        this.flushIncomplete,
+        this.keyParseState.mode === 'IN_PASTE' ? this.PASTE_TIMEOUT : this.NORMAL_TIMEOUT,
+      )
     }
-  };
+  }
   handleReadable = (): void => {
     // Detect long stdin gaps (tmux attach, ssh reconnect, laptop wake).
     // The terminal may have reset DEC private modes; re-assert mouse
     // tracking. Checked before the read loop so one Date.now() covers
     // all chunks in this readable event.
-    const now = Date.now();
+    const now = Date.now()
     if (now - this.lastStdinTime > STDIN_RESUME_GAP_MS) {
-      this.props.onStdinResume?.();
+      this.props.onStdinResume?.()
     }
-    this.lastStdinTime = now;
+    this.lastStdinTime = now
     try {
-      let chunk;
+      let chunk
       while ((chunk = this.props.stdin.read() as string | null) !== null) {
         // Process the input chunk
-        this.processInput(chunk);
+        this.processInput(chunk)
       }
     } catch (error) {
       // In Bun, an uncaught throw inside a stream 'readable' handler can
       // permanently wedge the stream: data stays buffered and 'readable'
       // never re-emits. Catching here ensures the stream stays healthy so
       // subsequent keystrokes are still delivered.
-      logError(error);
+      logError(error)
 
       // Re-attach the listener in case the exception detached it.
       // Bun may remove the listener after an error; without this,
       // the session freezes permanently (stdin reader dead, event loop alive).
-      const {
-        stdin
-      } = this.props;
-      if (this.rawModeEnabledCount > 0 && !stdin.listeners('readable').includes(this.handleReadable)) {
-        logForDebugging('handleReadable: re-attaching stdin readable listener after error recovery', {
-          level: 'warn'
-        });
-        stdin.addListener('readable', this.handleReadable);
+      const { stdin } = this.props
+      if (
+        this.rawModeEnabledCount > 0 &&
+        !stdin.listeners('readable').includes(this.handleReadable)
+      ) {
+        logForDebugging(
+          'handleReadable: re-attaching stdin readable listener after error recovery',
+          {
+            level: 'warn',
+          },
+        )
+        stdin.addListener('readable', this.handleReadable)
       }
     }
-  };
+  }
   handleInput = (input: string | undefined): void => {
     // Exit on Ctrl+C
     if (input === '\x03' && this.props.exitOnCtrlC) {
-      this.handleExit();
+      this.handleExit()
     }
 
     // Note: Ctrl+Z (suspend) is now handled in processKeysInBatch using the
     // parsed key to support both raw (\x1a) and CSI u format from Kitty
     // keyboard protocol terminals (Ghostty, iTerm2, kitty, WezTerm)
-  };
+  }
   handleExit = (error?: Error): void => {
     if (this.isRawModeSupported()) {
-      this.handleSetRawMode(false);
+      this.handleSetRawMode(false)
     }
-    this.props.onExit(error);
-  };
+    this.props.onExit(error)
+  }
   handleTerminalFocus = (isFocused: boolean): void => {
     // setTerminalFocused notifies subscribers: TerminalFocusProvider (context)
     // and Clock (interval speed) — no App setState needed.
-    setTerminalFocused(isFocused);
-  };
+    setTerminalFocused(isFocused)
+  }
   handleSuspend = (): void => {
     if (!this.isRawModeSupported()) {
-      return;
+      return
     }
 
     // Store the exact raw mode count to restore it properly
-    const rawModeCountBeforeSuspend = this.rawModeEnabledCount;
+    const rawModeCountBeforeSuspend = this.rawModeEnabledCount
 
     // Completely disable raw mode before suspending
     while (this.rawModeEnabledCount > 0) {
-      this.handleSetRawMode(false);
+      this.handleSetRawMode(false)
     }
 
     // Show cursor, disable focus reporting, and disable mouse tracking
@@ -400,42 +436,47 @@ export default class App extends PureComponent<Props, State> {
     // it, SGR mouse sequences would appear as garbled text at the
     // shell prompt while suspended.
     if (this.props.stdout.isTTY) {
-      this.props.stdout.write(SHOW_CURSOR + DFE + DISABLE_MOUSE_TRACKING);
+      this.props.stdout.write(SHOW_CURSOR + DFE + DISABLE_MOUSE_TRACKING)
     }
 
     // Emit suspend event for the host app to handle
-    this.internal_eventEmitter.emit('suspend');
+    this.internal_eventEmitter.emit('suspend')
 
     // Set up resume handler
     const resumeHandler = () => {
       // Restore raw mode to exact previous state
       for (let i = 0; i < rawModeCountBeforeSuspend; i++) {
         if (this.isRawModeSupported()) {
-          this.handleSetRawMode(true);
+          this.handleSetRawMode(true)
         }
       }
 
       // Hide cursor (unless in accessibility mode) and re-enable focus reporting after resuming
       if (this.props.stdout.isTTY) {
         if (!isEnvTruthy(process.env.CLAUDE_CODE_ACCESSIBILITY)) {
-          this.props.stdout.write(HIDE_CURSOR);
+          this.props.stdout.write(HIDE_CURSOR)
         }
         // Re-enable focus reporting to restore terminal state
-        this.props.stdout.write(EFE);
+        this.props.stdout.write(EFE)
       }
 
       // Emit resume event for the host app to handle
-      this.internal_eventEmitter.emit('resume');
-      process.removeListener('SIGCONT', resumeHandler);
-    };
-    process.on('SIGCONT', resumeHandler);
-    process.kill(process.pid, 'SIGSTOP');
-  };
+      this.internal_eventEmitter.emit('resume')
+      process.removeListener('SIGCONT', resumeHandler)
+    }
+    process.on('SIGCONT', resumeHandler)
+    process.kill(process.pid, 'SIGSTOP')
+  }
 }
 
 // Helper to process all keys within a single discrete update context.
 // discreteUpdates expects (fn, a, b, c, d) -> fn(a, b, c, d)
-function processKeysInBatch(app: App, items: ParsedInput[], _unused1: undefined, _unused2: undefined): void {
+function processKeysInBatch(
+  app: App,
+  items: ParsedInput[],
+  _unused1: undefined,
+  _unused2: undefined,
+): void {
   // Update interaction time for notification timeout tracking.
   // This is called from the central input handler to avoid having multiple
   // stdin listeners that can cause race conditions and dropped input.
@@ -447,69 +488,69 @@ function processKeysInBatch(app: App, items: ParsedInput[], _unused1: undefined,
     // Terminal responses (DECRPM, DA1, OSC replies, etc.) are not user
     // input — route them to the querier to resolve pending promises.
     if (item.kind === 'response') {
-      app.querier.onResponse(item.response);
-      continue;
+      app.querier.onResponse(item.response)
+      continue
     }
 
     // Mouse click/drag events update selection state (fullscreen only).
     // Terminal sends 1-indexed col/row; convert to 0-indexed for the
     // screen buffer. Button bit 0x20 = drag (motion while button held).
     if (item.kind === 'mouse') {
-      handleMouseEvent(app, item);
-      continue;
+      handleMouseEvent(app, item)
+      continue
     }
-    const sequence = item.sequence;
+    const sequence = item.sequence
 
     // Handle terminal focus events (DECSET 1004)
     if (sequence === FOCUS_IN) {
-      app.handleTerminalFocus(true);
-      const event = new TerminalFocusEvent('terminalfocus');
-      app.internal_eventEmitter.emit('terminalfocus', event);
-      continue;
+      app.handleTerminalFocus(true)
+      const event = new TerminalFocusEvent('terminalfocus')
+      app.internal_eventEmitter.emit('terminalfocus', event)
+      continue
     }
     if (sequence === FOCUS_OUT) {
-      app.handleTerminalFocus(false);
+      app.handleTerminalFocus(false)
       // Defensive: if we lost the release event (mouse released outside
       // terminal window — some emulators drop it rather than capturing the
       // pointer), focus-out is the next observable signal that the drag is
       // over. Without this, drag-to-scroll's timer runs until the scroll
       // boundary is hit.
       if (app.props.selection.isDragging) {
-        finishSelection(app.props.selection);
-        app.props.onSelectionChange();
+        finishSelection(app.props.selection)
+        app.props.onSelectionChange()
       }
-      const event = new TerminalFocusEvent('terminalblur');
-      app.internal_eventEmitter.emit('terminalblur', event);
-      continue;
+      const event = new TerminalFocusEvent('terminalblur')
+      app.internal_eventEmitter.emit('terminalblur', event)
+      continue
     }
 
     // Failsafe: if we receive input, the terminal must be focused
     if (!getTerminalFocused()) {
-      setTerminalFocused(true);
+      setTerminalFocused(true)
     }
 
     // Handle Ctrl+Z (suspend) using parsed key to support both raw (\x1a) and
     // CSI u format (\x1b[122;5u) from Kitty keyboard protocol terminals
     if (item.name === 'z' && item.ctrl && SUPPORTS_SUSPEND) {
-      app.handleSuspend();
-      continue;
+      app.handleSuspend()
+      continue
     }
-    app.handleInput(sequence);
-    const event = new InputEvent(item);
-    app.internal_eventEmitter.emit('input', event);
+    app.handleInput(sequence)
+    const event = new InputEvent(item)
+    app.internal_eventEmitter.emit('input', event)
 
     // Also dispatch through the DOM tree so onKeyDown handlers fire.
-    app.props.dispatchKeyboardEvent(item);
+    app.props.dispatchKeyboardEvent(item)
   }
 }
 
 /** Exported for testing. Mutates app.props.selection and click/hover state. */
 export function handleMouseEvent(app: App, m: ParsedMouse): void {
-  const sel = app.props.selection;
+  const sel = app.props.selection
   // Terminal coords are 1-indexed; screen buffer is 0-indexed
-  const col = m.col - 1;
-  const row = m.row - 1;
-  const baseButton = m.button & 0x03;
+  const col = m.col - 1
+  const row = m.row - 1
+  const baseButton = m.button & 0x03
   if (m.action === 'press') {
     if ((m.button & 0x20) !== 0 && baseButton === 3) {
       // Mode-1003 motion with no button held. Dispatch hover; skip the
@@ -522,25 +563,25 @@ export function handleMouseEvent(app: App, m: ParsedMouse): void {
       // past the edge, came back" — and tmux drops focus events unless
       // `focus-events on` is set, so this is the more reliable signal.
       if (sel.isDragging) {
-        finishSelection(sel);
-        app.props.onSelectionChange();
+        finishSelection(sel)
+        app.props.onSelectionChange()
       }
-      if (col === app.lastHoverCol && row === app.lastHoverRow) return;
-      app.lastHoverCol = col;
-      app.lastHoverRow = row;
-      app.props.onHoverAt(col, row);
-      return;
+      if (col === app.lastHoverCol && row === app.lastHoverRow) return
+      app.lastHoverCol = col
+      app.lastHoverRow = row
+      app.props.onHoverAt(col, row)
+      return
     }
     if (baseButton !== 0) {
       // Non-left press breaks the multi-click chain.
-      app.clickCount = 0;
-      return;
+      app.clickCount = 0
+      return
     }
     if ((m.button & 0x20) !== 0) {
       // Drag motion: mode-aware extension (char/word/line). onSelectionDrag
       // calls notifySelectionChange internally — no extra onSelectionChange.
-      app.props.onSelectionDrag(col, row);
-      return;
+      app.props.onSelectionDrag(col, row)
+      return
     }
     // Lost-release fallback for mode-1002-only terminals: a fresh press
     // while isDragging=true means the previous release was dropped (cursor
@@ -548,40 +589,43 @@ export function handleMouseEvent(app: App, m: ParsedMouse): void {
     // before startSelection/onMultiClick clobbers it. Mode-1003 terminals
     // hit the no-button-motion recovery above instead, so this is rare.
     if (sel.isDragging) {
-      finishSelection(sel);
-      app.props.onSelectionChange();
+      finishSelection(sel)
+      app.props.onSelectionChange()
     }
     // Fresh left press. Detect multi-click HERE (not on release) so the
     // word/line highlight appears immediately and a subsequent drag can
     // extend by word/line like native macOS. Previously detected on
     // release, which meant (a) visible latency before the word highlights
     // and (b) double-click+drag fell through to char-mode selection.
-    const now = Date.now();
-    const nearLast = now - app.lastClickTime < MULTI_CLICK_TIMEOUT_MS && Math.abs(col - app.lastClickCol) <= MULTI_CLICK_DISTANCE && Math.abs(row - app.lastClickRow) <= MULTI_CLICK_DISTANCE;
-    app.clickCount = nearLast ? app.clickCount + 1 : 1;
-    app.lastClickTime = now;
-    app.lastClickCol = col;
-    app.lastClickRow = row;
+    const now = Date.now()
+    const nearLast =
+      now - app.lastClickTime < MULTI_CLICK_TIMEOUT_MS &&
+      Math.abs(col - app.lastClickCol) <= MULTI_CLICK_DISTANCE &&
+      Math.abs(row - app.lastClickRow) <= MULTI_CLICK_DISTANCE
+    app.clickCount = nearLast ? app.clickCount + 1 : 1
+    app.lastClickTime = now
+    app.lastClickCol = col
+    app.lastClickRow = row
     if (app.clickCount >= 2) {
       // Cancel any pending hyperlink-open from the first click — this is
       // a double-click, not a single-click on a link.
       if (app.pendingHyperlinkTimer) {
-        clearTimeout(app.pendingHyperlinkTimer);
-        app.pendingHyperlinkTimer = null;
+        clearTimeout(app.pendingHyperlinkTimer)
+        app.pendingHyperlinkTimer = null
       }
       // Cap at 3 (line select) for quadruple+ clicks.
-      const count = app.clickCount === 2 ? 2 : 3;
-      app.props.onMultiClick(col, row, count);
-      return;
+      const count = app.clickCount === 2 ? 2 : 3
+      app.props.onMultiClick(col, row, count)
+      return
     }
-    startSelection(sel, col, row);
+    startSelection(sel, col, row)
     // SGR bit 0x08 = alt (xterm.js wires altKey here, not metaKey — see
     // comment at the hyperlink-open guard below). On macOS xterm.js,
     // receiving alt means macOptionClickForcesSelection is OFF (otherwise
     // xterm.js would have consumed the event for native selection).
-    sel.lastPressHadAlt = (m.button & 0x08) !== 0;
-    app.props.onSelectionChange();
-    return;
+    sel.lastPressHadAlt = (m.button & 0x08) !== 0
+    app.props.onSelectionChange()
+    return
   }
 
   // Release: end the drag even for non-zero button codes. Some terminals
@@ -591,12 +635,12 @@ export function handleMouseEvent(app: App, m: ParsedMouse): void {
   // scroll boundary. Only act on non-left releases when we ARE dragging
   // (so an unrelated middle/right click-release doesn't touch selection).
   if (baseButton !== 0) {
-    if (!sel.isDragging) return;
-    finishSelection(sel);
-    app.props.onSelectionChange();
-    return;
+    if (!sel.isDragging) return
+    finishSelection(sel)
+    app.props.onSelectionChange()
+    return
   }
-  finishSelection(sel);
+  finishSelection(sel)
   // NOTE: unlike the old release-based detection we do NOT reset clickCount
   // on release-after-drag. This aligns with NSEvent.clickCount semantics:
   // an intervening drag doesn't break the click chain. Practical upside:
@@ -617,7 +661,7 @@ export function handleMouseEvent(app: App, m: ParsedMouse): void {
       // Resolve the hyperlink URL synchronously while the screen buffer
       // still reflects what the user clicked — deferring only the
       // browser-open so double-click can cancel it.
-      const url = app.props.getHyperlinkAt(col, row);
+      const url = app.props.getHyperlinkAt(col, row)
       // xterm.js (VS Code, Cursor, Windsurf, etc.) has its own OSC 8 link
       // handler that fires on Cmd+click *without consuming the mouse event*
       // (Linkifier._handleMouseUp calls link.activate() but never
@@ -633,15 +677,20 @@ export function handleMouseEvent(app: App, m: ParsedMouse): void {
         // Clear any prior pending timer — clicking a second link
         // supersedes the first (only the latest click opens).
         if (app.pendingHyperlinkTimer) {
-          clearTimeout(app.pendingHyperlinkTimer);
+          clearTimeout(app.pendingHyperlinkTimer)
         }
-        app.pendingHyperlinkTimer = setTimeout((app, url) => {
-          app.pendingHyperlinkTimer = null;
-          app.props.onOpenHyperlink(url);
-        }, MULTI_CLICK_TIMEOUT_MS, app, url);
+        app.pendingHyperlinkTimer = setTimeout(
+          (app, url) => {
+            app.pendingHyperlinkTimer = null
+            app.props.onOpenHyperlink(url)
+          },
+          MULTI_CLICK_TIMEOUT_MS,
+          app,
+          url,
+        )
       }
     }
   }
-  app.props.onSelectionChange();
+  app.props.onSelectionChange()
 }
 //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJuYW1lcyI6WyJSZWFjdCIsIlB1cmVDb21wb25lbnQiLCJSZWFjdE5vZGUiLCJ1cGRhdGVMYXN0SW50ZXJhY3Rpb25UaW1lIiwibG9nRm9yRGVidWdnaW5nIiwic3RvcENhcHR1cmluZ0Vhcmx5SW5wdXQiLCJpc0VudlRydXRoeSIsImlzTW91c2VDbGlja3NEaXNhYmxlZCIsImxvZ0Vycm9yIiwiRXZlbnRFbWl0dGVyIiwiSW5wdXRFdmVudCIsIlRlcm1pbmFsRm9jdXNFdmVudCIsIklOSVRJQUxfU1RBVEUiLCJQYXJzZWRJbnB1dCIsIlBhcnNlZEtleSIsIlBhcnNlZE1vdXNlIiwicGFyc2VNdWx0aXBsZUtleXByZXNzZXMiLCJyZWNvbmNpbGVyIiwiZmluaXNoU2VsZWN0aW9uIiwiaGFzU2VsZWN0aW9uIiwiU2VsZWN0aW9uU3RhdGUiLCJzdGFydFNlbGVjdGlvbiIsImlzWHRlcm1KcyIsInNldFh0dmVyc2lvbk5hbWUiLCJzdXBwb3J0c0V4dGVuZGVkS2V5cyIsImdldFRlcm1pbmFsRm9jdXNlZCIsInNldFRlcm1pbmFsRm9jdXNlZCIsIlRlcm1pbmFsUXVlcmllciIsInh0dmVyc2lvbiIsIkRJU0FCTEVfS0lUVFlfS0VZQk9BUkQiLCJESVNBQkxFX01PRElGWV9PVEhFUl9LRVlTIiwiRU5BQkxFX0tJVFRZX0tFWUJPQVJEIiwiRU5BQkxFX01PRElGWV9PVEhFUl9LRVlTIiwiRk9DVVNfSU4iLCJGT0NVU19PVVQiLCJEQlAiLCJERkUiLCJESVNBQkxFX01PVVNFX1RSQUNLSU5HIiwiRUJQIiwiRUZFIiwiSElERV9DVVJTT1IiLCJTSE9XX0NVUlNPUiIsIkFwcENvbnRleHQiLCJDbG9ja1Byb3ZpZGVyIiwiQ3Vyc29yRGVjbGFyYXRpb25Db250ZXh0IiwiQ3Vyc29yRGVjbGFyYXRpb25TZXR0ZXIiLCJFcnJvck92ZXJ2aWV3IiwiU3RkaW5Db250ZXh0IiwiVGVybWluYWxGb2N1c1Byb3ZpZGVyIiwiVGVybWluYWxTaXplQ29udGV4dCIsIlNVUFBPUlRTX1NVU1BFTkQiLCJwcm9jZXNzIiwicGxhdGZvcm0iLCJTVERJTl9SRVNVTUVfR0FQX01TIiwiUHJvcHMiLCJjaGlsZHJlbiIsInN0ZGluIiwiTm9kZUpTIiwiUmVhZFN0cmVhbSIsInN0ZG91dCIsIldyaXRlU3RyZWFtIiwic3RkZXJyIiwiZXhpdE9uQ3RybEMiLCJvbkV4aXQiLCJlcnJvciIsIkVycm9yIiwidGVybWluYWxDb2x1bW5zIiwidGVybWluYWxSb3dzIiwic2VsZWN0aW9uIiwib25TZWxlY3Rpb25DaGFuZ2UiLCJvbkNsaWNrQXQiLCJjb2wiLCJyb3ciLCJvbkhvdmVyQXQiLCJnZXRIeXBlcmxpbmtBdCIsIm9uT3Blbkh5cGVybGluayIsInVybCIsIm9uTXVsdGlDbGljayIsImNvdW50Iiwib25TZWxlY3Rpb25EcmFnIiwib25TdGRpblJlc3VtZSIsIm9uQ3Vyc29yRGVjbGFyYXRpb24iLCJkaXNwYXRjaEtleWJvYXJkRXZlbnQiLCJwYXJzZWRLZXkiLCJNVUxUSV9DTElDS19USU1FT1VUX01TIiwiTVVMVElfQ0xJQ0tfRElTVEFOQ0UiLCJTdGF0ZSIsIkFwcCIsImRpc3BsYXlOYW1lIiwiZ2V0RGVyaXZlZFN0YXRlRnJvbUVycm9yIiwic3RhdGUiLCJ1bmRlZmluZWQiLCJyYXdNb2RlRW5hYmxlZENvdW50IiwiaW50ZXJuYWxfZXZlbnRFbWl0dGVyIiwia2V5UGFyc2VTdGF0ZSIsImluY29tcGxldGVFc2NhcGVUaW1lciIsIlRpbWVvdXQiLCJOT1JNQUxfVElNRU9VVCIsIlBBU1RFX1RJTUVPVVQiLCJxdWVyaWVyIiwicHJvcHMiLCJsYXN0Q2xpY2tUaW1lIiwibGFzdENsaWNrQ29sIiwibGFzdENsaWNrUm93IiwiY2xpY2tDb3VudCIsInBlbmRpbmdIeXBlcmxpbmtUaW1lciIsIlJldHVyblR5cGUiLCJzZXRUaW1lb3V0IiwibGFzdEhvdmVyQ29sIiwibGFzdEhvdmVyUm93IiwibGFzdFN0ZGluVGltZSIsIkRhdGUiLCJub3ciLCJpc1Jhd01vZGVTdXBwb3J0ZWQiLCJpc1RUWSIsInJlbmRlciIsImNvbHVtbnMiLCJyb3dzIiwiZXhpdCIsImhhbmRsZUV4aXQiLCJzZXRSYXdNb2RlIiwiaGFuZGxlU2V0UmF3TW9kZSIsImludGVybmFsX2V4aXRPbkN0cmxDIiwiaW50ZXJuYWxfcXVlcmllciIsImNvbXBvbmVudERpZE1vdW50IiwiZW52IiwiQ0xBVURFX0NPREVfQUNDRVNTSUJJTElUWSIsIndyaXRlIiwiY29tcG9uZW50V2lsbFVubW91bnQiLCJjbGVhclRpbWVvdXQiLCJjb21wb25lbnREaWRDYXRjaCIsImlzRW5hYmxlZCIsInNldEVuY29kaW5nIiwicmVmIiwiYWRkTGlzdGVuZXIiLCJoYW5kbGVSZWFkYWJsZSIsInNldEltbWVkaWF0ZSIsIlByb21pc2UiLCJhbGwiLCJzZW5kIiwiZmx1c2giLCJ0aGVuIiwiciIsIm5hbWUiLCJyZW1vdmVMaXN0ZW5lciIsInVucmVmIiwiZmx1c2hJbmNvbXBsZXRlIiwiaW5jb21wbGV0ZSIsInJlYWRhYmxlTGVuZ3RoIiwicHJvY2Vzc0lucHV0IiwiaW5wdXQiLCJCdWZmZXIiLCJrZXlzIiwibmV3U3RhdGUiLCJsZW5ndGgiLCJkaXNjcmV0ZVVwZGF0ZXMiLCJwcm9jZXNzS2V5c0luQmF0Y2giLCJtb2RlIiwiY2h1bmsiLCJyZWFkIiwibGlzdGVuZXJzIiwiaW5jbHVkZXMiLCJsZXZlbCIsImhhbmRsZUlucHV0IiwiaGFuZGxlVGVybWluYWxGb2N1cyIsImlzRm9jdXNlZCIsImhhbmRsZVN1c3BlbmQiLCJyYXdNb2RlQ291bnRCZWZvcmVTdXNwZW5kIiwiZW1pdCIsInJlc3VtZUhhbmRsZXIiLCJpIiwib24iLCJraWxsIiwicGlkIiwiYXBwIiwiaXRlbXMiLCJfdW51c2VkMSIsIl91bnVzZWQyIiwic29tZSIsImtpbmQiLCJidXR0b24iLCJpdGVtIiwib25SZXNwb25zZSIsInJlc3BvbnNlIiwiaGFuZGxlTW91c2VFdmVudCIsInNlcXVlbmNlIiwiZXZlbnQiLCJpc0RyYWdnaW5nIiwiY3RybCIsIm0iLCJzZWwiLCJiYXNlQnV0dG9uIiwiYWN0aW9uIiwibmVhckxhc3QiLCJNYXRoIiwiYWJzIiwibGFzdFByZXNzSGFkQWx0IiwiYW5jaG9yIiwiVEVSTV9QUk9HUkFNIl0sInNvdXJjZXMiOlsiQXBwLnRzeCJdLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgUmVhY3QsIHsgUHVyZUNvbXBvbmVudCwgdHlwZSBSZWFjdE5vZGUgfSBmcm9tICdyZWFjdCdcbmltcG9ydCB7IHVwZGF0ZUxhc3RJbnRlcmFjdGlvblRpbWUgfSBmcm9tICcuLi8uLi9ib290c3RyYXAvc3RhdGUuanMnXG5pbXBvcnQgeyBsb2dGb3JEZWJ1Z2dpbmcgfSBmcm9tICcuLi8uLi91dGlscy9kZWJ1Zy5qcydcbmltcG9ydCB7IHN0b3BDYXB0dXJpbmdFYXJseUlucHV0IH0gZnJvbSAnLi4vLi4vdXRpbHMvZWFybHlJbnB1dC5qcydcbmltcG9ydCB7IGlzRW52VHJ1dGh5IH0gZnJvbSAnLi4vLi4vdXRpbHMvZW52VXRpbHMuanMnXG5pbXBvcnQgeyBpc01vdXNlQ2xpY2tzRGlzYWJsZWQgfSBmcm9tICcuLi8uLi91dGlscy9mdWxsc2NyZWVuLmpzJ1xuaW1wb3J0IHsgbG9nRXJyb3IgfSBmcm9tICcuLi8uLi91dGlscy9sb2cuanMnXG5pbXBvcnQgeyBFdmVudEVtaXR0ZXIgfSBmcm9tICcuLi9ldmVudHMvZW1pdHRlci5qcydcbmltcG9ydCB7IElucHV0RXZlbnQgfSBmcm9tICcuLi9ldmVudHMvaW5wdXQtZXZlbnQuanMnXG5pbXBvcnQgeyBUZXJtaW5hbEZvY3VzRXZlbnQgfSBmcm9tICcuLi9ldmVudHMvdGVybWluYWwtZm9jdXMtZXZlbnQuanMnXG5pbXBvcnQge1xuICBJTklUSUFMX1NUQVRFLFxuICB0eXBlIFBhcnNlZElucHV0LFxuICB0eXBlIFBhcnNlZEtleSxcbiAgdHlwZSBQYXJzZWRNb3VzZSxcbiAgcGFyc2VNdWx0aXBsZUtleXByZXNzZXMsXG59IGZyb20gJy4uL3BhcnNlLWtleXByZXNzLmpzJ1xuaW1wb3J0IHJlY29uY2lsZXIgZnJvbSAnLi4vcmVjb25jaWxlci5qcydcbmltcG9ydCB7XG4gIGZpbmlzaFNlbGVjdGlvbixcbiAgaGFzU2VsZWN0aW9uLFxuICB0eXBlIFNlbGVjdGlvblN0YXRlLFxuICBzdGFydFNlbGVjdGlvbixcbn0gZnJvbSAnLi4vc2VsZWN0aW9uLmpzJ1xuaW1wb3J0IHtcbiAgaXNYdGVybUpzLFxuICBzZXRYdHZlcnNpb25OYW1lLFxuICBzdXBwb3J0c0V4dGVuZGVkS2V5cyxcbn0gZnJvbSAnLi4vdGVybWluYWwuanMnXG5pbXBvcnQge1xuICBnZXRUZXJtaW5hbEZvY3VzZWQsXG4gIHNldFRlcm1pbmFsRm9jdXNlZCxcbn0gZnJvbSAnLi4vdGVybWluYWwtZm9jdXMtc3RhdGUuanMnXG5pbXBvcnQgeyBUZXJtaW5hbFF1ZXJpZXIsIHh0dmVyc2lvbiB9IGZyb20gJy4uL3Rlcm1pbmFsLXF1ZXJpZXIuanMnXG5pbXBvcnQge1xuICBESVNBQkxFX0tJVFRZX0tFWUJPQVJELFxuICBESVNBQkxFX01PRElGWV9PVEhFUl9LRVlTLFxuICBFTkFCTEVfS0lUVFlfS0VZQk9BUkQsXG4gIEVOQUJMRV9NT0RJRllfT1RIRVJfS0VZUyxcbiAgRk9DVVNfSU4sXG4gIEZPQ1VTX09VVCxcbn0gZnJvbSAnLi4vdGVybWlvL2NzaS5qcydcbmltcG9ydCB7XG4gIERCUCxcbiAgREZFLFxuICBESVNBQkxFX01PVVNFX1RSQUNLSU5HLFxuICBFQlAsXG4gIEVGRSxcbiAgSElERV9DVVJTT1IsXG4gIFNIT1dfQ1VSU09SLFxufSBmcm9tICcuLi90ZXJtaW8vZGVjLmpzJ1xuaW1wb3J0IEFwcENvbnRleHQgZnJvbSAnLi9BcHBDb250ZXh0LmpzJ1xuaW1wb3J0IHsgQ2xvY2tQcm92aWRlciB9IGZyb20gJy4vQ2xvY2tDb250ZXh0LmpzJ1xuaW1wb3J0IEN1cnNvckRlY2xhcmF0aW9uQ29udGV4dCwge1xuICB0eXBlIEN1cnNvckRlY2xhcmF0aW9uU2V0dGVyLFxufSBmcm9tICcuL0N1cnNvckRlY2xhcmF0aW9uQ29udGV4dC5qcydcbmltcG9ydCBFcnJvck92ZXJ2aWV3IGZyb20gJy4vRXJyb3JPdmVydmlldy5qcydcbmltcG9ydCBTdGRpbkNvbnRleHQgZnJvbSAnLi9TdGRpbkNvbnRleHQuanMnXG5pbXBvcnQgeyBUZXJtaW5hbEZvY3VzUHJvdmlkZXIgfSBmcm9tICcuL1Rlcm1pbmFsRm9jdXNDb250ZXh0LmpzJ1xuaW1wb3J0IHsgVGVybWluYWxTaXplQ29udGV4dCB9IGZyb20gJy4vVGVybWluYWxTaXplQ29udGV4dC5qcydcblxuLy8gUGxhdGZvcm1zIHRoYXQgc3VwcG9ydCBVbml4LXN0eWxlIHByb2Nlc3Mgc3VzcGVuc2lvbiAoU0lHU1RPUC9TSUdDT05UKVxuY29uc3QgU1VQUE9SVFNfU1VTUEVORCA9IHByb2Nlc3MucGxhdGZvcm0gIT09ICd3aW4zMidcblxuLy8gQWZ0ZXIgdGhpcyBtYW55IG1pbGxpc2Vjb25kcyBvZiBzdGRpbiBzaWxlbmNlLCB0aGUgbmV4dCBjaHVuayB0cmlnZ2Vyc1xuLy8gYSB0ZXJtaW5hbCBtb2RlIHJlLWFzc2VydCAobW91c2UgdHJhY2tpbmcpLiBDYXRjaGVzIHRtdXggZGV0YWNo4oaSYXR0YWNoLFxuLy8gc3NoIHJlY29ubmVjdCwgYW5kIGxhcHRvcCB3YWtlIOKAlCB0aGUgdGVybWluYWwgcmVzZXRzIERFQyBwcml2YXRlIG1vZGVzXG4vLyBidXQgbm8gc2lnbmFsIHJlYWNoZXMgdXMuIDVzIGlzIHdlbGwgYWJvdmUgbm9ybWFsIGludGVyLWtleXN0cm9rZSBnYXBzXG4vLyBidXQgc2hvcnQgZW5vdWdoIHRoYXQgdGhlIGZpcnN0IHNjcm9sbCBhZnRlciByZWF0dGFjaCB3b3Jrcy5cbmNvbnN0IFNURElOX1JFU1VNRV9HQVBfTVMgPSA1MDAwXG5cbnR5cGUgUHJvcHMgPSB7XG4gIHJlYWRvbmx5IGNoaWxkcmVuOiBSZWFjdE5vZGVcbiAgcmVhZG9ubHkgc3RkaW46IE5vZGVKUy5SZWFkU3RyZWFtXG4gIHJlYWRvbmx5IHN0ZG91dDogTm9kZUpTLldyaXRlU3RyZWFtXG4gIHJlYWRvbmx5IHN0ZGVycjogTm9kZUpTLldyaXRlU3RyZWFtXG4gIHJlYWRvbmx5IGV4aXRPbkN0cmxDOiBib29sZWFuXG4gIHJlYWRvbmx5IG9uRXhpdDogKGVycm9yPzogRXJyb3IpID0+IHZvaWRcbiAgcmVhZG9ubHkgdGVybWluYWxDb2x1bW5zOiBudW1iZXJcbiAgcmVhZG9ubHkgdGVybWluYWxSb3dzOiBudW1iZXJcbiAgLy8gVGV4dCBzZWxlY3Rpb24gc3RhdGUuIEFwcCBtdXRhdGVzIHRoaXMgZGlyZWN0bHkgZnJvbSBtb3VzZSBldmVudHNcbiAgLy8gYW5kIGNhbGxzIG9uU2VsZWN0aW9uQ2hhbmdlIHRvIHRyaWdnZXIgYSByZXBhaW50LiBNb3VzZSBldmVudHMgb25seVxuICAvLyBhcnJpdmUgd2hlbiA8QWx0ZXJuYXRlU2NyZWVuPiAob3Igc2ltaWxhcikgZW5hYmxlcyBtb3VzZSB0cmFja2luZyxcbiAgLy8gc28gdGhlIGhhbmRsZXIgaXMgYWx3YXlzIHdpcmVkIGJ1dCBkb3JtYW50IHVudGlsIHRyYWNraW5nIGlzIG9uLlxuICByZWFkb25seSBzZWxlY3Rpb246IFNlbGVjdGlvblN0YXRlXG4gIHJlYWRvbmx5IG9uU2VsZWN0aW9uQ2hhbmdlOiAoKSA9PiB2b2lkXG4gIC8vIERpc3BhdGNoIGEgY2xpY2sgYXQgKGNvbCwgcm93KSDigJQgaGl0LXRlc3RzIHRoZSBET00gdHJlZSBhbmQgYnViYmxlc1xuICAvLyBvbkNsaWNrIGhhbmRsZXJzLiBSZXR1cm5zIHRydWUgaWYgYSBET00gaGFuZGxlciBjb25zdW1lZCB0aGUgY2xpY2suXG4gIC8vIE5vLW9wIChyZXR1cm5zIGZhbHNlKSBvdXRzaWRlIGZ1bGxzY3JlZW4gbW9kZSAoSW5rLmRpc3BhdGNoQ2xpY2tcbiAgLy8gZ2F0ZXMgb24gYWx0U2NyZWVuQWN0aXZlKS5cbiAgcmVhZG9ubHkgb25DbGlja0F0OiAoY29sOiBudW1iZXIsIHJvdzogbnVtYmVyKSA9PiBib29sZWFuXG4gIC8vIERpc3BhdGNoIGhvdmVyIChvbk1vdXNlRW50ZXIvb25Nb3VzZUxlYXZlKSBhcyB0aGUgcG9pbnRlciBtb3ZlcyBvdmVyXG4gIC8vIERPTSBlbGVtZW50cy4gQ2FsbGVkIGZvciBtb2RlLTEwMDMgbW90aW9uIGV2ZW50cyB3aXRoIG5vIGJ1dHRvbiBoZWxkLlxuICAvLyBOby1vcCBvdXRzaWRlIGZ1bGxzY3JlZW4gKEluay5kaXNwYXRjaEhvdmVyIGdhdGVzIG9uIGFsdFNjcmVlbkFjdGl2ZSkuXG4gIHJlYWRvbmx5IG9uSG92ZXJBdDogKGNvbDogbnVtYmVyLCByb3c6IG51bWJlcikgPT4gdm9pZFxuICAvLyBMb29rIHVwIHRoZSBPU0MgOCBoeXBlcmxpbmsgYXQgKGNvbCwgcm93KSBzeW5jaHJvbm91c2x5IGF0IGNsaWNrXG4gIC8vIHRpbWUuIFJldHVybnMgdGhlIFVSTCBvciB1bmRlZmluZWQuIFRoZSBicm93c2VyLW9wZW4gaXMgZGVmZXJyZWQgYnlcbiAgLy8gTVVMVElfQ0xJQ0tfVElNRU9VVF9NUyBzbyBkb3VibGUtY2xpY2sgY2FuIGNhbmNlbCBpdC5cbiAgcmVhZG9ubHkgZ2V0SHlwZXJsaW5rQXQ6IChjb2w6IG51bWJlciwgcm93OiBudW1iZXIpID0+IHN0cmluZyB8IHVuZGVmaW5lZFxuICAvLyBPcGVuIGEgaHlwZXJsaW5rIFVSTCBpbiB0aGUgYnJvd3Nlci4gQ2FsbGVkIGFmdGVyIHRoZSB0aW1lciBmaXJlcy5cbiAgcmVhZG9ubHkgb25PcGVuSHlwZXJsaW5rOiAodXJsOiBzdHJpbmcpID0+IHZvaWRcbiAgLy8gQ2FsbGVkIG9uIGRvdWJsZS90cmlwbGUtY2xpY2sgUFJFU1MgYXQgKGNvbCwgcm93KS4gY291bnQ9MiBzZWxlY3RzXG4gIC8vIHRoZSB3b3JkIHVuZGVyIHRoZSBjdXJzb3I7IGNvdW50PTMgc2VsZWN0cyB0aGUgbGluZS4gSW5rIHJlYWRzIHRoZVxuICAvLyBzY3JlZW4gYnVmZmVyIHRvIGZpbmQgd29yZC9saW5lIGJvdW5kYXJpZXMgYW5kIG11dGF0ZXMgc2VsZWN0aW9uLFxuICAvLyBzZXR0aW5nIGlzRHJhZ2dpbmc9dHJ1ZSBzbyBhIHN1YnNlcXVlbnQgZHJhZyBleHRlbmRzIGJ5IHdvcmQvbGluZS5cbiAgcmVhZG9ubHkgb25NdWx0aUNsaWNrOiAoY29sOiBudW1iZXIsIHJvdzogbnVtYmVyLCBjb3VudDogMiB8IDMpID0+IHZvaWRcbiAgLy8gQ2FsbGVkIG9uIGRyYWctbW90aW9uLiBNb2RlLWF3YXJlOiBjaGFyIG1vZGUgdXBkYXRlcyBmb2N1cyB0byB0aGVcbiAgLy8gZXhhY3QgY2VsbDsgd29yZC9saW5lIG1vZGUgc25hcHMgdG8gd29yZC9saW5lIGJvdW5kYXJpZXMuIE5lZWRzXG4gIC8vIHNjcmVlbi1idWZmZXIgYWNjZXNzICh3b3JkIGJvdW5kYXJpZXMpIHNvIGxpdmVzIG9uIEluaywgbm90IGhlcmUuXG4gIHJlYWRvbmx5IG9uU2VsZWN0aW9uRHJhZzogKGNvbDogbnVtYmVyLCByb3c6IG51bWJlcikgPT4gdm9pZFxuICAvLyBDYWxsZWQgd2hlbiBzdGRpbiBkYXRhIGFycml2ZXMgYWZ0ZXIgYSA+U1RESU5fUkVTVU1FX0dBUF9NUyBnYXAuXG4gIC8vIEluayByZS1hc3NlcnRzIHRlcm1pbmFsIG1vZGVzOiBleHRlbmRlZCBrZXkgcmVwb3J0aW5nLCBhbmQgKHdoZW4gaW5cbiAgLy8gZnVsbHNjcmVlbikgcmUtZW50ZXJzIGFsdC1zY3JlZW4gKyBtb3VzZSB0cmFja2luZy4gSWRlbXBvdGVudCBvbiB0aGVcbiAgLy8gdGVybWluYWwgc2lkZS4gT3B0aW9uYWwgc28gdGVzdGluZy50c3ggZG9lc24ndCBuZWVkIHRvIHN0dWIgaXQuXG4gIHJlYWRvbmx5IG9uU3RkaW5SZXN1bWU/OiAoKSA9PiB2b2lkXG4gIC8vIFJlY2VpdmVzIHRoZSBkZWNsYXJlZCBuYXRpdmUtY3Vyc29yIHBvc2l0aW9uIGZyb20gdXNlRGVjbGFyZWRDdXJzb3JcbiAgLy8gc28gaW5rLnRzeCBjYW4gcGFyayB0aGUgdGVybWluYWwgY3Vyc29yIHRoZXJlIGFmdGVyIGVhY2ggZnJhbWUuXG4gIC8vIEVuYWJsZXMgSU1FIGNvbXBvc2l0aW9uIGF0IHRoZSBpbnB1dCBjYXJldCBhbmQgbGV0cyBzY3JlZW4gcmVhZGVycyAvXG4gIC8vIG1hZ25pZmllcnMgdHJhY2sgdGhlIGlucHV0LiBPcHRpb25hbCBzbyB0ZXN0aW5nLnRzeCBkb2Vzbid0IHN0dWIgaXQuXG4gIHJlYWRvbmx5IG9uQ3Vyc29yRGVjbGFyYXRpb24/OiBDdXJzb3JEZWNsYXJhdGlvblNldHRlclxuICAvLyBEaXNwYXRjaCBhIGtleWJvYXJkIGV2ZW50IHRocm91Z2ggdGhlIERPTSB0cmVlLiBDYWxsZWQgZm9yIGVhY2hcbiAgLy8gcGFyc2VkIGtleSBhbG9uZ3NpZGUgdGhlIGxlZ2FjeSBFdmVudEVtaXR0ZXIgcGF0aC5cbiAgcmVhZG9ubHkgZGlzcGF0Y2hLZXlib2FyZEV2ZW50OiAocGFyc2VkS2V5OiBQYXJzZWRLZXkpID0+IHZvaWRcbn1cblxuLy8gTXVsdGktY2xpY2sgZGV0ZWN0aW9uIHRocmVzaG9sZHMuIDUwMG1zIGlzIHRoZSBtYWNPUyBkZWZhdWx0OyBhIHNtYWxsXG4vLyBwb3NpdGlvbiB0b2xlcmFuY2UgYWxsb3dzIGZvciB0cmFja3BhZCBqaXR0ZXIgYmV0d2VlbiBjbGlja3MuXG5jb25zdCBNVUxUSV9DTElDS19USU1FT1VUX01TID0gNTAwXG5jb25zdCBNVUxUSV9DTElDS19ESVNUQU5DRSA9IDFcblxudHlwZSBTdGF0ZSA9IHtcbiAgcmVhZG9ubHkgZXJyb3I/OiBFcnJvclxufVxuXG4vLyBSb290IGNvbXBvbmVudCBmb3IgYWxsIEluayBhcHBzXG4vLyBJdCByZW5kZXJzIHN0ZGluIGFuZCBzdGRvdXQgY29udGV4dHMsIHNvIHRoYXQgY2hpbGRyZW4gY2FuIGFjY2VzcyB0aGVtIGlmIG5lZWRlZFxuLy8gSXQgYWxzbyBoYW5kbGVzIEN0cmwrQyBleGl0aW5nIGFuZCBjdXJzb3IgdmlzaWJpbGl0eVxuZXhwb3J0IGRlZmF1bHQgY2xhc3MgQXBwIGV4dGVuZHMgUHVyZUNvbXBvbmVudDxQcm9wcywgU3RhdGU+IHtcbiAgc3RhdGljIGRpc3BsYXlOYW1lID0gJ0ludGVybmFsQXBwJ1xuXG4gIHN0YXRpYyBnZXREZXJpdmVkU3RhdGVGcm9tRXJyb3IoZXJyb3I6IEVycm9yKSB7XG4gICAgcmV0dXJuIHsgZXJyb3IgfVxuICB9XG5cbiAgb3ZlcnJpZGUgc3RhdGUgPSB7XG4gICAgZXJyb3I6IHVuZGVmaW5lZCxcbiAgfVxuXG4gIC8vIENvdW50IGhvdyBtYW55IGNvbXBvbmVudHMgZW5hYmxlZCByYXcgbW9kZSB0byBhdm9pZCBkaXNhYmxpbmdcbiAgLy8gcmF3IG1vZGUgdW50aWwgYWxsIGNvbXBvbmVudHMgZG9uJ3QgbmVlZCBpdCBhbnltb3JlXG4gIHJhd01vZGVFbmFibGVkQ291bnQgPSAwXG5cbiAgaW50ZXJuYWxfZXZlbnRFbWl0dGVyID0gbmV3IEV2ZW50RW1pdHRlcigpXG4gIGtleVBhcnNlU3RhdGUgPSBJTklUSUFMX1NUQVRFXG4gIC8vIFRpbWVyIGZvciBmbHVzaGluZyBpbmNvbXBsZXRlIGVzY2FwZSBzZXF1ZW5jZXNcbiAgaW5jb21wbGV0ZUVzY2FwZVRpbWVyOiBOb2RlSlMuVGltZW91dCB8IG51bGwgPSBudWxsXG4gIC8vIFRpbWVvdXQgZHVyYXRpb25zIGZvciBpbmNvbXBsZXRlIHNlcXVlbmNlcyAobXMpXG4gIHJlYWRvbmx5IE5PUk1BTF9USU1FT1VUID0gNTAgLy8gU2hvcnQgdGltZW91dCBmb3IgcmVndWxhciBlc2Mgc2VxdWVuY2VzXG4gIHJlYWRvbmx5IFBBU1RFX1RJTUVPVVQgPSA1MDAgLy8gTG9uZ2VyIHRpbWVvdXQgZm9yIHBhc3RlIG9wZXJhdGlvbnNcblxuICAvLyBUZXJtaW5hbCBxdWVyeS9yZXNwb25zZSBkaXNwYXRjaC4gUmVzcG9uc2VzIGFycml2ZSBvbiBzdGRpbiAocGFyc2VkXG4gIC8vIG91dCBieSBwYXJzZS1rZXlwcmVzcykgYW5kIGFyZSByb3V0ZWQgdG8gcGVuZGluZyBwcm9taXNlIHJlc29sdmVycy5cbiAgcXVlcmllciA9IG5ldyBUZXJtaW5hbFF1ZXJpZXIodGhpcy5wcm9wcy5zdGRvdXQpXG5cbiAgLy8gTXVsdGktY2xpY2sgdHJhY2tpbmcgZm9yIGRvdWJsZS90cmlwbGUtY2xpY2sgdGV4dCBzZWxlY3Rpb24uIEEgY2xpY2tcbiAgLy8gd2l0aGluIE1VTFRJX0NMSUNLX1RJTUVPVVRfTVMgYW5kIE1VTFRJX0NMSUNLX0RJU1RBTkNFIG9mIHRoZSBwcmV2aW91c1xuICAvLyBjbGljayBpbmNyZW1lbnRzIGNsaWNrQ291bnQ7IG90aGVyd2lzZSBpdCByZXNldHMgdG8gMS5cbiAgbGFzdENsaWNrVGltZSA9IDBcbiAgbGFzdENsaWNrQ29sID0gLTFcbiAgbGFzdENsaWNrUm93ID0gLTFcbiAgY2xpY2tDb3VudCA9IDBcbiAgLy8gRGVmZXJyZWQgaHlwZXJsaW5rLW9wZW4gdGltZXIg4oCUIGNhbmNlbGxlZCBpZiBhIHNlY29uZCBjbGljayBhcnJpdmVzXG4gIC8vIHdpdGhpbiBNVUxUSV9DTElDS19USU1FT1VUX01TIChzbyBkb3VibGUtY2xpY2tpbmcgYSBoeXBlcmxpbmsgc2VsZWN0c1xuICAvLyB0aGUgd29yZCB3aXRob3V0IGFsc28gb3BlbmluZyB0aGUgYnJvd3NlcikuIERPTSBvbkNsaWNrIGRpc3BhdGNoIGlzXG4gIC8vIE5PVCBkZWZlcnJlZCDigJQgaXQgcmV0dXJucyB0cnVlIGZyb20gb25DbGlja0F0IGFuZCBza2lwcyB0aGlzIHRpbWVyLlxuICBwZW5kaW5nSHlwZXJsaW5rVGltZXI6IFJldHVyblR5cGU8dHlwZW9mIHNldFRpbWVvdXQ+IHwgbnVsbCA9IG51bGxcbiAgLy8gTGFzdCBtb2RlLTEwMDMgbW90aW9uIHBvc2l0aW9uLiBUZXJtaW5hbHMgYWxyZWFkeSBkZWR1cGUgdG8gY2VsbFxuICAvLyBncmFudWxhcml0eSBidXQgdGhpcyBhbHNvIGxldHMgdXMgc2tpcCBkaXNwYXRjaEhvdmVyIGVudGlyZWx5IG9uXG4gIC8vIHJlcGVhdCBldmVudHMgKGRyYWctdGhlbi1yZWxlYXNlIGF0IHNhbWUgY2VsbCwgZXRjLikuXG4gIGxhc3RIb3ZlckNvbCA9IC0xXG4gIGxhc3RIb3ZlclJvdyA9IC0xXG5cbiAgLy8gVGltZXN0YW1wIG9mIGxhc3Qgc3RkaW4gY2h1bmsuIFVzZWQgdG8gZGV0ZWN0IGxvbmcgZ2FwcyAodG11eCBhdHRhY2gsXG4gIC8vIHNzaCByZWNvbm5lY3QsIGxhcHRvcCB3YWtlKSBhbmQgdHJpZ2dlciB0ZXJtaW5hbCBtb2RlIHJlLWFzc2VydC5cbiAgLy8gSW5pdGlhbGl6ZWQgdG8gbm93IHNvIHN0YXJ0dXAgZG9lc24ndCBmYWxzZS10cmlnZ2VyLlxuICBsYXN0U3RkaW5UaW1lID0gRGF0ZS5ub3coKVxuXG4gIC8vIERldGVybWluZXMgaWYgVFRZIGlzIHN1cHBvcnRlZCBvbiB0aGUgcHJvdmlkZWQgc3RkaW5cbiAgaXNSYXdNb2RlU3VwcG9ydGVkKCk6IGJvb2xlYW4ge1xuICAgIHJldHVybiB0aGlzLnByb3BzLnN0ZGluLmlzVFRZXG4gIH1cblxuICBvdmVycmlkZSByZW5kZXIoKSB7XG4gICAgcmV0dXJuIChcbiAgICAgIDxUZXJtaW5hbFNpemVDb250ZXh0LlByb3ZpZGVyXG4gICAgICAgIHZhbHVlPXt7XG4gICAgICAgICAgY29sdW1uczogdGhpcy5wcm9wcy50ZXJtaW5hbENvbHVtbnMsXG4gICAgICAgICAgcm93czogdGhpcy5wcm9wcy50ZXJtaW5hbFJvd3MsXG4gICAgICAgIH19XG4gICAgICA+XG4gICAgICAgIDxBcHBDb250ZXh0LlByb3ZpZGVyXG4gICAgICAgICAgdmFsdWU9e3tcbiAgICAgICAgICAgIGV4aXQ6IHRoaXMuaGFuZGxlRXhpdCxcbiAgICAgICAgICB9fVxuICAgICAgICA+XG4gICAgICAgICAgPFN0ZGluQ29udGV4dC5Qcm92aWRlclxuICAgICAgICAgICAgdmFsdWU9e3tcbiAgICAgICAgICAgICAgc3RkaW46IHRoaXMucHJvcHMuc3RkaW4sXG4gICAgICAgICAgICAgIHNldFJhd01vZGU6IHRoaXMuaGFuZGxlU2V0UmF3TW9kZSxcbiAgICAgICAgICAgICAgaXNSYXdNb2RlU3VwcG9ydGVkOiB0aGlzLmlzUmF3TW9kZVN1cHBvcnRlZCgpLFxuXG4gICAgICAgICAgICAgIGludGVybmFsX2V4aXRPbkN0cmxDOiB0aGlzLnByb3BzLmV4aXRPbkN0cmxDLFxuXG4gICAgICAgICAgICAgIGludGVybmFsX2V2ZW50RW1pdHRlcjogdGhpcy5pbnRlcm5hbF9ldmVudEVtaXR0ZXIsXG4gICAgICAgICAgICAgIGludGVybmFsX3F1ZXJpZXI6IHRoaXMucXVlcmllcixcbiAgICAgICAgICAgIH19XG4gICAgICAgICAgPlxuICAgICAgICAgICAgPFRlcm1pbmFsRm9jdXNQcm92aWRlcj5cbiAgICAgICAgICAgICAgPENsb2NrUHJvdmlkZXI+XG4gICAgICAgICAgICAgICAgPEN1cnNvckRlY2xhcmF0aW9uQ29udGV4dC5Qcm92aWRlclxuICAgICAgICAgICAgICAgICAgdmFsdWU9e3RoaXMucHJvcHMub25DdXJzb3JEZWNsYXJhdGlvbiA/PyAoKCkgPT4ge30pfVxuICAgICAgICAgICAgICAgID5cbiAgICAgICAgICAgICAgICAgIHt0aGlzLnN0YXRlLmVycm9yID8gKFxuICAgICAgICAgICAgICAgICAgICA8RXJyb3JPdmVydmlldyBlcnJvcj17dGhpcy5zdGF0ZS5lcnJvciBhcyBFcnJvcn0gLz5cbiAgICAgICAgICAgICAgICAgICkgOiAoXG4gICAgICAgICAgICAgICAgICAgIHRoaXMucHJvcHMuY2hpbGRyZW5cbiAgICAgICAgICAgICAgICAgICl9XG4gICAgICAgICAgICAgICAgPC9DdXJzb3JEZWNsYXJhdGlvbkNvbnRleHQuUHJvdmlkZXI+XG4gICAgICAgICAgICAgIDwvQ2xvY2tQcm92aWRlcj5cbiAgICAgICAgICAgIDwvVGVybWluYWxGb2N1c1Byb3ZpZGVyPlxuICAgICAgICAgIDwvU3RkaW5Db250ZXh0LlByb3ZpZGVyPlxuICAgICAgICA8L0FwcENvbnRleHQuUHJvdmlkZXI+XG4gICAgICA8L1Rlcm1pbmFsU2l6ZUNvbnRleHQuUHJvdmlkZXI+XG4gICAgKVxuICB9XG5cbiAgb3ZlcnJpZGUgY29tcG9uZW50RGlkTW91bnQoKSB7XG4gICAgLy8gSW4gYWNjZXNzaWJpbGl0eSBtb2RlLCBrZWVwIHRoZSBuYXRpdmUgY3Vyc29yIHZpc2libGUgZm9yIHNjcmVlbiBtYWduaWZpZXJzIGFuZCBvdGhlciB0b29sc1xuICAgIGlmIChcbiAgICAgIHRoaXMucHJvcHMuc3Rkb3V0LmlzVFRZICYmXG4gICAgICAhaXNFbnZUcnV0aHkocHJvY2Vzcy5lbnYuQ0xBVURFX0NPREVfQUNDRVNTSUJJTElUWSlcbiAgICApIHtcbiAgICAgIHRoaXMucHJvcHMuc3Rkb3V0LndyaXRlKEhJREVfQ1VSU09SKVxuICAgIH1cbiAgfVxuXG4gIG92ZXJyaWRlIGNvbXBvbmVudFdpbGxVbm1vdW50KCkge1xuICAgIGlmICh0aGlzLnByb3BzLnN0ZG91dC5pc1RUWSkge1xuICAgICAgdGhpcy5wcm9wcy5zdGRvdXQud3JpdGUoU0hPV19DVVJTT1IpXG4gICAgfVxuXG4gICAgLy8gQ2xlYXIgYW55IHBlbmRpbmcgdGltZXJzXG4gICAgaWYgKHRoaXMuaW5jb21wbGV0ZUVzY2FwZVRpbWVyKSB7XG4gICAgICBjbGVhclRpbWVvdXQodGhpcy5pbmNvbXBsZXRlRXNjYXBlVGltZXIpXG4gICAgICB0aGlzLmluY29tcGxldGVFc2NhcGVUaW1lciA9IG51bGxcbiAgICB9XG4gICAgaWYgKHRoaXMucGVuZGluZ0h5cGVybGlua1RpbWVyKSB7XG4gICAgICBjbGVhclRpbWVvdXQodGhpcy5wZW5kaW5nSHlwZXJsaW5rVGltZXIpXG4gICAgICB0aGlzLnBlbmRpbmdIeXBlcmxpbmtUaW1lciA9IG51bGxcbiAgICB9XG4gICAgLy8gaWdub3JlIGNhbGxpbmcgc2V0UmF3TW9kZSBvbiBhbiBoYW5kbGUgc3RkaW4gaXQgY2Fubm90IGJlIGNhbGxlZFxuICAgIGlmICh0aGlzLmlzUmF3TW9kZVN1cHBvcnRlZCgpKSB7XG4gICAgICB0aGlzLmhhbmRsZVNldFJhd01vZGUoZmFsc2UpXG4gICAgfVxuICB9XG5cbiAgb3ZlcnJpZGUgY29tcG9uZW50RGlkQ2F0Y2goZXJyb3I6IEVycm9yKSB7XG4gICAgdGhpcy5oYW5kbGVFeGl0KGVycm9yKVxuICB9XG5cbiAgaGFuZGxlU2V0UmF3TW9kZSA9IChpc0VuYWJsZWQ6IGJvb2xlYW4pOiB2b2lkID0+IHtcbiAgICBjb25zdCB7IHN0ZGluIH0gPSB0aGlzLnByb3BzXG5cbiAgICBpZiAoIXRoaXMuaXNSYXdNb2RlU3VwcG9ydGVkKCkpIHtcbiAgICAgIGlmIChzdGRpbiA9PT0gcHJvY2Vzcy5zdGRpbikge1xuICAgICAgICB0aHJvdyBuZXcgRXJyb3IoXG4gICAgICAgICAgJ1JhdyBtb2RlIGlzIG5vdCBzdXBwb3J0ZWQgb24gdGhlIGN1cnJlbnQgcHJvY2Vzcy5zdGRpbiwgd2hpY2ggSW5rIHVzZXMgYXMgaW5wdXQgc3RyZWFtIGJ5IGRlZmF1bHQuXFxuUmVhZCBhYm91dCBob3cgdG8gcHJldmVudCB0aGlzIGVycm9yIG9uIGh0dHBzOi8vZ2l0aHViLmNvbS92YWRpbWRlbWVkZXMvaW5rLyNpc3Jhd21vZGVzdXBwb3J0ZWQnLFxuICAgICAgICApXG4gICAgICB9IGVsc2Uge1xuICAgICAgICB0aHJvdyBuZXcgRXJyb3IoXG4gICAgICAgICAgJ1JhdyBtb2RlIGlzIG5vdCBzdXBwb3J0ZWQgb24gdGhlIHN0ZGluIHByb3ZpZGVkIHRvIEluay5cXG5SZWFkIGFib3V0IGhvdyB0byBwcmV2ZW50IHRoaXMgZXJyb3Igb24gaHR0cHM6Ly9naXRodWIuY29tL3ZhZGltZGVtZWRlcy9pbmsvI2lzcmF3bW9kZXN1cHBvcnRlZCcsXG4gICAgICAgIClcbiAgICAgIH1cbiAgICB9XG5cbiAgICBzdGRpbi5zZXRFbmNvZGluZygndXRmOCcpXG5cbiAgICBpZiAoaXNFbmFibGVkKSB7XG4gICAgICAvLyBFbnN1cmUgcmF3IG1vZGUgaXMgZW5hYmxlZCBvbmx5IG9uY2VcbiAgICAgIGlmICh0aGlzLnJhd01vZGVFbmFibGVkQ291bnQgPT09IDApIHtcbiAgICAgICAgLy8gU3RvcCBlYXJseSBpbnB1dCBjYXB0dXJlIHJpZ2h0IGJlZm9yZSB3ZSBhZGQgb3VyIG93biByZWFkYWJsZSBoYW5kbGVyLlxuICAgICAgICAvLyBCb3RoIHVzZSB0aGUgc2FtZSBzdGRpbiAncmVhZGFibGUnICsgcmVhZCgpIHBhdHRlcm4sIHNvIHRoZXkgY2FuJ3RcbiAgICAgICAgLy8gY29leGlzdCAtLSBvdXIgaGFuZGxlciB3b3VsZCBkcmFpbiBzdGRpbiBiZWZvcmUgSW5rJ3MgY2FuIHNlZSBpdC5cbiAgICAgICAgLy8gVGhlIGJ1ZmZlcmVkIHRleHQgaXMgcHJlc2VydmVkIGZvciBSRVBMLnRzeCB2aWEgY29uc3VtZUVhcmx5SW5wdXQoKS5cbiAgICAgICAgc3RvcENhcHR1cmluZ0Vhcmx5SW5wdXQoKVxuICAgICAgICBzdGRpbi5yZWYoKVxuICAgICAgICBzdGRpbi5zZXRSYXdNb2RlKHRydWUpXG4gICAgICAgIHN0ZGluLmFkZExpc3RlbmVyKCdyZWFkYWJsZScsIHRoaXMuaGFuZGxlUmVhZGFibGUpXG4gICAgICAgIC8vIEVuYWJsZSBicmFja2V0ZWQgcGFzdGUgbW9kZVxuICAgICAgICB0aGlzLnByb3BzLnN0ZG91dC53cml0ZShFQlApXG4gICAgICAgIC8vIEVuYWJsZSB0ZXJtaW5hbCBmb2N1cyByZXBvcnRpbmcgKERFQ1NFVCAxMDA0KVxuICAgICAgICB0aGlzLnByb3BzLnN0ZG91dC53cml0ZShFRkUpXG4gICAgICAgIC8vIEVuYWJsZSBleHRlbmRlZCBrZXkgcmVwb3J0aW5nIHNvIGN0cmwrc2hpZnQrPGxldHRlcj4gaXNcbiAgICAgICAgLy8gZGlzdGluZ3Vpc2hhYmxlIGZyb20gY3RybCs8bGV0dGVyPi4gV2Ugd3JpdGUgYm90aCB0aGUga2l0dHkgc3RhY2tcbiAgICAgICAgLy8gcHVzaCAoQ1NJID4xdSkgYW5kIHh0ZXJtIG1vZGlmeU90aGVyS2V5cyBsZXZlbCAyIChDU0kgPjQ7Mm0pIOKAlFxuICAgICAgICAvLyB0ZXJtaW5hbHMgaG9ub3Igd2hpY2hldmVyIHRoZXkgaW1wbGVtZW50ICh0bXV4IG9ubHkgYWNjZXB0cyB0aGVcbiAgICAgICAgLy8gbGF0dGVyKS5cbiAgICAgICAgaWYgKHN1cHBvcnRzRXh0ZW5kZWRLZXlzKCkpIHtcbiAgICAgICAgICB0aGlzLnByb3BzLnN0ZG91dC53cml0ZShFTkFCTEVfS0lUVFlfS0VZQk9BUkQpXG4gICAgICAgICAgdGhpcy5wcm9wcy5zdGRvdXQud3JpdGUoRU5BQkxFX01PRElGWV9PVEhFUl9LRVlTKVxuICAgICAgICB9XG4gICAgICAgIC8vIFByb2JlIHRlcm1pbmFsIGlkZW50aXR5LiBYVFZFUlNJT04gc3Vydml2ZXMgU1NIIChxdWVyeS9yZXBseSBnb2VzXG4gICAgICAgIC8vIHRocm91Z2ggdGhlIHB0eSksIHVubGlrZSBURVJNX1BST0dSQU0uIFVzZWQgZm9yIHdoZWVsLXNjcm9sbCBiYXNlXG4gICAgICAgIC8vIGRldGVjdGlvbiB3aGVuIGVudiB2YXJzIGFyZSBhYnNlbnQuIEZpcmUtYW5kLWZvcmdldDogdGhlIERBMVxuICAgICAgICAvLyBzZW50aW5lbCBib3VuZHMgdGhlIHJvdW5kLXRyaXAsIGFuZCBpZiB0aGUgdGVybWluYWwgaWdub3JlcyB0aGVcbiAgICAgICAgLy8gcXVlcnksIGZsdXNoKCkgc3RpbGwgcmVzb2x2ZXMgYW5kIG5hbWUgc3RheXMgdW5kZWZpbmVkLlxuICAgICAgICAvLyBEZWZlcnJlZCB0byBuZXh0IHRpY2sgc28gaXQgZmlyZXMgQUZURVIgdGhlIGN1cnJlbnQgc3luY2hyb25vdXNcbiAgICAgICAgLy8gaW5pdCBzZXF1ZW5jZSBjb21wbGV0ZXMg4oCUIGF2b2lkcyBpbnRlcmxlYXZpbmcgd2l0aCBhbHQtc2NyZWVuL21vdXNlXG4gICAgICAgIC8vIHRyYWNraW5nIGVuYWJsZSB3cml0ZXMgdGhhdCBtYXkgaGFwcGVuIGluIHRoZSBzYW1lIHJlbmRlciBjeWNsZS5cbiAgICAgICAgc2V0SW1tZWRpYXRlKCgpID0+IHtcbiAgICAgICAgICB2b2lkIFByb21pc2UuYWxsKFtcbiAgICAgICAgICAgIHRoaXMucXVlcmllci5zZW5kKHh0dmVyc2lvbigpKSxcbiAgICAgICAgICAgIHRoaXMucXVlcmllci5mbHVzaCgpLFxuICAgICAgICAgIF0pLnRoZW4oKFtyXSkgPT4ge1xuICAgICAgICAgICAgaWYgKHIpIHtcbiAgICAgICAgICAgICAgc2V0WHR2ZXJzaW9uTmFtZShyLm5hbWUpXG4gICAgICAgICAgICAgIGxvZ0ZvckRlYnVnZ2luZyhgWFRWRVJTSU9OOiB0ZXJtaW5hbCBpZGVudGlmaWVkIGFzIFwiJHtyLm5hbWV9XCJgKVxuICAgICAgICAgICAgfSBlbHNlIHtcbiAgICAgICAgICAgICAgbG9nRm9yRGVidWdnaW5nKCdYVFZFUlNJT046IG5vIHJlcGx5ICh0ZXJtaW5hbCBpZ25vcmVkIHF1ZXJ5KScpXG4gICAgICAgICAgICB9XG4gICAgICAgICAgfSlcbiAgICAgICAgfSlcbiAgICAgIH1cblxuICAgICAgdGhpcy5yYXdNb2RlRW5hYmxlZENvdW50KytcbiAgICAgIHJldHVyblxuICAgIH1cblxuICAgIC8vIERpc2FibGUgcmF3IG1vZGUgb25seSB3aGVuIG5vIGNvbXBvbmVudHMgbGVmdCB0aGF0IGFyZSB1c2luZyBpdFxuICAgIGlmICgtLXRoaXMucmF3TW9kZUVuYWJsZWRDb3VudCA9PT0gMCkge1xuICAgICAgdGhpcy5wcm9wcy5zdGRvdXQud3JpdGUoRElTQUJMRV9NT0RJRllfT1RIRVJfS0VZUylcbiAgICAgIHRoaXMucHJvcHMuc3Rkb3V0LndyaXRlKERJU0FCTEVfS0lUVFlfS0VZQk9BUkQpXG4gICAgICAvLyBEaXNhYmxlIHRlcm1pbmFsIGZvY3VzIHJlcG9ydGluZyAoREVDU0VUIDEwMDQpXG4gICAgICB0aGlzLnByb3BzLnN0ZG91dC53cml0ZShERkUpXG4gICAgICAvLyBEaXNhYmxlIGJyYWNrZXRlZCBwYXN0ZSBtb2RlXG4gICAgICB0aGlzLnByb3BzLnN0ZG91dC53cml0ZShEQlApXG4gICAgICBzdGRpbi5zZXRSYXdNb2RlKGZhbHNlKVxuICAgICAgc3RkaW4ucmVtb3ZlTGlzdGVuZXIoJ3JlYWRhYmxlJywgdGhpcy5oYW5kbGVSZWFkYWJsZSlcbiAgICAgIHN0ZGluLnVucmVmKClcbiAgICB9XG4gIH1cblxuICAvLyBIZWxwZXIgdG8gZmx1c2ggaW5jb21wbGV0ZSBlc2NhcGUgc2VxdWVuY2VzXG4gIGZsdXNoSW5jb21wbGV0ZSA9ICgpOiB2b2lkID0+IHtcbiAgICAvLyBDbGVhciB0aGUgdGltZXIgcmVmZXJlbmNlXG4gICAgdGhpcy5pbmNvbXBsZXRlRXNjYXBlVGltZXIgPSBudWxsXG5cbiAgICAvLyBPbmx5IHByb2NlZWQgaWYgd2UgaGF2ZSBpbmNvbXBsZXRlIHNlcXVlbmNlc1xuICAgIGlmICghdGhpcy5rZXlQYXJzZVN0YXRlLmluY29tcGxldGUpIHJldHVyblxuXG4gICAgLy8gRnVsbHNjcmVlbjogaWYgc3RkaW4gaGFzIGRhdGEgd2FpdGluZywgaXQncyBhbG1vc3QgY2VydGFpbmx5IHRoZVxuICAgIC8vIGNvbnRpbnVhdGlvbiBvZiB0aGUgYnVmZmVyZWQgc2VxdWVuY2UgKGUuZy4gYFs8NjQ7NzQ7MTZNYCBhZnRlciBhXG4gICAgLy8gbG9uZSBFU0MpLiBOb2RlJ3MgZXZlbnQgbG9vcCBydW5zIHRoZSB0aW1lcnMgcGhhc2UgYmVmb3JlIHRoZSBwb2xsXG4gICAgLy8gcGhhc2UsIHNvIHdoZW4gYSBoZWF2eSByZW5kZXIgYmxvY2tzIHRoZSBsb29wIHBhc3QgNTBtcywgdGhpcyB0aW1lclxuICAgIC8vIGZpcmVzIGJlZm9yZSB0aGUgcXVldWVkIHJlYWRhYmxlIGV2ZW50IGV2ZW4gdGhvdWdoIHRoZSBieXRlcyBhcmVcbiAgICAvLyBhbHJlYWR5IGJ1ZmZlcmVkLiBSZS1hcm0gaW5zdGVhZCBvZiBmbHVzaGluZzogaGFuZGxlUmVhZGFibGUgd2lsbFxuICAgIC8vIGRyYWluIHN0ZGluIG5leHQgYW5kIGNsZWFyIHRoaXMgdGltZXIuIFByZXZlbnRzIGJvdGggdGhlIHNwdXJpb3VzXG4gICAgLy8gRXNjYXBlIGtleSBhbmQgdGhlIGxvc3Qgc2Nyb2xsIGV2ZW50LlxuICAgIGlmICh0aGlzLnByb3BzLnN0ZGluLnJlYWRhYmxlTGVuZ3RoID4gMCkge1xuICAgICAgdGhpcy5pbmNvbXBsZXRlRXNjYXBlVGltZXIgPSBzZXRUaW1lb3V0KFxuICAgICAgICB0aGlzLmZsdXNoSW5jb21wbGV0ZSxcbiAgICAgICAgdGhpcy5OT1JNQUxfVElNRU9VVCxcbiAgICAgIClcbiAgICAgIHJldHVyblxuICAgIH1cblxuICAgIC8vIFByb2Nlc3MgaW5jb21wbGV0ZSBhcyBhIGZsdXNoIG9wZXJhdGlvbiAoaW5wdXQ9bnVsbClcbiAgICAvLyBUaGlzIHJldXNlcyBhbGwgZXhpc3RpbmcgcGFyc2luZyBsb2dpY1xuICAgIHRoaXMucHJvY2Vzc0lucHV0KG51bGwpXG4gIH1cblxuICAvLyBQcm9jZXNzIGlucHV0IHRocm91Z2ggdGhlIHBhcnNlciBhbmQgaGFuZGxlIHRoZSByZXN1bHRzXG4gIHByb2Nlc3NJbnB1dCA9IChpbnB1dDogc3RyaW5nIHwgQnVmZmVyIHwgbnVsbCk6IHZvaWQgPT4ge1xuICAgIC8vIFBhcnNlIGlucHV0IHVzaW5nIG91ciBzdGF0ZSBtYWNoaW5lXG4gICAgY29uc3QgW2tleXMsIG5ld1N0YXRlXSA9IHBhcnNlTXVsdGlwbGVLZXlwcmVzc2VzKHRoaXMua2V5UGFyc2VTdGF0ZSwgaW5wdXQpXG4gICAgdGhpcy5rZXlQYXJzZVN0YXRlID0gbmV3U3RhdGVcblxuICAgIC8vIFByb2Nlc3MgQUxMIGtleXMgaW4gYSBTSU5HTEUgZGlzY3JldGVVcGRhdGVzIGNhbGwgdG8gcHJldmVudFxuICAgIC8vIFwiTWF4aW11bSB1cGRhdGUgZGVwdGggZXhjZWVkZWRcIiBlcnJvciB3aGVuIG1hbnkga2V5cyBhcnJpdmUgYXQgb25jZVxuICAgIC8vIChlLmcuLCBmcm9tIHBhc3RlIG9wZXJhdGlvbnMgb3IgaG9sZGluZyBrZXlzIHJhcGlkbHkpLlxuICAgIC8vIFRoaXMgYmF0Y2hlcyBhbGwgc3RhdGUgdXBkYXRlcyBmcm9tIGhhbmRsZUlucHV0IGFuZCBhbGwgdXNlSW5wdXRcbiAgICAvLyBsaXN0ZW5lcnMgdG9nZXRoZXIgd2l0aGluIG9uZSBoaWdoLXByaW9yaXR5IHVwZGF0ZSBjb250ZXh0LlxuICAgIGlmIChrZXlzLmxlbmd0aCA+IDApIHtcbiAgICAgIHJlY29uY2lsZXIuZGlzY3JldGVVcGRhdGVzKFxuICAgICAgICBwcm9jZXNzS2V5c0luQmF0Y2gsXG4gICAgICAgIHRoaXMsXG4gICAgICAgIGtleXMsXG4gICAgICAgIHVuZGVmaW5lZCxcbiAgICAgICAgdW5kZWZpbmVkLFxuICAgICAgKVxuICAgIH1cblxuICAgIC8vIElmIHdlIGhhdmUgaW5jb21wbGV0ZSBlc2NhcGUgc2VxdWVuY2VzLCBzZXQgYSB0aW1lciB0byBmbHVzaCB0aGVtXG4gICAgaWYgKHRoaXMua2V5UGFyc2VTdGF0ZS5pbmNvbXBsZXRlKSB7XG4gICAgICAvLyBDYW5jZWwgYW55IGV4aXN0aW5nIHRpbWVyIGZpcnN0XG4gICAgICBpZiAodGhpcy5pbmNvbXBsZXRlRXNjYXBlVGltZXIpIHtcbiAgICAgICAgY2xlYXJUaW1lb3V0KHRoaXMuaW5jb21wbGV0ZUVzY2FwZVRpbWVyKVxuICAgICAgfVxuICAgICAgdGhpcy5pbmNvbXBsZXRlRXNjYXBlVGltZXIgPSBzZXRUaW1lb3V0KFxuICAgICAgICB0aGlzLmZsdXNoSW5jb21wbGV0ZSxcbiAgICAgICAgdGhpcy5rZXlQYXJzZVN0YXRlLm1vZGUgPT09ICdJTl9QQVNURSdcbiAgICAgICAgICA/IHRoaXMuUEFTVEVfVElNRU9VVFxuICAgICAgICAgIDogdGhpcy5OT1JNQUxfVElNRU9VVCxcbiAgICAgIClcbiAgICB9XG4gIH1cblxuICBoYW5kbGVSZWFkYWJsZSA9ICgpOiB2b2lkID0+IHtcbiAgICAvLyBEZXRlY3QgbG9uZyBzdGRpbiBnYXBzICh0bXV4IGF0dGFjaCwgc3NoIHJlY29ubmVjdCwgbGFwdG9wIHdha2UpLlxuICAgIC8vIFRoZSB0ZXJtaW5hbCBtYXkgaGF2ZSByZXNldCBERUMgcHJpdmF0ZSBtb2RlczsgcmUtYXNzZXJ0IG1vdXNlXG4gICAgLy8gdHJhY2tpbmcuIENoZWNrZWQgYmVmb3JlIHRoZSByZWFkIGxvb3Agc28gb25lIERhdGUubm93KCkgY292ZXJzXG4gICAgLy8gYWxsIGNodW5rcyBpbiB0aGlzIHJlYWRhYmxlIGV2ZW50LlxuICAgIGNvbnN0IG5vdyA9IERhdGUubm93KClcbiAgICBpZiAobm93IC0gdGhpcy5sYXN0U3RkaW5UaW1lID4gU1RESU5fUkVTVU1FX0dBUF9NUykge1xuICAgICAgdGhpcy5wcm9wcy5vblN0ZGluUmVzdW1lPy4oKVxuICAgIH1cbiAgICB0aGlzLmxhc3RTdGRpblRpbWUgPSBub3dcbiAgICB0cnkge1xuICAgICAgbGV0IGNodW5rXG4gICAgICB3aGlsZSAoKGNodW5rID0gdGhpcy5wcm9wcy5zdGRpbi5yZWFkKCkgYXMgc3RyaW5nIHwgbnVsbCkgIT09IG51bGwpIHtcbiAgICAgICAgLy8gUHJvY2VzcyB0aGUgaW5wdXQgY2h1bmtcbiAgICAgICAgdGhpcy5wcm9jZXNzSW5wdXQoY2h1bmspXG4gICAgICB9XG4gICAgfSBjYXRjaCAoZXJyb3IpIHtcbiAgICAgIC8vIEluIEJ1biwgYW4gdW5jYXVnaHQgdGhyb3cgaW5zaWRlIGEgc3RyZWFtICdyZWFkYWJsZScgaGFuZGxlciBjYW5cbiAgICAgIC8vIHBlcm1hbmVudGx5IHdlZGdlIHRoZSBzdHJlYW06IGRhdGEgc3RheXMgYnVmZmVyZWQgYW5kICdyZWFkYWJsZSdcbiAgICAgIC8vIG5ldmVyIHJlLWVtaXRzLiBDYXRjaGluZyBoZXJlIGVuc3VyZXMgdGhlIHN0cmVhbSBzdGF5cyBoZWFsdGh5IHNvXG4gICAgICAvLyBzdWJzZXF1ZW50IGtleXN0cm9rZXMgYXJlIHN0aWxsIGRlbGl2ZXJlZC5cbiAgICAgIGxvZ0Vycm9yKGVycm9yKVxuXG4gICAgICAvLyBSZS1hdHRhY2ggdGhlIGxpc3RlbmVyIGluIGNhc2UgdGhlIGV4Y2VwdGlvbiBkZXRhY2hlZCBpdC5cbiAgICAgIC8vIEJ1biBtYXkgcmVtb3ZlIHRoZSBsaXN0ZW5lciBhZnRlciBhbiBlcnJvcjsgd2l0aG91dCB0aGlzLFxuICAgICAgLy8gdGhlIHNlc3Npb24gZnJlZXplcyBwZXJtYW5lbnRseSAoc3RkaW4gcmVhZGVyIGRlYWQsIGV2ZW50IGxvb3AgYWxpdmUpLlxuICAgICAgY29uc3QgeyBzdGRpbiB9ID0gdGhpcy5wcm9wc1xuICAgICAgaWYgKFxuICAgICAgICB0aGlzLnJhd01vZGVFbmFibGVkQ291bnQgPiAwICYmXG4gICAgICAgICFzdGRpbi5saXN0ZW5lcnMoJ3JlYWRhYmxlJykuaW5jbHVkZXModGhpcy5oYW5kbGVSZWFkYWJsZSlcbiAgICAgICkge1xuICAgICAgICBsb2dGb3JEZWJ1Z2dpbmcoXG4gICAgICAgICAgJ2hhbmRsZVJlYWRhYmxlOiByZS1hdHRhY2hpbmcgc3RkaW4gcmVhZGFibGUgbGlzdGVuZXIgYWZ0ZXIgZXJyb3IgcmVjb3ZlcnknLFxuICAgICAgICAgIHsgbGV2ZWw6ICd3YXJuJyB9LFxuICAgICAgICApXG4gICAgICAgIHN0ZGluLmFkZExpc3RlbmVyKCdyZWFkYWJsZScsIHRoaXMuaGFuZGxlUmVhZGFibGUpXG4gICAgICB9XG4gICAgfVxuICB9XG5cbiAgaGFuZGxlSW5wdXQgPSAoaW5wdXQ6IHN0cmluZyB8IHVuZGVmaW5lZCk6IHZvaWQgPT4ge1xuICAgIC8vIEV4aXQgb24gQ3RybCtDXG4gICAgaWYgKGlucHV0ID09PSAnXFx4MDMnICYmIHRoaXMucHJvcHMuZXhpdE9uQ3RybEMpIHtcbiAgICAgIHRoaXMuaGFuZGxlRXhpdCgpXG4gICAgfVxuXG4gICAgLy8gTm90ZTogQ3RybCtaIChzdXNwZW5kKSBpcyBub3cgaGFuZGxlZCBpbiBwcm9jZXNzS2V5c0luQmF0Y2ggdXNpbmcgdGhlXG4gICAgLy8gcGFyc2VkIGtleSB0byBzdXBwb3J0IGJvdGggcmF3IChcXHgxYSkgYW5kIENTSSB1IGZvcm1hdCBmcm9tIEtpdHR5XG4gICAgLy8ga2V5Ym9hcmQgcHJvdG9jb2wgdGVybWluYWxzIChHaG9zdHR5LCBpVGVybTIsIGtpdHR5LCBXZXpUZXJtKVxuICB9XG5cbiAgaGFuZGxlRXhpdCA9IChlcnJvcj86IEVycm9yKTogdm9pZCA9PiB7XG4gICAgaWYgKHRoaXMuaXNSYXdNb2RlU3VwcG9ydGVkKCkpIHtcbiAgICAgIHRoaXMuaGFuZGxlU2V0UmF3TW9kZShmYWxzZSlcbiAgICB9XG5cbiAgICB0aGlzLnByb3BzLm9uRXhpdChlcnJvcilcbiAgfVxuXG4gIGhhbmRsZVRlcm1pbmFsRm9jdXMgPSAoaXNGb2N1c2VkOiBib29sZWFuKTogdm9pZCA9PiB7XG4gICAgLy8gc2V0VGVybWluYWxGb2N1c2VkIG5vdGlmaWVzIHN1YnNjcmliZXJzOiBUZXJtaW5hbEZvY3VzUHJvdmlkZXIgKGNvbnRleHQpXG4gICAgLy8gYW5kIENsb2NrIChpbnRlcnZhbCBzcGVlZCkg4oCUIG5vIEFwcCBzZXRTdGF0ZSBuZWVkZWQuXG4gICAgc2V0VGVybWluYWxGb2N1c2VkKGlzRm9jdXNlZClcbiAgfVxuXG4gIGhhbmRsZVN1c3BlbmQgPSAoKTogdm9pZCA9PiB7XG4gICAgaWYgKCF0aGlzLmlzUmF3TW9kZVN1cHBvcnRlZCgpKSB7XG4gICAgICByZXR1cm5cbiAgICB9XG5cbiAgICAvLyBTdG9yZSB0aGUgZXhhY3QgcmF3IG1vZGUgY291bnQgdG8gcmVzdG9yZSBpdCBwcm9wZXJseVxuICAgIGNvbnN0IHJhd01vZGVDb3VudEJlZm9yZVN1c3BlbmQgPSB0aGlzLnJhd01vZGVFbmFibGVkQ291bnRcblxuICAgIC8vIENvbXBsZXRlbHkgZGlzYWJsZSByYXcgbW9kZSBiZWZvcmUgc3VzcGVuZGluZ1xuICAgIHdoaWxlICh0aGlzLnJhd01vZGVFbmFibGVkQ291bnQgPiAwKSB7XG4gICAgICB0aGlzLmhhbmRsZVNldFJhd01vZGUoZmFsc2UpXG4gICAgfVxuXG4gICAgLy8gU2hvdyBjdXJzb3IsIGRpc2FibGUgZm9jdXMgcmVwb3J0aW5nLCBhbmQgZGlzYWJsZSBtb3VzZSB0cmFja2luZ1xuICAgIC8vIGJlZm9yZSBzdXNwZW5kaW5nLiBESVNBQkxFX01PVVNFX1RSQUNLSU5HIGlzIGEgbm8tb3AgaWYgdHJhY2tpbmdcbiAgICAvLyB3YXNuJ3QgZW5hYmxlZCwgc28gaXQncyBzYWZlIHRvIGVtaXQgdW5jb25kaXRpb25hbGx5IOKAlCB3aXRob3V0XG4gICAgLy8gaXQsIFNHUiBtb3VzZSBzZXF1ZW5jZXMgd291bGQgYXBwZWFyIGFzIGdhcmJsZWQgdGV4dCBhdCB0aGVcbiAgICAvLyBzaGVsbCBwcm9tcHQgd2hpbGUgc3VzcGVuZGVkLlxuICAgIGlmICh0aGlzLnByb3BzLnN0ZG91dC5pc1RUWSkge1xuICAgICAgdGhpcy5wcm9wcy5zdGRvdXQud3JpdGUoU0hPV19DVVJTT1IgKyBERkUgKyBESVNBQkxFX01PVVNFX1RSQUNLSU5HKVxuICAgIH1cblxuICAgIC8vIEVtaXQgc3VzcGVuZCBldmVudCBmb3IgQ2xhdWRlIENvZGUgdG8gaGFuZGxlLiBNb3N0bHkganVzdCBoYXMgYSBub3RpZmljYXRpb25cbiAgICB0aGlzLmludGVybmFsX2V2ZW50RW1pdHRlci5lbWl0KCdzdXNwZW5kJylcblxuICAgIC8vIFNldCB1cCByZXN1bWUgaGFuZGxlclxuICAgIGNvbnN0IHJlc3VtZUhhbmRsZXIgPSAoKSA9PiB7XG4gICAgICAvLyBSZXN0b3JlIHJhdyBtb2RlIHRvIGV4YWN0IHByZXZpb3VzIHN0YXRlXG4gICAgICBmb3IgKGxldCBpID0gMDsgaSA8IHJhd01vZGVDb3VudEJlZm9yZVN1c3BlbmQ7IGkrKykge1xuICAgICAgICBpZiAodGhpcy5pc1Jhd01vZGVTdXBwb3J0ZWQoKSkge1xuICAgICAgICAgIHRoaXMuaGFuZGxlU2V0UmF3TW9kZSh0cnVlKVxuICAgICAgICB9XG4gICAgICB9XG5cbiAgICAgIC8vIEhpZGUgY3Vyc29yICh1bmxlc3MgaW4gYWNjZXNzaWJpbGl0eSBtb2RlKSBhbmQgcmUtZW5hYmxlIGZvY3VzIHJlcG9ydGluZyBhZnRlciByZXN1bWluZ1xuICAgICAgaWYgKHRoaXMucHJvcHMuc3Rkb3V0LmlzVFRZKSB7XG4gICAgICAgIGlmICghaXNFbnZUcnV0aHkocHJvY2Vzcy5lbnYuQ0xBVURFX0NPREVfQUNDRVNTSUJJTElUWSkpIHtcbiAgICAgICAgICB0aGlzLnByb3BzLnN0ZG91dC53cml0ZShISURFX0NVUlNPUilcbiAgICAgICAgfVxuICAgICAgICAvLyBSZS1lbmFibGUgZm9jdXMgcmVwb3J0aW5nIHRvIHJlc3RvcmUgdGVybWluYWwgc3RhdGVcbiAgICAgICAgdGhpcy5wcm9wcy5zdGRvdXQud3JpdGUoRUZFKVxuICAgICAgfVxuXG4gICAgICAvLyBFbWl0IHJlc3VtZSBldmVudCBmb3IgQ2xhdWRlIENvZGUgdG8gaGFuZGxlXG4gICAgICB0aGlzLmludGVybmFsX2V2ZW50RW1pdHRlci5lbWl0KCdyZXN1bWUnKVxuXG4gICAgICBwcm9jZXNzLnJlbW92ZUxpc3RlbmVyKCdTSUdDT05UJywgcmVzdW1lSGFuZGxlcilcbiAgICB9XG5cbiAgICBwcm9jZXNzLm9uKCdTSUdDT05UJywgcmVzdW1lSGFuZGxlcilcbiAgICBwcm9jZXNzLmtpbGwocHJvY2Vzcy5waWQsICdTSUdTVE9QJylcbiAgfVxufVxuXG4vLyBIZWxwZXIgdG8gcHJvY2VzcyBhbGwga2V5cyB3aXRoaW4gYSBzaW5nbGUgZGlzY3JldGUgdXBkYXRlIGNvbnRleHQuXG4vLyBkaXNjcmV0ZVVwZGF0ZXMgZXhwZWN0cyAoZm4sIGEsIGIsIGMsIGQpIC0+IGZuKGEsIGIsIGMsIGQpXG5mdW5jdGlvbiBwcm9jZXNzS2V5c0luQmF0Y2goXG4gIGFwcDogQXBwLFxuICBpdGVtczogUGFyc2VkSW5wdXRbXSxcbiAgX3VudXNlZDE6IHVuZGVmaW5lZCxcbiAgX3VudXNlZDI6IHVuZGVmaW5lZCxcbik6IHZvaWQge1xuICAvLyBVcGRhdGUgaW50ZXJhY3Rpb24gdGltZSBmb3Igbm90aWZpY2F0aW9uIHRpbWVvdXQgdHJhY2tpbmcuXG4gIC8vIFRoaXMgaXMgY2FsbGVkIGZyb20gdGhlIGNlbnRyYWwgaW5wdXQgaGFuZGxlciB0byBhdm9pZCBoYXZpbmcgbXVsdGlwbGVcbiAgLy8gc3RkaW4gbGlzdGVuZXJzIHRoYXQgY2FuIGNhdXNlIHJhY2UgY29uZGl0aW9ucyBhbmQgZHJvcHBlZCBpbnB1dC5cbiAgLy8gVGVybWluYWwgcmVzcG9uc2VzIChraW5kOiAncmVzcG9uc2UnKSBhcmUgYXV0b21hdGVkLCBub3QgdXNlciBpbnB1dC5cbiAgLy8gTW9kZS0xMDAzIG5vLWJ1dHRvbiBtb3Rpb24gaXMgYWxzbyBleGNsdWRlZCDigJQgcGFzc2l2ZSBjdXJzb3IgZHJpZnQgaXNcbiAgLy8gbm90IGVuZ2FnZW1lbnQgKHdvdWxkIHN1cHByZXNzIGlkbGUgbm90aWZpY2F0aW9ucyArIGRlZmVyIGhvdXNla2VlcGluZykuXG4gIGlmIChcbiAgICBpdGVtcy5zb21lKFxuICAgICAgaSA9PlxuICAgICAgICBpLmtpbmQgPT09ICdrZXknIHx8XG4gICAgICAgIChpLmtpbmQgPT09ICdtb3VzZScgJiZcbiAgICAgICAgICAhKChpLmJ1dHRvbiAmIDB4MjApICE9PSAwICYmIChpLmJ1dHRvbiAmIDB4MDMpID09PSAzKSksXG4gICAgKVxuICApIHtcbiAgICB1cGRhdGVMYXN0SW50ZXJhY3Rpb25UaW1lKClcbiAgfVxuXG4gIGZvciAoY29uc3QgaXRlbSBvZiBpdGVtcykge1xuICAgIC8vIFRlcm1pbmFsIHJlc3BvbnNlcyAoREVDUlBNLCBEQTEsIE9TQyByZXBsaWVzLCBldGMuKSBhcmUgbm90IHVzZXJcbiAgICAvLyBpbnB1dCDigJQgcm91dGUgdGhlbSB0byB0aGUgcXVlcmllciB0byByZXNvbHZlIHBlbmRpbmcgcHJvbWlzZXMuXG4gICAgaWYgKGl0ZW0ua2luZCA9PT0gJ3Jlc3BvbnNlJykge1xuICAgICAgYXBwLnF1ZXJpZXIub25SZXNwb25zZShpdGVtLnJlc3BvbnNlKVxuICAgICAgY29udGludWVcbiAgICB9XG5cbiAgICAvLyBNb3VzZSBjbGljay9kcmFnIGV2ZW50cyB1cGRhdGUgc2VsZWN0aW9uIHN0YXRlIChmdWxsc2NyZWVuIG9ubHkpLlxuICAgIC8vIFRlcm1pbmFsIHNlbmRzIDEtaW5kZXhlZCBjb2wvcm93OyBjb252ZXJ0IHRvIDAtaW5kZXhlZCBmb3IgdGhlXG4gICAgLy8gc2NyZWVuIGJ1ZmZlci4gQnV0dG9uIGJpdCAweDIwID0gZHJhZyAobW90aW9uIHdoaWxlIGJ1dHRvbiBoZWxkKS5cbiAgICBpZiAoaXRlbS5raW5kID09PSAnbW91c2UnKSB7XG4gICAgICBoYW5kbGVNb3VzZUV2ZW50KGFwcCwgaXRlbSlcbiAgICAgIGNvbnRpbnVlXG4gICAgfVxuXG4gICAgY29uc3Qgc2VxdWVuY2UgPSBpdGVtLnNlcXVlbmNlXG5cbiAgICAvLyBIYW5kbGUgdGVybWluYWwgZm9jdXMgZXZlbnRzIChERUNTRVQgMTAwNClcbiAgICBpZiAoc2VxdWVuY2UgPT09IEZPQ1VTX0lOKSB7XG4gICAgICBhcHAuaGFuZGxlVGVybWluYWxGb2N1cyh0cnVlKVxuICAgICAgY29uc3QgZXZlbnQgPSBuZXcgVGVybWluYWxGb2N1c0V2ZW50KCd0ZXJtaW5hbGZvY3VzJylcbiAgICAgIGFwcC5pbnRlcm5hbF9ldmVudEVtaXR0ZXIuZW1pdCgndGVybWluYWxmb2N1cycsIGV2ZW50KVxuICAgICAgY29udGludWVcbiAgICB9XG4gICAgaWYgKHNlcXVlbmNlID09PSBGT0NVU19PVVQpIHtcbiAgICAgIGFwcC5oYW5kbGVUZXJtaW5hbEZvY3VzKGZhbHNlKVxuICAgICAgLy8gRGVmZW5zaXZlOiBpZiB3ZSBsb3N0IHRoZSByZWxlYXNlIGV2ZW50IChtb3VzZSByZWxlYXNlZCBvdXRzaWRlXG4gICAgICAvLyB0ZXJtaW5hbCB3aW5kb3cg4oCUIHNvbWUgZW11bGF0b3JzIGRyb3AgaXQgcmF0aGVyIHRoYW4gY2FwdHVyaW5nIHRoZVxuICAgICAgLy8gcG9pbnRlciksIGZvY3VzLW91dCBpcyB0aGUgbmV4dCBvYnNlcnZhYmxlIHNpZ25hbCB0aGF0IHRoZSBkcmFnIGlzXG4gICAgICAvLyBvdmVyLiBXaXRob3V0IHRoaXMsIGRyYWctdG8tc2Nyb2xsJ3MgdGltZXIgcnVucyB1bnRpbCB0aGUgc2Nyb2xsXG4gICAgICAvLyBib3VuZGFyeSBpcyBoaXQuXG4gICAgICBpZiAoYXBwLnByb3BzLnNlbGVjdGlvbi5pc0RyYWdnaW5nKSB7XG4gICAgICAgIGZpbmlzaFNlbGVjdGlvbihhcHAucHJvcHMuc2VsZWN0aW9uKVxuICAgICAgICBhcHAucHJvcHMub25TZWxlY3Rpb25DaGFuZ2UoKVxuICAgICAgfVxuICAgICAgY29uc3QgZXZlbnQgPSBuZXcgVGVybWluYWxGb2N1c0V2ZW50KCd0ZXJtaW5hbGJsdXInKVxuICAgICAgYXBwLmludGVybmFsX2V2ZW50RW1pdHRlci5lbWl0KCd0ZXJtaW5hbGJsdXInLCBldmVudClcbiAgICAgIGNvbnRpbnVlXG4gICAgfVxuXG4gICAgLy8gRmFpbHNhZmU6IGlmIHdlIHJlY2VpdmUgaW5wdXQsIHRoZSB0ZXJtaW5hbCBtdXN0IGJlIGZvY3VzZWRcbiAgICBpZiAoIWdldFRlcm1pbmFsRm9jdXNlZCgpKSB7XG4gICAgICBzZXRUZXJtaW5hbEZvY3VzZWQodHJ1ZSlcbiAgICB9XG5cbiAgICAvLyBIYW5kbGUgQ3RybCtaIChzdXNwZW5kKSB1c2luZyBwYXJzZWQga2V5IHRvIHN1cHBvcnQgYm90aCByYXcgKFxceDFhKSBhbmRcbiAgICAvLyBDU0kgdSBmb3JtYXQgKFxceDFiWzEyMjs1dSkgZnJvbSBLaXR0eSBrZXlib2FyZCBwcm90b2NvbCB0ZXJtaW5hbHNcbiAgICBpZiAoaXRlbS5uYW1lID09PSAneicgJiYgaXRlbS5jdHJsICYmIFNVUFBPUlRTX1NVU1BFTkQpIHtcbiAgICAgIGFwcC5oYW5kbGVTdXNwZW5kKClcbiAgICAgIGNvbnRpbnVlXG4gICAgfVxuXG4gICAgYXBwLmhhbmRsZUlucHV0KHNlcXVlbmNlKVxuICAgIGNvbnN0IGV2ZW50ID0gbmV3IElucHV0RXZlbnQoaXRlbSlcbiAgICBhcHAuaW50ZXJuYWxfZXZlbnRFbWl0dGVyLmVtaXQoJ2lucHV0JywgZXZlbnQpXG5cbiAgICAvLyBBbHNvIGRpc3BhdGNoIHRocm91Z2ggdGhlIERPTSB0cmVlIHNvIG9uS2V5RG93biBoYW5kbGVycyBmaXJlLlxuICAgIGFwcC5wcm9wcy5kaXNwYXRjaEtleWJvYXJkRXZlbnQoaXRlbSlcbiAgfVxufVxuXG4vKiogRXhwb3J0ZWQgZm9yIHRlc3RpbmcuIE11dGF0ZXMgYXBwLnByb3BzLnNlbGVjdGlvbiBhbmQgY2xpY2svaG92ZXIgc3RhdGUuICovXG5leHBvcnQgZnVuY3Rpb24gaGFuZGxlTW91c2VFdmVudChhcHA6IEFwcCwgbTogUGFyc2VkTW91c2UpOiB2b2lkIHtcbiAgLy8gQWxsb3cgZGlzYWJsaW5nIGNsaWNrIGhhbmRsaW5nIHdoaWxlIGtlZXBpbmcgd2hlZWwgc2Nyb2xsICh3aGljaCBnb2VzXG4gIC8vIHRocm91Z2ggdGhlIGtleWJpbmRpbmcgc3lzdGVtIGFzICd3aGVlbHVwJy8nd2hlZWxkb3duJywgbm90IGhlcmUpLlxuICBpZiAoaXNNb3VzZUNsaWNrc0Rpc2FibGVkKCkpIHJldHVyblxuXG4gIGNvbnN0IHNlbCA9IGFwcC5wcm9wcy5zZWxlY3Rpb25cbiAgLy8gVGVybWluYWwgY29vcmRzIGFyZSAxLWluZGV4ZWQ7IHNjcmVlbiBidWZmZXIgaXMgMC1pbmRleGVkXG4gIGNvbnN0IGNvbCA9IG0uY29sIC0gMVxuICBjb25zdCByb3cgPSBtLnJvdyAtIDFcbiAgY29uc3QgYmFzZUJ1dHRvbiA9IG0uYnV0dG9uICYgMHgwM1xuXG4gIGlmIChtLmFjdGlvbiA9PT0gJ3ByZXNzJykge1xuICAgIGlmICgobS5idXR0b24gJiAweDIwKSAhPT0gMCAmJiBiYXNlQnV0dG9uID09PSAzKSB7XG4gICAgICAvLyBNb2RlLTEwMDMgbW90aW9uIHdpdGggbm8gYnV0dG9uIGhlbGQuIERpc3BhdGNoIGhvdmVyOyBza2lwIHRoZVxuICAgICAgLy8gcmVzdCBvZiB0aGlzIGhhbmRsZXIgKG5vIHNlbGVjdGlvbiwgbm8gY2xpY2stY291bnQgc2lkZSBlZmZlY3RzKS5cbiAgICAgIC8vIExvc3QtcmVsZWFzZSByZWNvdmVyeTogbm8tYnV0dG9uIG1vdGlvbiB3aGlsZSBpc0RyYWdnaW5nPXRydWUgbWVhbnNcbiAgICAgIC8vIHRoZSByZWxlYXNlIGhhcHBlbmVkIG91dHNpZGUgdGhlIHRlcm1pbmFsIHdpbmRvdyAoaVRlcm0yIGRvZXNuJ3RcbiAgICAgIC8vIGNhcHR1cmUgdGhlIHBvaW50ZXIgcGFzdCB3aW5kb3cgYm91bmRzLCBzbyB0aGUgU0dSICdtJyBuZXZlclxuICAgICAgLy8gYXJyaXZlcykuIEZpbmlzaCB0aGUgc2VsZWN0aW9uIGhlcmUgc28gY29weS1vbi1zZWxlY3QgZmlyZXMuIFRoZVxuICAgICAgLy8gRk9DVVNfT1VUIGhhbmRsZXIgY292ZXJzIHRoZSBcInN3aXRjaGVkIGFwcHNcIiBjYXNlIGJ1dCBub3QgXCJyZWxlYXNlZFxuICAgICAgLy8gcGFzdCB0aGUgZWRnZSwgY2FtZSBiYWNrXCIg4oCUIGFuZCB0bXV4IGRyb3BzIGZvY3VzIGV2ZW50cyB1bmxlc3NcbiAgICAgIC8vIGBmb2N1cy1ldmVudHMgb25gIGlzIHNldCwgc28gdGhpcyBpcyB0aGUgbW9yZSByZWxpYWJsZSBzaWduYWwuXG4gICAgICBpZiAoc2VsLmlzRHJhZ2dpbmcpIHtcbiAgICAgICAgZmluaXNoU2VsZWN0aW9uKHNlbClcbiAgICAgICAgYXBwLnByb3BzLm9uU2VsZWN0aW9uQ2hhbmdlKClcbiAgICAgIH1cbiAgICAgIGlmIChjb2wgPT09IGFwcC5sYXN0SG92ZXJDb2wgJiYgcm93ID09PSBhcHAubGFzdEhvdmVyUm93KSByZXR1cm5cbiAgICAgIGFwcC5sYXN0SG92ZXJDb2wgPSBjb2xcbiAgICAgIGFwcC5sYXN0SG92ZXJSb3cgPSByb3dcbiAgICAgIGFwcC5wcm9wcy5vbkhvdmVyQXQoY29sLCByb3cpXG4gICAgICByZXR1cm5cbiAgICB9XG4gICAgaWYgKGJhc2VCdXR0b24gIT09IDApIHtcbiAgICAgIC8vIE5vbi1sZWZ0IHByZXNzIGJyZWFrcyB0aGUgbXVsdGktY2xpY2sgY2hhaW4uXG4gICAgICBhcHAuY2xpY2tDb3VudCA9IDBcbiAgICAgIHJldHVyblxuICAgIH1cbiAgICBpZiAoKG0uYnV0dG9uICYgMHgyMCkgIT09IDApIHtcbiAgICAgIC8vIERyYWcgbW90aW9uOiBtb2RlLWF3YXJlIGV4dGVuc2lvbiAoY2hhci93b3JkL2xpbmUpLiBvblNlbGVjdGlvbkRyYWdcbiAgICAgIC8vIGNhbGxzIG5vdGlmeVNlbGVjdGlvbkNoYW5nZSBpbnRlcm5hbGx5IOKAlCBubyBleHRyYSBvblNlbGVjdGlvbkNoYW5nZS5cbiAgICAgIGFwcC5wcm9wcy5vblNlbGVjdGlvbkRyYWcoY29sLCByb3cpXG4gICAgICByZXR1cm5cbiAgICB9XG4gICAgLy8gTG9zdC1yZWxlYXNlIGZhbGxiYWNrIGZvciBtb2RlLTEwMDItb25seSB0ZXJtaW5hbHM6IGEgZnJlc2ggcHJlc3NcbiAgICAvLyB3aGlsZSBpc0RyYWdnaW5nPXRydWUgbWVhbnMgdGhlIHByZXZpb3VzIHJlbGVhc2Ugd2FzIGRyb3BwZWQgKGN1cnNvclxuICAgIC8vIGxlZnQgdGhlIHdpbmRvdykuIEZpbmlzaCB0aGF0IHNlbGVjdGlvbiBzbyBjb3B5LW9uLXNlbGVjdCBmaXJlc1xuICAgIC8vIGJlZm9yZSBzdGFydFNlbGVjdGlvbi9vbk11bHRpQ2xpY2sgY2xvYmJlcnMgaXQuIE1vZGUtMTAwMyB0ZXJtaW5hbHNcbiAgICAvLyBoaXQgdGhlIG5vLWJ1dHRvbi1tb3Rpb24gcmVjb3ZlcnkgYWJvdmUgaW5zdGVhZCwgc28gdGhpcyBpcyByYXJlLlxuICAgIGlmIChzZWwuaXNEcmFnZ2luZykge1xuICAgICAgZmluaXNoU2VsZWN0aW9uKHNlbClcbiAgICAgIGFwcC5wcm9wcy5vblNlbGVjdGlvbkNoYW5nZSgpXG4gICAgfVxuICAgIC8vIEZyZXNoIGxlZnQgcHJlc3MuIERldGVjdCBtdWx0aS1jbGljayBIRVJFIChub3Qgb24gcmVsZWFzZSkgc28gdGhlXG4gICAgLy8gd29yZC9saW5lIGhpZ2hsaWdodCBhcHBlYXJzIGltbWVkaWF0ZWx5IGFuZCBhIHN1YnNlcXVlbnQgZHJhZyBjYW5cbiAgICAvLyBleHRlbmQgYnkgd29yZC9saW5lIGxpa2UgbmF0aXZlIG1hY09TLiBQcmV2aW91c2x5IGRldGVjdGVkIG9uXG4gICAgLy8gcmVsZWFzZSwgd2hpY2ggbWVhbnQgKGEpIHZpc2libGUgbGF0ZW5jeSBiZWZvcmUgdGhlIHdvcmQgaGlnaGxpZ2h0c1xuICAgIC8vIGFuZCAoYikgZG91YmxlLWNsaWNrK2RyYWcgZmVsbCB0aHJvdWdoIHRvIGNoYXItbW9kZSBzZWxlY3Rpb24uXG4gICAgY29uc3Qgbm93ID0gRGF0ZS5ub3coKVxuICAgIGNvbnN0IG5lYXJMYXN0ID1cbiAgICAgIG5vdyAtIGFwcC5sYXN0Q2xpY2tUaW1lIDwgTVVMVElfQ0xJQ0tfVElNRU9VVF9NUyAmJlxuICAgICAgTWF0aC5hYnMoY29sIC0gYXBwLmxhc3RDbGlja0NvbCkgPD0gTVVMVElfQ0xJQ0tfRElTVEFOQ0UgJiZcbiAgICAgIE1hdGguYWJzKHJvdyAtIGFwcC5sYXN0Q2xpY2tSb3cpIDw9IE1VTFRJX0NMSUNLX0RJU1RBTkNFXG4gICAgYXBwLmNsaWNrQ291bnQgPSBuZWFyTGFzdCA/IGFwcC5jbGlja0NvdW50ICsgMSA6IDFcbiAgICBhcHAubGFzdENsaWNrVGltZSA9IG5vd1xuICAgIGFwcC5sYXN0Q2xpY2tDb2wgPSBjb2xcbiAgICBhcHAubGFzdENsaWNrUm93ID0gcm93XG4gICAgaWYgKGFwcC5jbGlja0NvdW50ID49IDIpIHtcbiAgICAgIC8vIENhbmNlbCBhbnkgcGVuZGluZyBoeXBlcmxpbmstb3BlbiBmcm9tIHRoZSBmaXJzdCBjbGljayDigJQgdGhpcyBpc1xuICAgICAgLy8gYSBkb3VibGUtY2xpY2ssIG5vdCBhIHNpbmdsZS1jbGljayBvbiBhIGxpbmsuXG4gICAgICBpZiAoYXBwLnBlbmRpbmdIeXBlcmxpbmtUaW1lcikge1xuICAgICAgICBjbGVhclRpbWVvdXQoYXBwLnBlbmRpbmdIeXBlcmxpbmtUaW1lcilcbiAgICAgICAgYXBwLnBlbmRpbmdIeXBlcmxpbmtUaW1lciA9IG51bGxcbiAgICAgIH1cbiAgICAgIC8vIENhcCBhdCAzIChsaW5lIHNlbGVjdCkgZm9yIHF1YWRydXBsZSsgY2xpY2tzLlxuICAgICAgY29uc3QgY291bnQgPSBhcHAuY2xpY2tDb3VudCA9PT0gMiA/IDIgOiAzXG4gICAgICBhcHAucHJvcHMub25NdWx0aUNsaWNrKGNvbCwgcm93LCBjb3VudClcbiAgICAgIHJldHVyblxuICAgIH1cbiAgICBzdGFydFNlbGVjdGlvbihzZWwsIGNvbCwgcm93KVxuICAgIC8vIFNHUiBiaXQgMHgwOCA9IGFsdCAoeHRlcm0uanMgd2lyZXMgYWx0S2V5IGhlcmUsIG5vdCBtZXRhS2V5IOKAlCBzZWVcbiAgICAvLyBjb21tZW50IGF0IHRoZSBoeXBlcmxpbmstb3BlbiBndWFyZCBiZWxvdykuIE9uIG1hY09TIHh0ZXJtLmpzLFxuICAgIC8vIHJlY2VpdmluZyBhbHQgbWVhbnMgbWFjT3B0aW9uQ2xpY2tGb3JjZXNTZWxlY3Rpb24gaXMgT0ZGIChvdGhlcndpc2VcbiAgICAvLyB4dGVybS5qcyB3b3VsZCBoYXZlIGNvbnN1bWVkIHRoZSBldmVudCBmb3IgbmF0aXZlIHNlbGVjdGlvbikuXG4gICAgc2VsLmxhc3RQcmVzc0hhZEFsdCA9IChtLmJ1dHRvbiAmIDB4MDgpICE9PSAwXG4gICAgYXBwLnByb3BzLm9uU2VsZWN0aW9uQ2hhbmdlKClcbiAgICByZXR1cm5cbiAgfVxuXG4gIC8vIFJlbGVhc2U6IGVuZCB0aGUgZHJhZyBldmVuIGZvciBub24temVybyBidXR0b24gY29kZXMuIFNvbWUgdGVybWluYWxzXG4gIC8vIGVuY29kZSByZWxlYXNlIHdpdGggdGhlIG1vdGlvbiBiaXQgb3IgYnV0dG9uPTMgXCJubyBidXR0b25cIiAoY2FycmllZFxuICAvLyBvdmVyIGZyb20gcHJlLVNHUiBYMTAgZW5jb2RpbmcpIOKAlCBmaWx0ZXJpbmcgdGhvc2Ugd291bGQgb3JwaGFuXG4gIC8vIGlzRHJhZ2dpbmc9dHJ1ZSBhbmQgbGVhdmUgZHJhZy10by1zY3JvbGwncyB0aW1lciBydW5uaW5nIHVudGlsIHRoZVxuICAvLyBzY3JvbGwgYm91bmRhcnkuIE9ubHkgYWN0IG9uIG5vbi1sZWZ0IHJlbGVhc2VzIHdoZW4gd2UgQVJFIGRyYWdnaW5nXG4gIC8vIChzbyBhbiB1bnJlbGF0ZWQgbWlkZGxlL3JpZ2h0IGNsaWNrLXJlbGVhc2UgZG9lc24ndCB0b3VjaCBzZWxlY3Rpb24pLlxuICBpZiAoYmFzZUJ1dHRvbiAhPT0gMCkge1xuICAgIGlmICghc2VsLmlzRHJhZ2dpbmcpIHJldHVyblxuICAgIGZpbmlzaFNlbGVjdGlvbihzZWwpXG4gICAgYXBwLnByb3BzLm9uU2VsZWN0aW9uQ2hhbmdlKClcbiAgICByZXR1cm5cbiAgfVxuICBmaW5pc2hTZWxlY3Rpb24oc2VsKVxuICAvLyBOT1RFOiB1bmxpa2UgdGhlIG9sZCByZWxlYXNlLWJhc2VkIGRldGVjdGlvbiB3ZSBkbyBOT1QgcmVzZXQgY2xpY2tDb3VudFxuICAvLyBvbiByZWxlYXNlLWFmdGVyLWRyYWcuIFRoaXMgYWxpZ25zIHdpdGggTlNFdmVudC5jbGlja0NvdW50IHNlbWFudGljczpcbiAgLy8gYW4gaW50ZXJ2ZW5pbmcgZHJhZyBkb2Vzbid0IGJyZWFrIHRoZSBjbGljayBjaGFpbi4gUHJhY3RpY2FsIHVwc2lkZTpcbiAgLy8gdHJhY2twYWQgaml0dGVyIGR1cmluZyBhbiBpbnRlbmRlZCBkb3VibGUtY2xpY2sgKHByZXNz4oaSd29iYmxl4oaScmVsZWFzZVxuICAvLyDihpJwcmVzcykgbm93IGNvcnJlY3RseSByZXNvbHZlcyB0byB3b3JkLXNlbGVjdCBpbnN0ZWFkIG9mIGJyZWFraW5nIHRvIGFcbiAgLy8gZnJlc2ggc2luZ2xlIGNsaWNrLiBUaGUgbmVhckxhc3Qgd2luZG93ICg1MDBtcywgMSBjZWxsKSBib3VuZHMgdGhlXG4gIC8vIGVmZmVjdCDigJQgYSBkZWxpYmVyYXRlIGRyYWcgcGFzdCB0aGF0IGp1c3Qgc3RhcnRzIGEgZnJlc2ggY2hhaW4uXG4gIC8vIEEgcHJlc3MrcmVsZWFzZSB3aXRoIG5vIGRyYWcgaW4gY2hhciBtb2RlIGlzIGEgY2xpY2s6IGFuY2hvciBzZXQsXG4gIC8vIGZvY3VzIG51bGwg4oaSIGhhc1NlbGVjdGlvbiBmYWxzZS4gSW4gd29yZC9saW5lIG1vZGUgdGhlIHByZXNzIGFscmVhZHlcbiAgLy8gc2V0IGFuY2hvcitmb2N1cyAoaGFzU2VsZWN0aW9uIHRydWUpLCBzbyByZWxlYXNlIGp1c3Qga2VlcHMgdGhlXG4gIC8vIGhpZ2hsaWdodC4gVGhlIGFuY2hvciBjaGVjayBndWFyZHMgYWdhaW5zdCBhbiBvcnBoYW5lZCByZWxlYXNlIChub1xuICAvLyBwcmlvciBwcmVzcyDigJQgZS5nLiBidXR0b24gd2FzIGhlbGQgd2hlbiBtb3VzZSB0cmFja2luZyB3YXMgZW5hYmxlZCkuXG4gIGlmICghaGFzU2VsZWN0aW9uKHNlbCkgJiYgc2VsLmFuY2hvcikge1xuICAgIC8vIFNpbmdsZSBjbGljazogZGlzcGF0Y2ggRE9NIGNsaWNrIGltbWVkaWF0ZWx5IChjdXJzb3IgcmVwb3NpdGlvbmluZ1xuICAgIC8vIGV0Yy4gYXJlIGxhdGVuY3ktc2Vuc2l0aXZlKS4gSWYgbm8gRE9NIGhhbmRsZXIgY29uc3VtZWQgaXQsIGRlZmVyXG4gICAgLy8gdGhlIGh5cGVybGluayBjaGVjayBzbyBhIHNlY29uZCBjbGljayBjYW4gY2FuY2VsIGl0LlxuICAgIGlmICghYXBwLnByb3BzLm9uQ2xpY2tBdChjb2wsIHJvdykpIHtcbiAgICAgIC8vIFJlc29sdmUgdGhlIGh5cGVybGluayBVUkwgc3luY2hyb25vdXNseSB3aGlsZSB0aGUgc2NyZWVuIGJ1ZmZlclxuICAgICAgLy8gc3RpbGwgcmVmbGVjdHMgd2hhdCB0aGUgdXNlciBjbGlja2VkIOKAlCBkZWZlcnJpbmcgb25seSB0aGVcbiAgICAgIC8vIGJyb3dzZXItb3BlbiBzbyBkb3VibGUtY2xpY2sgY2FuIGNhbmNlbCBpdC5cbiAgICAgIGNvbnN0IHVybCA9IGFwcC5wcm9wcy5nZXRIeXBlcmxpbmtBdChjb2wsIHJvdylcbiAgICAgIC8vIHh0ZXJtLmpzIChWUyBDb2RlLCBDdXJzb3IsIFdpbmRzdXJmLCBldGMuKSBoYXMgaXRzIG93biBPU0MgOCBsaW5rXG4gICAgICAvLyBoYW5kbGVyIHRoYXQgZmlyZXMgb24gQ21kK2NsaWNrICp3aXRob3V0IGNvbnN1bWluZyB0aGUgbW91c2UgZXZlbnQqXG4gICAgICAvLyAoTGlua2lmaWVyLl9oYW5kbGVNb3VzZVVwIGNhbGxzIGxpbmsuYWN0aXZhdGUoKSBidXQgbmV2ZXJcbiAgICAgIC8vIHByZXZlbnREZWZhdWx0L3N0b3BQcm9wYWdhdGlvbikuIFRoZSBjbGljayBpcyBhbHNvIGZvcndhcmRlZCB0byB0aGVcbiAgICAgIC8vIHB0eSBhcyBTR1IsIHNvIGJvdGggVlMgQ29kZSdzIHRlcm1pbmFsTGlua01hbmFnZXIgQU5EIG91ciBoYW5kbGVyXG4gICAgICAvLyBoZXJlIHdvdWxkIG9wZW4gdGhlIFVSTCDigJQgdHdpY2UuIFdlIGNhbid0IGZpbHRlciBvbiBDbWQ6IHh0ZXJtLmpzXG4gICAgICAvLyBkcm9wcyBtZXRhS2V5IGJlZm9yZSBTR1IgZW5jb2RpbmcgKElDb3JlTW91c2VFdmVudCBoYXMgbm8gbWV0YVxuICAgICAgLy8gZmllbGQ7IHRoZSBTR1IgYml0IHdlIGNhbGwgJ21ldGEnIGlzIHdpcmVkIHRvIGFsdCkuIExldCB4dGVybS5qc1xuICAgICAgLy8gb3duIGxpbmstb3BlbmluZzsgQ21kK2NsaWNrIGlzIHRoZSBuYXRpdmUgVVggdGhlcmUgYW55d2F5LlxuICAgICAgLy8gVEVSTV9QUk9HUkFNIGlzIHRoZSBzeW5jIGZhc3QtcGF0aDsgaXNYdGVybUpzKCkgaXMgdGhlIFhUVkVSU0lPTlxuICAgICAgLy8gcHJvYmUgcmVzdWx0IChjYXRjaGVzIFNTSCArIG5vbi1WUyBDb2RlIGVtYmVkZGVycyBsaWtlIEh5cGVyKS5cbiAgICAgIGlmICh1cmwgJiYgcHJvY2Vzcy5lbnYuVEVSTV9QUk9HUkFNICE9PSAndnNjb2RlJyAmJiAhaXNYdGVybUpzKCkpIHtcbiAgICAgICAgLy8gQ2xlYXIgYW55IHByaW9yIHBlbmRpbmcgdGltZXIg4oCUIGNsaWNraW5nIGEgc2Vjb25kIGxpbmtcbiAgICAgICAgLy8gc3VwZXJzZWRlcyB0aGUgZmlyc3QgKG9ubHkgdGhlIGxhdGVzdCBjbGljayBvcGVucykuXG4gICAgICAgIGlmIChhcHAucGVuZGluZ0h5cGVybGlua1RpbWVyKSB7XG4gICAgICAgICAgY2xlYXJUaW1lb3V0KGFwcC5wZW5kaW5nSHlwZXJsaW5rVGltZXIpXG4gICAgICAgIH1cbiAgICAgICAgYXBwLnBlbmRpbmdIeXBlcmxpbmtUaW1lciA9IHNldFRpbWVvdXQoXG4gICAgICAgICAgKGFwcCwgdXJsKSA9PiB7XG4gICAgICAgICAgICBhcHAucGVuZGluZ0h5cGVybGlua1RpbWVyID0gbnVsbFxuICAgICAgICAgICAgYXBwLnByb3BzLm9uT3Blbkh5cGVybGluayh1cmwpXG4gICAgICAgICAgfSxcbiAgICAgICAgICBNVUxUSV9DTElDS19USU1FT1VUX01TLFxuICAgICAgICAgIGFwcCxcbiAgICAgICAgICB1cmwsXG4gICAgICAgIClcbiAgICAgIH1cbiAgICB9XG4gIH1cbiAgYXBwLnByb3BzLm9uU2VsZWN0aW9uQ2hhbmdlKClcbn1cbiJdLCJtYXBwaW5ncyI6IkFBQUEsT0FBT0EsS0FBSyxJQUFJQyxhQUFhLEVBQUUsS0FBS0MsU0FBUyxRQUFRLE9BQU87QUFDNUQsU0FBU0MseUJBQXlCLFFBQVEsMEJBQTBCO0FBQ3BFLFNBQVNDLGVBQWUsUUFBUSxzQkFBc0I7QUFDdEQsU0FBU0MsdUJBQXVCLFFBQVEsMkJBQTJCO0FBQ25FLFNBQVNDLFdBQVcsUUFBUSx5QkFBeUI7QUFDckQsU0FBU0MscUJBQXFCLFFBQVEsMkJBQTJCO0FBQ2pFLFNBQVNDLFFBQVEsUUFBUSxvQkFBb0I7QUFDN0MsU0FBU0MsWUFBWSxRQUFRLHNCQUFzQjtBQUNuRCxTQUFTQyxVQUFVLFFBQVEsMEJBQTBCO0FBQ3JELFNBQVNDLGtCQUFrQixRQUFRLG1DQUFtQztBQUN0RSxTQUNFQyxhQUFhLEVBQ2IsS0FBS0MsV0FBVyxFQUNoQixLQUFLQyxTQUFTLEVBQ2QsS0FBS0MsV0FBVyxFQUNoQkMsdUJBQXVCLFFBQ2xCLHNCQUFzQjtBQUM3QixPQUFPQyxVQUFVLE1BQU0sa0JBQWtCO0FBQ3pDLFNBQ0VDLGVBQWUsRUFDZkMsWUFBWSxFQUNaLEtBQUtDLGNBQWMsRUFDbkJDLGNBQWMsUUFDVCxpQkFBaUI7QUFDeEIsU0FDRUMsU0FBUyxFQUNUQyxnQkFBZ0IsRUFDaEJDLG9CQUFvQixRQUNmLGdCQUFnQjtBQUN2QixTQUNFQyxrQkFBa0IsRUFDbEJDLGtCQUFrQixRQUNiLDRCQUE0QjtBQUNuQyxTQUFTQyxlQUFlLEVBQUVDLFNBQVMsUUFBUSx3QkFBd0I7QUFDbkUsU0FDRUMsc0JBQXNCLEVBQ3RCQyx5QkFBeUIsRUFDekJDLHFCQUFxQixFQUNyQkMsd0JBQXdCLEVBQ3hCQyxRQUFRLEVBQ1JDLFNBQVMsUUFDSixrQkFBa0I7QUFDekIsU0FDRUMsR0FBRyxFQUNIQyxHQUFHLEVBQ0hDLHNCQUFzQixFQUN0QkMsR0FBRyxFQUNIQyxHQUFHLEVBQ0hDLFdBQVcsRUFDWEMsV0FBVyxRQUNOLGtCQUFrQjtBQUN6QixPQUFPQyxVQUFVLE1BQU0saUJBQWlCO0FBQ3hDLFNBQVNDLGFBQWEsUUFBUSxtQkFBbUI7QUFDakQsT0FBT0Msd0JBQXdCLElBQzdCLEtBQUtDLHVCQUF1QixRQUN2QiwrQkFBK0I7QUFDdEMsT0FBT0MsYUFBYSxNQUFNLG9CQUFvQjtBQUM5QyxPQUFPQyxZQUFZLE1BQU0sbUJBQW1CO0FBQzVDLFNBQVNDLHFCQUFxQixRQUFRLDJCQUEyQjtBQUNqRSxTQUFTQyxtQkFBbUIsUUFBUSwwQkFBMEI7O0FBRTlEO0FBQ0EsTUFBTUMsZ0JBQWdCLEdBQUdDLE9BQU8sQ0FBQ0MsUUFBUSxLQUFLLE9BQU87O0FBRXJEO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQSxNQUFNQyxtQkFBbUIsR0FBRyxJQUFJO0FBRWhDLEtBQUtDLEtBQUssR0FBRztFQUNYLFNBQVNDLFFBQVEsRUFBRXJELFNBQVM7RUFDNUIsU0FBU3NELEtBQUssRUFBRUMsTUFBTSxDQUFDQyxVQUFVO0VBQ2pDLFNBQVNDLE1BQU0sRUFBRUYsTUFBTSxDQUFDRyxXQUFXO0VBQ25DLFNBQVNDLE1BQU0sRUFBRUosTUFBTSxDQUFDRyxXQUFXO0VBQ25DLFNBQVNFLFdBQVcsRUFBRSxPQUFPO0VBQzdCLFNBQVNDLE1BQU0sRUFBRSxDQUFDQyxLQUFhLENBQVAsRUFBRUMsS0FBSyxFQUFFLEdBQUcsSUFBSTtFQUN4QyxTQUFTQyxlQUFlLEVBQUUsTUFBTTtFQUNoQyxTQUFTQyxZQUFZLEVBQUUsTUFBTTtFQUM3QjtFQUNBO0VBQ0E7RUFDQTtFQUNBLFNBQVNDLFNBQVMsRUFBRWhELGNBQWM7RUFDbEMsU0FBU2lELGlCQUFpQixFQUFFLEdBQUcsR0FBRyxJQUFJO0VBQ3RDO0VBQ0E7RUFDQTtFQUNBO0VBQ0EsU0FBU0MsU0FBUyxFQUFFLENBQUNDLEdBQUcsRUFBRSxNQUFNLEVBQUVDLEdBQUcsRUFBRSxNQUFNLEVBQUUsR0FBRyxPQUFPO0VBQ3pEO0VBQ0E7RUFDQTtFQUNBLFNBQVNDLFNBQVMsRUFBRSxDQUFDRixHQUFHLEVBQUUsTUFBTSxFQUFFQyxHQUFHLEVBQUUsTUFBTSxFQUFFLEdBQUcsSUFBSTtFQUN0RDtFQUNBO0VBQ0E7RUFDQSxTQUFTRSxjQUFjLEVBQUUsQ0FBQ0gsR0FBRyxFQUFFLE1BQU0sRUFBRUMsR0FBRyxFQUFFLE1BQU0sRUFBRSxHQUFHLE1BQU0sR0FBRyxTQUFTO0VBQ3pFO0VBQ0EsU0FBU0csZUFBZSxFQUFFLENBQUNDLEdBQUcsRUFBRSxNQUFNLEVBQUUsR0FBRyxJQUFJO0VBQy9DO0VBQ0E7RUFDQTtFQUNBO0VBQ0EsU0FBU0MsWUFBWSxFQUFFLENBQUNOLEdBQUcsRUFBRSxNQUFNLEVBQUVDLEdBQUcsRUFBRSxNQUFNLEVBQUVNLEtBQUssRUFBRSxDQUFDLEdBQUcsQ0FBQyxFQUFFLEdBQUcsSUFBSTtFQUN2RTtFQUNBO0VBQ0E7RUFDQSxTQUFTQyxlQUFlLEVBQUUsQ0FBQ1IsR0FBRyxFQUFFLE1BQU0sRUFBRUMsR0FBRyxFQUFFLE1BQU0sRUFBRSxHQUFHLElBQUk7RUFDNUQ7RUFDQTtFQUNBO0VBQ0E7RUFDQSxTQUFTUSxhQUFhLENBQUMsRUFBRSxHQUFHLEdBQUcsSUFBSTtFQUNuQztFQUNBO0VBQ0E7RUFDQTtFQUNBLFNBQVNDLG1CQUFtQixDQUFDLEVBQUVwQyx1QkFBdUI7RUFDdEQ7RUFDQTtFQUNBLFNBQVNxQyxxQkFBcUIsRUFBRSxDQUFDQyxTQUFTLEVBQUVyRSxTQUFTLEVBQUUsR0FBRyxJQUFJO0FBQ2hFLENBQUM7O0FBRUQ7QUFDQTtBQUNBLE1BQU1zRSxzQkFBc0IsR0FBRyxHQUFHO0FBQ2xDLE1BQU1DLG9CQUFvQixHQUFHLENBQUM7QUFFOUIsS0FBS0MsS0FBSyxHQUFHO0VBQ1gsU0FBU3RCLEtBQUssQ0FBQyxFQUFFQyxLQUFLO0FBQ3hCLENBQUM7O0FBRUQ7QUFDQTtBQUNBO0FBQ0EsZUFBZSxNQUFNc0IsR0FBRyxTQUFTdEYsYUFBYSxDQUFDcUQsS0FBSyxFQUFFZ0MsS0FBSyxDQUFDLENBQUM7RUFDM0QsT0FBT0UsV0FBVyxHQUFHLGFBQWE7RUFFbEMsT0FBT0Msd0JBQXdCQSxDQUFDekIsS0FBSyxFQUFFQyxLQUFLLEVBQUU7SUFDNUMsT0FBTztNQUFFRDtJQUFNLENBQUM7RUFDbEI7RUFFQSxTQUFTMEIsS0FBSyxHQUFHO0lBQ2YxQixLQUFLLEVBQUUyQjtFQUNULENBQUM7O0VBRUQ7RUFDQTtFQUNBQyxtQkFBbUIsR0FBRyxDQUFDO0VBRXZCQyxxQkFBcUIsR0FBRyxJQUFJcEYsWUFBWSxDQUFDLENBQUM7RUFDMUNxRixhQUFhLEdBQUdsRixhQUFhO0VBQzdCO0VBQ0FtRixxQkFBcUIsRUFBRXRDLE1BQU0sQ0FBQ3VDLE9BQU8sR0FBRyxJQUFJLEdBQUcsSUFBSTtFQUNuRDtFQUNBLFNBQVNDLGNBQWMsR0FBRyxFQUFFLEVBQUM7RUFDN0IsU0FBU0MsYUFBYSxHQUFHLEdBQUcsRUFBQzs7RUFFN0I7RUFDQTtFQUNBQyxPQUFPLEdBQUcsSUFBSXhFLGVBQWUsQ0FBQyxJQUFJLENBQUN5RSxLQUFLLENBQUN6QyxNQUFNLENBQUM7O0VBRWhEO0VBQ0E7RUFDQTtFQUNBMEMsYUFBYSxHQUFHLENBQUM7RUFDakJDLFlBQVksR0FBRyxDQUFDLENBQUM7RUFDakJDLFlBQVksR0FBRyxDQUFDLENBQUM7RUFDakJDLFVBQVUsR0FBRyxDQUFDO0VBQ2Q7RUFDQTtFQUNBO0VBQ0E7RUFDQUMscUJBQXFCLEVBQUVDLFVBQVUsQ0FBQyxPQUFPQyxVQUFVLENBQUMsR0FBRyxJQUFJLEdBQUcsSUFBSTtFQUNsRTtFQUNBO0VBQ0E7RUFDQUMsWUFBWSxHQUFHLENBQUMsQ0FBQztFQUNqQkMsWUFBWSxHQUFHLENBQUMsQ0FBQzs7RUFFakI7RUFDQTtFQUNBO0VBQ0FDLGFBQWEsR0FBR0MsSUFBSSxDQUFDQyxHQUFHLENBQUMsQ0FBQzs7RUFFMUI7RUFDQUMsa0JBQWtCQSxDQUFBLENBQUUsRUFBRSxPQUFPLENBQUM7SUFDNUIsT0FBTyxJQUFJLENBQUNiLEtBQUssQ0FBQzVDLEtBQUssQ0FBQzBELEtBQUs7RUFDL0I7RUFFQSxTQUFTQyxNQUFNQSxDQUFBLEVBQUc7SUFDaEIsT0FDRSxDQUFDLG1CQUFtQixDQUFDLFFBQVEsQ0FDM0IsS0FBSyxDQUFDLENBQUM7TUFDTEMsT0FBTyxFQUFFLElBQUksQ0FBQ2hCLEtBQUssQ0FBQ2xDLGVBQWU7TUFDbkNtRCxJQUFJLEVBQUUsSUFBSSxDQUFDakIsS0FBSyxDQUFDakM7SUFDbkIsQ0FBQyxDQUFDO0FBRVYsUUFBUSxDQUFDLFVBQVUsQ0FBQyxRQUFRLENBQ2xCLEtBQUssQ0FBQyxDQUFDO1FBQ0xtRCxJQUFJLEVBQUUsSUFBSSxDQUFDQztNQUNiLENBQUMsQ0FBQztBQUVaLFVBQVUsQ0FBQyxZQUFZLENBQUMsUUFBUSxDQUNwQixLQUFLLENBQUMsQ0FBQztVQUNML0QsS0FBSyxFQUFFLElBQUksQ0FBQzRDLEtBQUssQ0FBQzVDLEtBQUs7VUFDdkJnRSxVQUFVLEVBQUUsSUFBSSxDQUFDQyxnQkFBZ0I7VUFDakNSLGtCQUFrQixFQUFFLElBQUksQ0FBQ0Esa0JBQWtCLENBQUMsQ0FBQztVQUU3Q1Msb0JBQW9CLEVBQUUsSUFBSSxDQUFDdEIsS0FBSyxDQUFDdEMsV0FBVztVQUU1QytCLHFCQUFxQixFQUFFLElBQUksQ0FBQ0EscUJBQXFCO1VBQ2pEOEIsZ0JBQWdCLEVBQUUsSUFBSSxDQUFDeEI7UUFDekIsQ0FBQyxDQUFDO0FBRWQsWUFBWSxDQUFDLHFCQUFxQjtBQUNsQyxjQUFjLENBQUMsYUFBYTtBQUM1QixnQkFBZ0IsQ0FBQyx3QkFBd0IsQ0FBQyxRQUFRLENBQ2hDLEtBQUssQ0FBQyxDQUFDLElBQUksQ0FBQ0MsS0FBSyxDQUFDbkIsbUJBQW1CLEtBQUssTUFBTSxDQUFDLENBQUMsQ0FBQyxDQUFDO0FBRXRFLGtCQUFrQixDQUFDLElBQUksQ0FBQ1MsS0FBSyxDQUFDMUIsS0FBSyxHQUNmLENBQUMsYUFBYSxDQUFDLEtBQUssQ0FBQyxDQUFDLElBQUksQ0FBQzBCLEtBQUssQ0FBQzFCLEtBQUssSUFBSUMsS0FBSyxDQUFDLEdBQUcsR0FFbkQsSUFBSSxDQUFDbUMsS0FBSyxDQUFDN0MsUUFDWjtBQUNuQixnQkFBZ0IsRUFBRSx3QkFBd0IsQ0FBQyxRQUFRO0FBQ25ELGNBQWMsRUFBRSxhQUFhO0FBQzdCLFlBQVksRUFBRSxxQkFBcUI7QUFDbkMsVUFBVSxFQUFFLFlBQVksQ0FBQyxRQUFRO0FBQ2pDLFFBQVEsRUFBRSxVQUFVLENBQUMsUUFBUTtBQUM3QixNQUFNLEVBQUUsbUJBQW1CLENBQUMsUUFBUSxDQUFDO0VBRW5DO0VBRUEsU0FBU3FFLGlCQUFpQkEsQ0FBQSxFQUFHO0lBQzNCO0lBQ0EsSUFDRSxJQUFJLENBQUN4QixLQUFLLENBQUN6QyxNQUFNLENBQUN1RCxLQUFLLElBQ3ZCLENBQUM1RyxXQUFXLENBQUM2QyxPQUFPLENBQUMwRSxHQUFHLENBQUNDLHlCQUF5QixDQUFDLEVBQ25EO01BQ0EsSUFBSSxDQUFDMUIsS0FBSyxDQUFDekMsTUFBTSxDQUFDb0UsS0FBSyxDQUFDdkYsV0FBVyxDQUFDO0lBQ3RDO0VBQ0Y7RUFFQSxTQUFTd0Ysb0JBQW9CQSxDQUFBLEVBQUc7SUFDOUIsSUFBSSxJQUFJLENBQUM1QixLQUFLLENBQUN6QyxNQUFNLENBQUN1RCxLQUFLLEVBQUU7TUFDM0IsSUFBSSxDQUFDZCxLQUFLLENBQUN6QyxNQUFNLENBQUNvRSxLQUFLLENBQUN0RixXQUFXLENBQUM7SUFDdEM7O0lBRUE7SUFDQSxJQUFJLElBQUksQ0FBQ3NELHFCQUFxQixFQUFFO01BQzlCa0MsWUFBWSxDQUFDLElBQUksQ0FBQ2xDLHFCQUFxQixDQUFDO01BQ3hDLElBQUksQ0FBQ0EscUJBQXFCLEdBQUcsSUFBSTtJQUNuQztJQUNBLElBQUksSUFBSSxDQUFDVSxxQkFBcUIsRUFBRTtNQUM5QndCLFlBQVksQ0FBQyxJQUFJLENBQUN4QixxQkFBcUIsQ0FBQztNQUN4QyxJQUFJLENBQUNBLHFCQUFxQixHQUFHLElBQUk7SUFDbkM7SUFDQTtJQUNBLElBQUksSUFBSSxDQUFDUSxrQkFBa0IsQ0FBQyxDQUFDLEVBQUU7TUFDN0IsSUFBSSxDQUFDUSxnQkFBZ0IsQ0FBQyxLQUFLLENBQUM7SUFDOUI7RUFDRjtFQUVBLFNBQVNTLGlCQUFpQkEsQ0FBQ2xFLEtBQUssRUFBRUMsS0FBSyxFQUFFO0lBQ3ZDLElBQUksQ0FBQ3NELFVBQVUsQ0FBQ3ZELEtBQUssQ0FBQztFQUN4QjtFQUVBeUQsZ0JBQWdCLEdBQUdBLENBQUNVLFNBQVMsRUFBRSxPQUFPLENBQUMsRUFBRSxJQUFJLElBQUk7SUFDL0MsTUFBTTtNQUFFM0U7SUFBTSxDQUFDLEdBQUcsSUFBSSxDQUFDNEMsS0FBSztJQUU1QixJQUFJLENBQUMsSUFBSSxDQUFDYSxrQkFBa0IsQ0FBQyxDQUFDLEVBQUU7TUFDOUIsSUFBSXpELEtBQUssS0FBS0wsT0FBTyxDQUFDSyxLQUFLLEVBQUU7UUFDM0IsTUFBTSxJQUFJUyxLQUFLLENBQ2IscU1BQ0YsQ0FBQztNQUNILENBQUMsTUFBTTtRQUNMLE1BQU0sSUFBSUEsS0FBSyxDQUNiLDBKQUNGLENBQUM7TUFDSDtJQUNGO0lBRUFULEtBQUssQ0FBQzRFLFdBQVcsQ0FBQyxNQUFNLENBQUM7SUFFekIsSUFBSUQsU0FBUyxFQUFFO01BQ2I7TUFDQSxJQUFJLElBQUksQ0FBQ3ZDLG1CQUFtQixLQUFLLENBQUMsRUFBRTtRQUNsQztRQUNBO1FBQ0E7UUFDQTtRQUNBdkYsdUJBQXVCLENBQUMsQ0FBQztRQUN6Qm1ELEtBQUssQ0FBQzZFLEdBQUcsQ0FBQyxDQUFDO1FBQ1g3RSxLQUFLLENBQUNnRSxVQUFVLENBQUMsSUFBSSxDQUFDO1FBQ3RCaEUsS0FBSyxDQUFDOEUsV0FBVyxDQUFDLFVBQVUsRUFBRSxJQUFJLENBQUNDLGNBQWMsQ0FBQztRQUNsRDtRQUNBLElBQUksQ0FBQ25DLEtBQUssQ0FBQ3pDLE1BQU0sQ0FBQ29FLEtBQUssQ0FBQ3pGLEdBQUcsQ0FBQztRQUM1QjtRQUNBLElBQUksQ0FBQzhELEtBQUssQ0FBQ3pDLE1BQU0sQ0FBQ29FLEtBQUssQ0FBQ3hGLEdBQUcsQ0FBQztRQUM1QjtRQUNBO1FBQ0E7UUFDQTtRQUNBO1FBQ0EsSUFBSWYsb0JBQW9CLENBQUMsQ0FBQyxFQUFFO1VBQzFCLElBQUksQ0FBQzRFLEtBQUssQ0FBQ3pDLE1BQU0sQ0FBQ29FLEtBQUssQ0FBQ2hHLHFCQUFxQixDQUFDO1VBQzlDLElBQUksQ0FBQ3FFLEtBQUssQ0FBQ3pDLE1BQU0sQ0FBQ29FLEtBQUssQ0FBQy9GLHdCQUF3QixDQUFDO1FBQ25EO1FBQ0E7UUFDQTtRQUNBO1FBQ0E7UUFDQTtRQUNBO1FBQ0E7UUFDQTtRQUNBd0csWUFBWSxDQUFDLE1BQU07VUFDakIsS0FBS0MsT0FBTyxDQUFDQyxHQUFHLENBQUMsQ0FDZixJQUFJLENBQUN2QyxPQUFPLENBQUN3QyxJQUFJLENBQUMvRyxTQUFTLENBQUMsQ0FBQyxDQUFDLEVBQzlCLElBQUksQ0FBQ3VFLE9BQU8sQ0FBQ3lDLEtBQUssQ0FBQyxDQUFDLENBQ3JCLENBQUMsQ0FBQ0MsSUFBSSxDQUFDLENBQUMsQ0FBQ0MsQ0FBQyxDQUFDLEtBQUs7WUFDZixJQUFJQSxDQUFDLEVBQUU7Y0FDTHZILGdCQUFnQixDQUFDdUgsQ0FBQyxDQUFDQyxJQUFJLENBQUM7Y0FDeEIzSSxlQUFlLENBQUMsc0NBQXNDMEksQ0FBQyxDQUFDQyxJQUFJLEdBQUcsQ0FBQztZQUNsRSxDQUFDLE1BQU07Y0FDTDNJLGVBQWUsQ0FBQyw4Q0FBOEMsQ0FBQztZQUNqRTtVQUNGLENBQUMsQ0FBQztRQUNKLENBQUMsQ0FBQztNQUNKO01BRUEsSUFBSSxDQUFDd0YsbUJBQW1CLEVBQUU7TUFDMUI7SUFDRjs7SUFFQTtJQUNBLElBQUksRUFBRSxJQUFJLENBQUNBLG1CQUFtQixLQUFLLENBQUMsRUFBRTtNQUNwQyxJQUFJLENBQUNRLEtBQUssQ0FBQ3pDLE1BQU0sQ0FBQ29FLEtBQUssQ0FBQ2pHLHlCQUF5QixDQUFDO01BQ2xELElBQUksQ0FBQ3NFLEtBQUssQ0FBQ3pDLE1BQU0sQ0FBQ29FLEtBQUssQ0FBQ2xHLHNCQUFzQixDQUFDO01BQy9DO01BQ0EsSUFBSSxDQUFDdUUsS0FBSyxDQUFDekMsTUFBTSxDQUFDb0UsS0FBSyxDQUFDM0YsR0FBRyxDQUFDO01BQzVCO01BQ0EsSUFBSSxDQUFDZ0UsS0FBSyxDQUFDekMsTUFBTSxDQUFDb0UsS0FBSyxDQUFDNUYsR0FBRyxDQUFDO01BQzVCcUIsS0FBSyxDQUFDZ0UsVUFBVSxDQUFDLEtBQUssQ0FBQztNQUN2QmhFLEtBQUssQ0FBQ3dGLGNBQWMsQ0FBQyxVQUFVLEVBQUUsSUFBSSxDQUFDVCxjQUFjLENBQUM7TUFDckQvRSxLQUFLLENBQUN5RixLQUFLLENBQUMsQ0FBQztJQUNmO0VBQ0YsQ0FBQzs7RUFFRDtFQUNBQyxlQUFlLEdBQUdBLENBQUEsQ0FBRSxFQUFFLElBQUksSUFBSTtJQUM1QjtJQUNBLElBQUksQ0FBQ25ELHFCQUFxQixHQUFHLElBQUk7O0lBRWpDO0lBQ0EsSUFBSSxDQUFDLElBQUksQ0FBQ0QsYUFBYSxDQUFDcUQsVUFBVSxFQUFFOztJQUVwQztJQUNBO0lBQ0E7SUFDQTtJQUNBO0lBQ0E7SUFDQTtJQUNBO0lBQ0EsSUFBSSxJQUFJLENBQUMvQyxLQUFLLENBQUM1QyxLQUFLLENBQUM0RixjQUFjLEdBQUcsQ0FBQyxFQUFFO01BQ3ZDLElBQUksQ0FBQ3JELHFCQUFxQixHQUFHWSxVQUFVLENBQ3JDLElBQUksQ0FBQ3VDLGVBQWUsRUFDcEIsSUFBSSxDQUFDakQsY0FDUCxDQUFDO01BQ0Q7SUFDRjs7SUFFQTtJQUNBO0lBQ0EsSUFBSSxDQUFDb0QsWUFBWSxDQUFDLElBQUksQ0FBQztFQUN6QixDQUFDOztFQUVEO0VBQ0FBLFlBQVksR0FBR0EsQ0FBQ0MsS0FBSyxFQUFFLE1BQU0sR0FBR0MsTUFBTSxHQUFHLElBQUksQ0FBQyxFQUFFLElBQUksSUFBSTtJQUN0RDtJQUNBLE1BQU0sQ0FBQ0MsSUFBSSxFQUFFQyxRQUFRLENBQUMsR0FBR3pJLHVCQUF1QixDQUFDLElBQUksQ0FBQzhFLGFBQWEsRUFBRXdELEtBQUssQ0FBQztJQUMzRSxJQUFJLENBQUN4RCxhQUFhLEdBQUcyRCxRQUFROztJQUU3QjtJQUNBO0lBQ0E7SUFDQTtJQUNBO0lBQ0EsSUFBSUQsSUFBSSxDQUFDRSxNQUFNLEdBQUcsQ0FBQyxFQUFFO01BQ25CekksVUFBVSxDQUFDMEksZUFBZSxDQUN4QkMsa0JBQWtCLEVBQ2xCLElBQUksRUFDSkosSUFBSSxFQUNKN0QsU0FBUyxFQUNUQSxTQUNGLENBQUM7SUFDSDs7SUFFQTtJQUNBLElBQUksSUFBSSxDQUFDRyxhQUFhLENBQUNxRCxVQUFVLEVBQUU7TUFDakM7TUFDQSxJQUFJLElBQUksQ0FBQ3BELHFCQUFxQixFQUFFO1FBQzlCa0MsWUFBWSxDQUFDLElBQUksQ0FBQ2xDLHFCQUFxQixDQUFDO01BQzFDO01BQ0EsSUFBSSxDQUFDQSxxQkFBcUIsR0FBR1ksVUFBVSxDQUNyQyxJQUFJLENBQUN1QyxlQUFlLEVBQ3BCLElBQUksQ0FBQ3BELGFBQWEsQ0FBQytELElBQUksS0FBSyxVQUFVLEdBQ2xDLElBQUksQ0FBQzNELGFBQWEsR0FDbEIsSUFBSSxDQUFDRCxjQUNYLENBQUM7SUFDSDtFQUNGLENBQUM7RUFFRHNDLGNBQWMsR0FBR0EsQ0FBQSxDQUFFLEVBQUUsSUFBSSxJQUFJO0lBQzNCO0lBQ0E7SUFDQTtJQUNBO0lBQ0EsTUFBTXZCLEdBQUcsR0FBR0QsSUFBSSxDQUFDQyxHQUFHLENBQUMsQ0FBQztJQUN0QixJQUFJQSxHQUFHLEdBQUcsSUFBSSxDQUFDRixhQUFhLEdBQUd6RCxtQkFBbUIsRUFBRTtNQUNsRCxJQUFJLENBQUMrQyxLQUFLLENBQUNwQixhQUFhLEdBQUcsQ0FBQztJQUM5QjtJQUNBLElBQUksQ0FBQzhCLGFBQWEsR0FBR0UsR0FBRztJQUN4QixJQUFJO01BQ0YsSUFBSThDLEtBQUs7TUFDVCxPQUFPLENBQUNBLEtBQUssR0FBRyxJQUFJLENBQUMxRCxLQUFLLENBQUM1QyxLQUFLLENBQUN1RyxJQUFJLENBQUMsQ0FBQyxJQUFJLE1BQU0sR0FBRyxJQUFJLE1BQU0sSUFBSSxFQUFFO1FBQ2xFO1FBQ0EsSUFBSSxDQUFDVixZQUFZLENBQUNTLEtBQUssQ0FBQztNQUMxQjtJQUNGLENBQUMsQ0FBQyxPQUFPOUYsS0FBSyxFQUFFO01BQ2Q7TUFDQTtNQUNBO01BQ0E7TUFDQXhELFFBQVEsQ0FBQ3dELEtBQUssQ0FBQzs7TUFFZjtNQUNBO01BQ0E7TUFDQSxNQUFNO1FBQUVSO01BQU0sQ0FBQyxHQUFHLElBQUksQ0FBQzRDLEtBQUs7TUFDNUIsSUFDRSxJQUFJLENBQUNSLG1CQUFtQixHQUFHLENBQUMsSUFDNUIsQ0FBQ3BDLEtBQUssQ0FBQ3dHLFNBQVMsQ0FBQyxVQUFVLENBQUMsQ0FBQ0MsUUFBUSxDQUFDLElBQUksQ0FBQzFCLGNBQWMsQ0FBQyxFQUMxRDtRQUNBbkksZUFBZSxDQUNiLDJFQUEyRSxFQUMzRTtVQUFFOEosS0FBSyxFQUFFO1FBQU8sQ0FDbEIsQ0FBQztRQUNEMUcsS0FBSyxDQUFDOEUsV0FBVyxDQUFDLFVBQVUsRUFBRSxJQUFJLENBQUNDLGNBQWMsQ0FBQztNQUNwRDtJQUNGO0VBQ0YsQ0FBQztFQUVENEIsV0FBVyxHQUFHQSxDQUFDYixLQUFLLEVBQUUsTUFBTSxHQUFHLFNBQVMsQ0FBQyxFQUFFLElBQUksSUFBSTtJQUNqRDtJQUNBLElBQUlBLEtBQUssS0FBSyxNQUFNLElBQUksSUFBSSxDQUFDbEQsS0FBSyxDQUFDdEMsV0FBVyxFQUFFO01BQzlDLElBQUksQ0FBQ3lELFVBQVUsQ0FBQyxDQUFDO0lBQ25COztJQUVBO0lBQ0E7SUFDQTtFQUNGLENBQUM7RUFFREEsVUFBVSxHQUFHQSxDQUFDdkQsS0FBYSxDQUFQLEVBQUVDLEtBQUssQ0FBQyxFQUFFLElBQUksSUFBSTtJQUNwQyxJQUFJLElBQUksQ0FBQ2dELGtCQUFrQixDQUFDLENBQUMsRUFBRTtNQUM3QixJQUFJLENBQUNRLGdCQUFnQixDQUFDLEtBQUssQ0FBQztJQUM5QjtJQUVBLElBQUksQ0FBQ3JCLEtBQUssQ0FBQ3JDLE1BQU0sQ0FBQ0MsS0FBSyxDQUFDO0VBQzFCLENBQUM7RUFFRG9HLG1CQUFtQixHQUFHQSxDQUFDQyxTQUFTLEVBQUUsT0FBTyxDQUFDLEVBQUUsSUFBSSxJQUFJO0lBQ2xEO0lBQ0E7SUFDQTNJLGtCQUFrQixDQUFDMkksU0FBUyxDQUFDO0VBQy9CLENBQUM7RUFFREMsYUFBYSxHQUFHQSxDQUFBLENBQUUsRUFBRSxJQUFJLElBQUk7SUFDMUIsSUFBSSxDQUFDLElBQUksQ0FBQ3JELGtCQUFrQixDQUFDLENBQUMsRUFBRTtNQUM5QjtJQUNGOztJQUVBO0lBQ0EsTUFBTXNELHlCQUF5QixHQUFHLElBQUksQ0FBQzNFLG1CQUFtQjs7SUFFMUQ7SUFDQSxPQUFPLElBQUksQ0FBQ0EsbUJBQW1CLEdBQUcsQ0FBQyxFQUFFO01BQ25DLElBQUksQ0FBQzZCLGdCQUFnQixDQUFDLEtBQUssQ0FBQztJQUM5Qjs7SUFFQTtJQUNBO0lBQ0E7SUFDQTtJQUNBO0lBQ0EsSUFBSSxJQUFJLENBQUNyQixLQUFLLENBQUN6QyxNQUFNLENBQUN1RCxLQUFLLEVBQUU7TUFDM0IsSUFBSSxDQUFDZCxLQUFLLENBQUN6QyxNQUFNLENBQUNvRSxLQUFLLENBQUN0RixXQUFXLEdBQUdMLEdBQUcsR0FBR0Msc0JBQXNCLENBQUM7SUFDckU7O0lBRUE7SUFDQSxJQUFJLENBQUN3RCxxQkFBcUIsQ0FBQzJFLElBQUksQ0FBQyxTQUFTLENBQUM7O0lBRTFDO0lBQ0EsTUFBTUMsYUFBYSxHQUFHQSxDQUFBLEtBQU07TUFDMUI7TUFDQSxLQUFLLElBQUlDLENBQUMsR0FBRyxDQUFDLEVBQUVBLENBQUMsR0FBR0gseUJBQXlCLEVBQUVHLENBQUMsRUFBRSxFQUFFO1FBQ2xELElBQUksSUFBSSxDQUFDekQsa0JBQWtCLENBQUMsQ0FBQyxFQUFFO1VBQzdCLElBQUksQ0FBQ1EsZ0JBQWdCLENBQUMsSUFBSSxDQUFDO1FBQzdCO01BQ0Y7O01BRUE7TUFDQSxJQUFJLElBQUksQ0FBQ3JCLEtBQUssQ0FBQ3pDLE1BQU0sQ0FBQ3VELEtBQUssRUFBRTtRQUMzQixJQUFJLENBQUM1RyxXQUFXLENBQUM2QyxPQUFPLENBQUMwRSxHQUFHLENBQUNDLHlCQUF5QixDQUFDLEVBQUU7VUFDdkQsSUFBSSxDQUFDMUIsS0FBSyxDQUFDekMsTUFBTSxDQUFDb0UsS0FBSyxDQUFDdkYsV0FBVyxDQUFDO1FBQ3RDO1FBQ0E7UUFDQSxJQUFJLENBQUM0RCxLQUFLLENBQUN6QyxNQUFNLENBQUNvRSxLQUFLLENBQUN4RixHQUFHLENBQUM7TUFDOUI7O01BRUE7TUFDQSxJQUFJLENBQUNzRCxxQkFBcUIsQ0FBQzJFLElBQUksQ0FBQyxRQUFRLENBQUM7TUFFekNySCxPQUFPLENBQUM2RixjQUFjLENBQUMsU0FBUyxFQUFFeUIsYUFBYSxDQUFDO0lBQ2xELENBQUM7SUFFRHRILE9BQU8sQ0FBQ3dILEVBQUUsQ0FBQyxTQUFTLEVBQUVGLGFBQWEsQ0FBQztJQUNwQ3RILE9BQU8sQ0FBQ3lILElBQUksQ0FBQ3pILE9BQU8sQ0FBQzBILEdBQUcsRUFBRSxTQUFTLENBQUM7RUFDdEMsQ0FBQztBQUNIOztBQUVBO0FBQ0E7QUFDQSxTQUFTakIsa0JBQWtCQSxDQUN6QmtCLEdBQUcsRUFBRXZGLEdBQUcsRUFDUndGLEtBQUssRUFBRWxLLFdBQVcsRUFBRSxFQUNwQm1LLFFBQVEsRUFBRSxTQUFTLEVBQ25CQyxRQUFRLEVBQUUsU0FBUyxDQUNwQixFQUFFLElBQUksQ0FBQztFQUNOO0VBQ0E7RUFDQTtFQUNBO0VBQ0E7RUFDQTtFQUNBLElBQ0VGLEtBQUssQ0FBQ0csSUFBSSxDQUNSUixDQUFDLElBQ0NBLENBQUMsQ0FBQ1MsSUFBSSxLQUFLLEtBQUssSUFDZlQsQ0FBQyxDQUFDUyxJQUFJLEtBQUssT0FBTyxJQUNqQixFQUFFLENBQUNULENBQUMsQ0FBQ1UsTUFBTSxHQUFHLElBQUksTUFBTSxDQUFDLElBQUksQ0FBQ1YsQ0FBQyxDQUFDVSxNQUFNLEdBQUcsSUFBSSxNQUFNLENBQUMsQ0FDMUQsQ0FBQyxFQUNEO0lBQ0FqTCx5QkFBeUIsQ0FBQyxDQUFDO0VBQzdCO0VBRUEsS0FBSyxNQUFNa0wsSUFBSSxJQUFJTixLQUFLLEVBQUU7SUFDeEI7SUFDQTtJQUNBLElBQUlNLElBQUksQ0FBQ0YsSUFBSSxLQUFLLFVBQVUsRUFBRTtNQUM1QkwsR0FBRyxDQUFDM0UsT0FBTyxDQUFDbUYsVUFBVSxDQUFDRCxJQUFJLENBQUNFLFFBQVEsQ0FBQztNQUNyQztJQUNGOztJQUVBO0lBQ0E7SUFDQTtJQUNBLElBQUlGLElBQUksQ0FBQ0YsSUFBSSxLQUFLLE9BQU8sRUFBRTtNQUN6QkssZ0JBQWdCLENBQUNWLEdBQUcsRUFBRU8sSUFBSSxDQUFDO01BQzNCO0lBQ0Y7SUFFQSxNQUFNSSxRQUFRLEdBQUdKLElBQUksQ0FBQ0ksUUFBUTs7SUFFOUI7SUFDQSxJQUFJQSxRQUFRLEtBQUt4SixRQUFRLEVBQUU7TUFDekI2SSxHQUFHLENBQUNWLG1CQUFtQixDQUFDLElBQUksQ0FBQztNQUM3QixNQUFNc0IsS0FBSyxHQUFHLElBQUkvSyxrQkFBa0IsQ0FBQyxlQUFlLENBQUM7TUFDckRtSyxHQUFHLENBQUNqRixxQkFBcUIsQ0FBQzJFLElBQUksQ0FBQyxlQUFlLEVBQUVrQixLQUFLLENBQUM7TUFDdEQ7SUFDRjtJQUNBLElBQUlELFFBQVEsS0FBS3ZKLFNBQVMsRUFBRTtNQUMxQjRJLEdBQUcsQ0FBQ1YsbUJBQW1CLENBQUMsS0FBSyxDQUFDO01BQzlCO01BQ0E7TUFDQTtNQUNBO01BQ0E7TUFDQSxJQUFJVSxHQUFHLENBQUMxRSxLQUFLLENBQUNoQyxTQUFTLENBQUN1SCxVQUFVLEVBQUU7UUFDbEN6SyxlQUFlLENBQUM0SixHQUFHLENBQUMxRSxLQUFLLENBQUNoQyxTQUFTLENBQUM7UUFDcEMwRyxHQUFHLENBQUMxRSxLQUFLLENBQUMvQixpQkFBaUIsQ0FBQyxDQUFDO01BQy9CO01BQ0EsTUFBTXFILEtBQUssR0FBRyxJQUFJL0ssa0JBQWtCLENBQUMsY0FBYyxDQUFDO01BQ3BEbUssR0FBRyxDQUFDakYscUJBQXFCLENBQUMyRSxJQUFJLENBQUMsY0FBYyxFQUFFa0IsS0FBSyxDQUFDO01BQ3JEO0lBQ0Y7O0lBRUE7SUFDQSxJQUFJLENBQUNqSyxrQkFBa0IsQ0FBQyxDQUFDLEVBQUU7TUFDekJDLGtCQUFrQixDQUFDLElBQUksQ0FBQztJQUMxQjs7SUFFQTtJQUNBO0lBQ0EsSUFBSTJKLElBQUksQ0FBQ3RDLElBQUksS0FBSyxHQUFHLElBQUlzQyxJQUFJLENBQUNPLElBQUksSUFBSTFJLGdCQUFnQixFQUFFO01BQ3RENEgsR0FBRyxDQUFDUixhQUFhLENBQUMsQ0FBQztNQUNuQjtJQUNGO0lBRUFRLEdBQUcsQ0FBQ1gsV0FBVyxDQUFDc0IsUUFBUSxDQUFDO0lBQ3pCLE1BQU1DLEtBQUssR0FBRyxJQUFJaEwsVUFBVSxDQUFDMkssSUFBSSxDQUFDO0lBQ2xDUCxHQUFHLENBQUNqRixxQkFBcUIsQ0FBQzJFLElBQUksQ0FBQyxPQUFPLEVBQUVrQixLQUFLLENBQUM7O0lBRTlDO0lBQ0FaLEdBQUcsQ0FBQzFFLEtBQUssQ0FBQ2xCLHFCQUFxQixDQUFDbUcsSUFBSSxDQUFDO0VBQ3ZDO0FBQ0Y7O0FBRUE7QUFDQSxPQUFPLFNBQVNHLGdCQUFnQkEsQ0FBQ1YsR0FBRyxFQUFFdkYsR0FBRyxFQUFFc0csQ0FBQyxFQUFFOUssV0FBVyxDQUFDLEVBQUUsSUFBSSxDQUFDO0VBQy9EO0VBQ0E7RUFDQSxJQUFJUixxQkFBcUIsQ0FBQyxDQUFDLEVBQUU7RUFFN0IsTUFBTXVMLEdBQUcsR0FBR2hCLEdBQUcsQ0FBQzFFLEtBQUssQ0FBQ2hDLFNBQVM7RUFDL0I7RUFDQSxNQUFNRyxHQUFHLEdBQUdzSCxDQUFDLENBQUN0SCxHQUFHLEdBQUcsQ0FBQztFQUNyQixNQUFNQyxHQUFHLEdBQUdxSCxDQUFDLENBQUNySCxHQUFHLEdBQUcsQ0FBQztFQUNyQixNQUFNdUgsVUFBVSxHQUFHRixDQUFDLENBQUNULE1BQU0sR0FBRyxJQUFJO0VBRWxDLElBQUlTLENBQUMsQ0FBQ0csTUFBTSxLQUFLLE9BQU8sRUFBRTtJQUN4QixJQUFJLENBQUNILENBQUMsQ0FBQ1QsTUFBTSxHQUFHLElBQUksTUFBTSxDQUFDLElBQUlXLFVBQVUsS0FBSyxDQUFDLEVBQUU7TUFDL0M7TUFDQTtNQUNBO01BQ0E7TUFDQTtNQUNBO01BQ0E7TUFDQTtNQUNBO01BQ0EsSUFBSUQsR0FBRyxDQUFDSCxVQUFVLEVBQUU7UUFDbEJ6SyxlQUFlLENBQUM0SyxHQUFHLENBQUM7UUFDcEJoQixHQUFHLENBQUMxRSxLQUFLLENBQUMvQixpQkFBaUIsQ0FBQyxDQUFDO01BQy9CO01BQ0EsSUFBSUUsR0FBRyxLQUFLdUcsR0FBRyxDQUFDbEUsWUFBWSxJQUFJcEMsR0FBRyxLQUFLc0csR0FBRyxDQUFDakUsWUFBWSxFQUFFO01BQzFEaUUsR0FBRyxDQUFDbEUsWUFBWSxHQUFHckMsR0FBRztNQUN0QnVHLEdBQUcsQ0FBQ2pFLFlBQVksR0FBR3JDLEdBQUc7TUFDdEJzRyxHQUFHLENBQUMxRSxLQUFLLENBQUMzQixTQUFTLENBQUNGLEdBQUcsRUFBRUMsR0FBRyxDQUFDO01BQzdCO0lBQ0Y7SUFDQSxJQUFJdUgsVUFBVSxLQUFLLENBQUMsRUFBRTtNQUNwQjtNQUNBakIsR0FBRyxDQUFDdEUsVUFBVSxHQUFHLENBQUM7TUFDbEI7SUFDRjtJQUNBLElBQUksQ0FBQ3FGLENBQUMsQ0FBQ1QsTUFBTSxHQUFHLElBQUksTUFBTSxDQUFDLEVBQUU7TUFDM0I7TUFDQTtNQUNBTixHQUFHLENBQUMxRSxLQUFLLENBQUNyQixlQUFlLENBQUNSLEdBQUcsRUFBRUMsR0FBRyxDQUFDO01BQ25DO0lBQ0Y7SUFDQTtJQUNBO0lBQ0E7SUFDQTtJQUNBO0lBQ0EsSUFBSXNILEdBQUcsQ0FBQ0gsVUFBVSxFQUFFO01BQ2xCekssZUFBZSxDQUFDNEssR0FBRyxDQUFDO01BQ3BCaEIsR0FBRyxDQUFDMUUsS0FBSyxDQUFDL0IsaUJBQWlCLENBQUMsQ0FBQztJQUMvQjtJQUNBO0lBQ0E7SUFDQTtJQUNBO0lBQ0E7SUFDQSxNQUFNMkMsR0FBRyxHQUFHRCxJQUFJLENBQUNDLEdBQUcsQ0FBQyxDQUFDO0lBQ3RCLE1BQU1pRixRQUFRLEdBQ1pqRixHQUFHLEdBQUc4RCxHQUFHLENBQUN6RSxhQUFhLEdBQUdqQixzQkFBc0IsSUFDaEQ4RyxJQUFJLENBQUNDLEdBQUcsQ0FBQzVILEdBQUcsR0FBR3VHLEdBQUcsQ0FBQ3hFLFlBQVksQ0FBQyxJQUFJakIsb0JBQW9CLElBQ3hENkcsSUFBSSxDQUFDQyxHQUFHLENBQUMzSCxHQUFHLEdBQUdzRyxHQUFHLENBQUN2RSxZQUFZLENBQUMsSUFBSWxCLG9CQUFvQjtJQUMxRHlGLEdBQUcsQ0FBQ3RFLFVBQVUsR0FBR3lGLFFBQVEsR0FBR25CLEdBQUcsQ0FBQ3RFLFVBQVUsR0FBRyxDQUFDLEdBQUcsQ0FBQztJQUNsRHNFLEdBQUcsQ0FBQ3pFLGFBQWEsR0FBR1csR0FBRztJQUN2QjhELEdBQUcsQ0FBQ3hFLFlBQVksR0FBRy9CLEdBQUc7SUFDdEJ1RyxHQUFHLENBQUN2RSxZQUFZLEdBQUcvQixHQUFHO0lBQ3RCLElBQUlzRyxHQUFHLENBQUN0RSxVQUFVLElBQUksQ0FBQyxFQUFFO01BQ3ZCO01BQ0E7TUFDQSxJQUFJc0UsR0FBRyxDQUFDckUscUJBQXFCLEVBQUU7UUFDN0J3QixZQUFZLENBQUM2QyxHQUFHLENBQUNyRSxxQkFBcUIsQ0FBQztRQUN2Q3FFLEdBQUcsQ0FBQ3JFLHFCQUFxQixHQUFHLElBQUk7TUFDbEM7TUFDQTtNQUNBLE1BQU0zQixLQUFLLEdBQUdnRyxHQUFHLENBQUN0RSxVQUFVLEtBQUssQ0FBQyxHQUFHLENBQUMsR0FBRyxDQUFDO01BQzFDc0UsR0FBRyxDQUFDMUUsS0FBSyxDQUFDdkIsWUFBWSxDQUFDTixHQUFHLEVBQUVDLEdBQUcsRUFBRU0sS0FBSyxDQUFDO01BQ3ZDO0lBQ0Y7SUFDQXpELGNBQWMsQ0FBQ3lLLEdBQUcsRUFBRXZILEdBQUcsRUFBRUMsR0FBRyxDQUFDO0lBQzdCO0lBQ0E7SUFDQTtJQUNBO0lBQ0FzSCxHQUFHLENBQUNNLGVBQWUsR0FBRyxDQUFDUCxDQUFDLENBQUNULE1BQU0sR0FBRyxJQUFJLE1BQU0sQ0FBQztJQUM3Q04sR0FBRyxDQUFDMUUsS0FBSyxDQUFDL0IsaUJBQWlCLENBQUMsQ0FBQztJQUM3QjtFQUNGOztFQUVBO0VBQ0E7RUFDQTtFQUNBO0VBQ0E7RUFDQTtFQUNBLElBQUkwSCxVQUFVLEtBQUssQ0FBQyxFQUFFO0lBQ3BCLElBQUksQ0FBQ0QsR0FBRyxDQUFDSCxVQUFVLEVBQUU7SUFDckJ6SyxlQUFlLENBQUM0SyxHQUFHLENBQUM7SUFDcEJoQixHQUFHLENBQUMxRSxLQUFLLENBQUMvQixpQkFBaUIsQ0FBQyxDQUFDO0lBQzdCO0VBQ0Y7RUFDQW5ELGVBQWUsQ0FBQzRLLEdBQUcsQ0FBQztFQUNwQjtFQUNBO0VBQ0E7RUFDQTtFQUNBO0VBQ0E7RUFDQTtFQUNBO0VBQ0E7RUFDQTtFQUNBO0VBQ0E7RUFDQSxJQUFJLENBQUMzSyxZQUFZLENBQUMySyxHQUFHLENBQUMsSUFBSUEsR0FBRyxDQUFDTyxNQUFNLEVBQUU7SUFDcEM7SUFDQTtJQUNBO0lBQ0EsSUFBSSxDQUFDdkIsR0FBRyxDQUFDMUUsS0FBSyxDQUFDOUIsU0FBUyxDQUFDQyxHQUFHLEVBQUVDLEdBQUcsQ0FBQyxFQUFFO01BQ2xDO01BQ0E7TUFDQTtNQUNBLE1BQU1JLEdBQUcsR0FBR2tHLEdBQUcsQ0FBQzFFLEtBQUssQ0FBQzFCLGNBQWMsQ0FBQ0gsR0FBRyxFQUFFQyxHQUFHLENBQUM7TUFDOUM7TUFDQTtNQUNBO01BQ0E7TUFDQTtNQUNBO01BQ0E7TUFDQTtNQUNBO01BQ0E7TUFDQTtNQUNBLElBQUlJLEdBQUcsSUFBSXpCLE9BQU8sQ0FBQzBFLEdBQUcsQ0FBQ3lFLFlBQVksS0FBSyxRQUFRLElBQUksQ0FBQ2hMLFNBQVMsQ0FBQyxDQUFDLEVBQUU7UUFDaEU7UUFDQTtRQUNBLElBQUl3SixHQUFHLENBQUNyRSxxQkFBcUIsRUFBRTtVQUM3QndCLFlBQVksQ0FBQzZDLEdBQUcsQ0FBQ3JFLHFCQUFxQixDQUFDO1FBQ3pDO1FBQ0FxRSxHQUFHLENBQUNyRSxxQkFBcUIsR0FBR0UsVUFBVSxDQUNwQyxDQUFDbUUsR0FBRyxFQUFFbEcsR0FBRyxLQUFLO1VBQ1prRyxHQUFHLENBQUNyRSxxQkFBcUIsR0FBRyxJQUFJO1VBQ2hDcUUsR0FBRyxDQUFDMUUsS0FBSyxDQUFDekIsZUFBZSxDQUFDQyxHQUFHLENBQUM7UUFDaEMsQ0FBQyxFQUNEUSxzQkFBc0IsRUFDdEIwRixHQUFHLEVBQ0hsRyxHQUNGLENBQUM7TUFDSDtJQUNGO0VBQ0Y7RUFDQWtHLEdBQUcsQ0FBQzFFLEtBQUssQ0FBQy9CLGlCQUFpQixDQUFDLENBQUM7QUFDL0IiLCJpZ25vcmVMaXN0IjpbXX0=

--- a/packages/renderer/src/components/AppContext.ts
+++ b/packages/renderer/src/components/AppContext.ts
@@ -19,4 +19,3 @@ const AppContext = createContext<Props>({
 AppContext.displayName = 'InternalAppContext'
 
 export default AppContext
-

--- a/packages/renderer/src/components/Box.tsx
+++ b/packages/renderer/src/components/Box.tsx
@@ -1,4 +1,5 @@
-import React, { type PropsWithChildren, type Ref } from 'react'
+import type React from 'react'
+import type { PropsWithChildren, Ref } from 'react'
 import type { Except } from 'type-fest'
 import type { DOMElement } from '../dom.js'
 import type { ClickEvent } from '../events/click-event.js'

--- a/packages/renderer/src/components/Button.tsx
+++ b/packages/renderer/src/components/Button.tsx
@@ -1,10 +1,4 @@
-import React, {
-  type Ref,
-  useCallback,
-  useEffect,
-  useRef,
-  useState,
-} from 'react'
+import React, { type Ref, useCallback, useEffect, useRef, useState } from 'react'
 import type { Except } from 'type-fest'
 import type { DOMElement } from '../dom.js'
 import type { ClickEvent } from '../events/click-event.js'
@@ -71,11 +65,7 @@ function Button({
         setIsActive(true)
         onAction()
         if (activeTimer.current) clearTimeout(activeTimer.current)
-        activeTimer.current = setTimeout(
-          setter => setter(false),
-          100,
-          setIsActive,
-        )
+        activeTimer.current = setTimeout((setter) => setter(false), 100, setIsActive)
       }
     },
     [onAction],

--- a/packages/renderer/src/components/Button.tsx
+++ b/packages/renderer/src/components/Button.tsx
@@ -1,4 +1,5 @@
-import React, { type Ref, useCallback, useEffect, useRef, useState } from 'react'
+import type React from 'react'
+import { type Ref, useCallback, useEffect, useRef, useState } from 'react'
 import type { Except } from 'type-fest'
 import type { DOMElement } from '../dom.js'
 import type { ClickEvent } from '../events/click-event.js'

--- a/packages/renderer/src/components/ClockContext.tsx
+++ b/packages/renderer/src/components/ClockContext.tsx
@@ -1,4 +1,5 @@
-import React, { createContext, useEffect, useState } from 'react'
+import type React from 'react'
+import { createContext, useEffect, useState } from 'react'
 import { FRAME_INTERVAL_MS } from '../constants.js'
 import { useTerminalFocus } from '../hooks/use-terminal-focus.js'
 

--- a/packages/renderer/src/components/ClockContext.tsx
+++ b/packages/renderer/src/components/ClockContext.tsx
@@ -90,9 +90,7 @@ export function ClockProvider({
   const focused = useTerminalFocus()
 
   useEffect(() => {
-    clock.setTickInterval(
-      focused ? FRAME_INTERVAL_MS : BLURRED_TICK_INTERVAL_MS,
-    )
+    clock.setTickInterval(focused ? FRAME_INTERVAL_MS : BLURRED_TICK_INTERVAL_MS)
   }, [clock, focused])
 
   return <ClockContext.Provider value={clock}>{children}</ClockContext.Provider>

--- a/packages/renderer/src/components/CursorDeclarationContext.ts
+++ b/packages/renderer/src/components/CursorDeclarationContext.ts
@@ -25,9 +25,6 @@ export type CursorDeclarationSetter = (
   clearIfNode?: DOMElement | null,
 ) => void
 
-const CursorDeclarationContext = createContext<CursorDeclarationSetter>(
-  () => {},
-)
+const CursorDeclarationContext = createContext<CursorDeclarationSetter>(() => {})
 
 export default CursorDeclarationContext
-

--- a/packages/renderer/src/components/ErrorOverview.tsx
+++ b/packages/renderer/src/components/ErrorOverview.tsx
@@ -1,55 +1,52 @@
-import codeExcerpt, { type CodeExcerpt } from 'code-excerpt';
-import { readFileSync } from 'fs';
-import React from 'react';
-import StackUtils from 'stack-utils';
-import Box from './Box';
-import Text from './Text';
+import codeExcerpt, { type CodeExcerpt } from 'code-excerpt'
+import { readFileSync } from 'fs'
+import React from 'react'
+import StackUtils from 'stack-utils'
+import Box from './Box'
+import Text from './Text'
 
 /* eslint-disable custom-rules/no-process-cwd -- stack trace file:// paths are relative to the real OS cwd, not the virtual cwd */
 
 // Error's source file is reported as file:///home/user/file.js
 // This function removes the file://[cwd] part
 const cleanupPath = (path: string | undefined): string | undefined => {
-  return path?.replace(`file://${process.cwd()}/`, '');
-};
-let stackUtils: StackUtils | undefined;
+  return path?.replace(`file://${process.cwd()}/`, '')
+}
+let stackUtils: StackUtils | undefined
 function getStackUtils(): StackUtils {
-  return stackUtils ??= new StackUtils({
+  return (stackUtils ??= new StackUtils({
     cwd: process.cwd(),
-    internals: StackUtils.nodeInternals()
-  });
+    internals: StackUtils.nodeInternals(),
+  }))
 }
 
 /* eslint-enable custom-rules/no-process-cwd */
 
 type Props = {
-  readonly error: Error;
-};
-export default function ErrorOverview({
-  error
-}: Props) {
-  const stack = error.stack ? error.stack.split('\n').slice(1) : undefined;
-  const origin = stack ? getStackUtils().parseLine(stack[0]!) : undefined;
-  const filePath = cleanupPath(origin?.file);
-  let excerpt: CodeExcerpt[] | undefined;
-  let lineWidth = 0;
+  readonly error: Error
+}
+export default function ErrorOverview({ error }: Props) {
+  const stack = error.stack ? error.stack.split('\n').slice(1) : undefined
+  const origin = stack ? getStackUtils().parseLine(stack[0]!) : undefined
+  const filePath = cleanupPath(origin?.file)
+  let excerpt: CodeExcerpt[] | undefined
+  let lineWidth = 0
   if (filePath && origin?.line) {
     try {
       // eslint-disable-next-line custom-rules/no-sync-fs -- sync render path; error overlay can't go async without suspense restructuring
-      const sourceCode = readFileSync(filePath, 'utf8');
-      excerpt = codeExcerpt(sourceCode, origin.line);
+      const sourceCode = readFileSync(filePath, 'utf8')
+      excerpt = codeExcerpt(sourceCode, origin.line)
       if (excerpt) {
-        for (const {
-          line
-        } of excerpt) {
-          lineWidth = Math.max(lineWidth, String(line).length);
+        for (const { line } of excerpt) {
+          lineWidth = Math.max(lineWidth, String(line).length)
         }
       }
     } catch {
       // file not readable — skip source context
     }
   }
-  return <Box flexDirection="column" padding={1}>
+  return (
+    <Box flexDirection="column" padding={1}>
       <Box>
         <Text backgroundColor="ansi:red" color="ansi:white">
           {' '}
@@ -59,51 +56,71 @@ export default function ErrorOverview({
         <Text> {error.message}</Text>
       </Box>
 
-      {origin && filePath && <Box marginTop={1}>
+      {origin && filePath && (
+        <Box marginTop={1}>
           <Text dim>
             {filePath}:{origin.line}:{origin.column}
           </Text>
-        </Box>}
+        </Box>
+      )}
 
-      {origin && excerpt && <Box marginTop={1} flexDirection="column">
-          {excerpt.map(({
-        line: line_0,
-        value
-      }) => <Box key={line_0}>
+      {origin && excerpt && (
+        <Box marginTop={1} flexDirection="column">
+          {excerpt.map(({ line: line_0, value }) => (
+            <Box key={line_0}>
               <Box width={lineWidth + 1}>
-                <Text dim={line_0 !== origin.line} backgroundColor={line_0 === origin.line ? 'ansi:red' : undefined} color={line_0 === origin.line ? 'ansi:white' : undefined}>
+                <Text
+                  dim={line_0 !== origin.line}
+                  backgroundColor={line_0 === origin.line ? 'ansi:red' : undefined}
+                  color={line_0 === origin.line ? 'ansi:white' : undefined}
+                >
                   {String(line_0).padStart(lineWidth, ' ')}:
                 </Text>
               </Box>
 
-              <Text key={line_0} backgroundColor={line_0 === origin.line ? 'ansi:red' : undefined} color={line_0 === origin.line ? 'ansi:white' : undefined}>
+              <Text
+                key={line_0}
+                backgroundColor={line_0 === origin.line ? 'ansi:red' : undefined}
+                color={line_0 === origin.line ? 'ansi:white' : undefined}
+              >
                 {' ' + value}
               </Text>
-            </Box>)}
-        </Box>}
+            </Box>
+          ))}
+        </Box>
+      )}
 
-      {error.stack && <Box marginTop={1} flexDirection="column">
-          {error.stack.split('\n').slice(1).map(line_1 => {
-        const parsedLine = getStackUtils().parseLine(line_1);
+      {error.stack && (
+        <Box marginTop={1} flexDirection="column">
+          {error.stack
+            .split('\n')
+            .slice(1)
+            .map((line_1) => {
+              const parsedLine = getStackUtils().parseLine(line_1)
 
-        // If the line from the stack cannot be parsed, we print out the unparsed line.
-        if (!parsedLine) {
-          return <Box key={line_1}>
+              // If the line from the stack cannot be parsed, we print out the unparsed line.
+              if (!parsedLine) {
+                return (
+                  <Box key={line_1}>
                     <Text dim>- </Text>
                     <Text bold>{line_1}</Text>
-                  </Box>;
-        }
-        return <Box key={line_1}>
+                  </Box>
+                )
+              }
+              return (
+                <Box key={line_1}>
                   <Text dim>- </Text>
                   <Text bold>{parsedLine.function}</Text>
                   <Text dim>
                     {' '}
-                    ({cleanupPath(parsedLine.file) ?? ''}:{parsedLine.line}:
-                    {parsedLine.column})
+                    ({cleanupPath(parsedLine.file) ?? ''}:{parsedLine.line}:{parsedLine.column})
                   </Text>
-                </Box>;
-      })}
-        </Box>}
-    </Box>;
+                </Box>
+              )
+            })}
+        </Box>
+      )}
+    </Box>
+  )
 }
 //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJuYW1lcyI6WyJjb2RlRXhjZXJwdCIsIkNvZGVFeGNlcnB0IiwicmVhZEZpbGVTeW5jIiwiUmVhY3QiLCJTdGFja1V0aWxzIiwiQm94IiwiVGV4dCIsImNsZWFudXBQYXRoIiwicGF0aCIsInJlcGxhY2UiLCJwcm9jZXNzIiwiY3dkIiwic3RhY2tVdGlscyIsImdldFN0YWNrVXRpbHMiLCJpbnRlcm5hbHMiLCJub2RlSW50ZXJuYWxzIiwiUHJvcHMiLCJlcnJvciIsIkVycm9yIiwiRXJyb3JPdmVydmlldyIsInN0YWNrIiwic3BsaXQiLCJzbGljZSIsInVuZGVmaW5lZCIsIm9yaWdpbiIsInBhcnNlTGluZSIsImZpbGVQYXRoIiwiZmlsZSIsImV4Y2VycHQiLCJsaW5lV2lkdGgiLCJsaW5lIiwic291cmNlQ29kZSIsIk1hdGgiLCJtYXgiLCJTdHJpbmciLCJsZW5ndGgiLCJtZXNzYWdlIiwiY29sdW1uIiwibWFwIiwidmFsdWUiLCJwYWRTdGFydCIsInBhcnNlZExpbmUiLCJmdW5jdGlvbiJdLCJzb3VyY2VzIjpbIkVycm9yT3ZlcnZpZXcudHN4Il0sInNvdXJjZXNDb250ZW50IjpbImltcG9ydCBjb2RlRXhjZXJwdCwgeyB0eXBlIENvZGVFeGNlcnB0IH0gZnJvbSAnY29kZS1leGNlcnB0J1xuaW1wb3J0IHsgcmVhZEZpbGVTeW5jIH0gZnJvbSAnZnMnXG5pbXBvcnQgUmVhY3QgZnJvbSAncmVhY3QnXG5pbXBvcnQgU3RhY2tVdGlscyBmcm9tICdzdGFjay11dGlscydcbmltcG9ydCBCb3ggZnJvbSAnLi9Cb3guanMnXG5pbXBvcnQgVGV4dCBmcm9tICcuL1RleHQuanMnXG5cbi8qIGVzbGludC1kaXNhYmxlIGN1c3RvbS1ydWxlcy9uby1wcm9jZXNzLWN3ZCAtLSBzdGFjayB0cmFjZSBmaWxlOi8vIHBhdGhzIGFyZSByZWxhdGl2ZSB0byB0aGUgcmVhbCBPUyBjd2QsIG5vdCB0aGUgdmlydHVhbCBjd2QgKi9cblxuLy8gRXJyb3IncyBzb3VyY2UgZmlsZSBpcyByZXBvcnRlZCBhcyBmaWxlOi8vL2hvbWUvdXNlci9maWxlLmpzXG4vLyBUaGlzIGZ1bmN0aW9uIHJlbW92ZXMgdGhlIGZpbGU6Ly9bY3dkXSBwYXJ0XG5jb25zdCBjbGVhbnVwUGF0aCA9IChwYXRoOiBzdHJpbmcgfCB1bmRlZmluZWQpOiBzdHJpbmcgfCB1bmRlZmluZWQgPT4ge1xuICByZXR1cm4gcGF0aD8ucmVwbGFjZShgZmlsZTovLyR7cHJvY2Vzcy5jd2QoKX0vYCwgJycpXG59XG5cbmxldCBzdGFja1V0aWxzOiBTdGFja1V0aWxzIHwgdW5kZWZpbmVkXG5mdW5jdGlvbiBnZXRTdGFja1V0aWxzKCk6IFN0YWNrVXRpbHMge1xuICByZXR1cm4gKHN0YWNrVXRpbHMgPz89IG5ldyBTdGFja1V0aWxzKHtcbiAgICBjd2Q6IHByb2Nlc3MuY3dkKCksXG4gICAgaW50ZXJuYWxzOiBTdGFja1V0aWxzLm5vZGVJbnRlcm5hbHMoKSxcbiAgfSkpXG59XG5cbi8qIGVzbGludC1lbmFibGUgY3VzdG9tLXJ1bGVzL25vLXByb2Nlc3MtY3dkICovXG5cbnR5cGUgUHJvcHMgPSB7XG4gIHJlYWRvbmx5IGVycm9yOiBFcnJvclxufVxuXG5leHBvcnQgZGVmYXVsdCBmdW5jdGlvbiBFcnJvck92ZXJ2aWV3KHsgZXJyb3IgfTogUHJvcHMpIHtcbiAgY29uc3Qgc3RhY2sgPSBlcnJvci5zdGFjayA/IGVycm9yLnN0YWNrLnNwbGl0KCdcXG4nKS5zbGljZSgxKSA6IHVuZGVmaW5lZFxuICBjb25zdCBvcmlnaW4gPSBzdGFjayA/IGdldFN0YWNrVXRpbHMoKS5wYXJzZUxpbmUoc3RhY2tbMF0hKSA6IHVuZGVmaW5lZFxuICBjb25zdCBmaWxlUGF0aCA9IGNsZWFudXBQYXRoKG9yaWdpbj8uZmlsZSlcbiAgbGV0IGV4Y2VycHQ6IENvZGVFeGNlcnB0W10gfCB1bmRlZmluZWRcbiAgbGV0IGxpbmVXaWR0aCA9IDBcblxuICBpZiAoZmlsZVBhdGggJiYgb3JpZ2luPy5saW5lKSB7XG4gICAgdHJ5IHtcbiAgICAgIC8vIGVzbGludC1kaXNhYmxlLW5leHQtbGluZSBjdXN0b20tcnVsZXMvbm8tc3luYy1mcyAtLSBzeW5jIHJlbmRlciBwYXRoOyBlcnJvciBvdmVybGF5IGNhbid0IGdvIGFzeW5jIHdpdGhvdXQgc3VzcGVuc2UgcmVzdHJ1Y3R1cmluZ1xuICAgICAgY29uc3Qgc291cmNlQ29kZSA9IHJlYWRGaWxlU3luYyhmaWxlUGF0aCwgJ3V0ZjgnKVxuICAgICAgZXhjZXJwdCA9IGNvZGVFeGNlcnB0KHNvdXJjZUNvZGUsIG9yaWdpbi5saW5lKVxuXG4gICAgICBpZiAoZXhjZXJwdCkge1xuICAgICAgICBmb3IgKGNvbnN0IHsgbGluZSB9IG9mIGV4Y2VycHQpIHtcbiAgICAgICAgICBsaW5lV2lkdGggPSBNYXRoLm1heChsaW5lV2lkdGgsIFN0cmluZyhsaW5lKS5sZW5ndGgpXG4gICAgICAgIH1cbiAgICAgIH1cbiAgICB9IGNhdGNoIHtcbiAgICAgIC8vIGZpbGUgbm90IHJlYWRhYmxlIOKAlCBza2lwIHNvdXJjZSBjb250ZXh0XG4gICAgfVxuICB9XG5cbiAgcmV0dXJuIChcbiAgICA8Qm94IGZsZXhEaXJlY3Rpb249XCJjb2x1bW5cIiBwYWRkaW5nPXsxfT5cbiAgICAgIDxCb3g+XG4gICAgICAgIDxUZXh0IGJhY2tncm91bmRDb2xvcj1cImFuc2k6cmVkXCIgY29sb3I9XCJhbnNpOndoaXRlXCI+XG4gICAgICAgICAgeycgJ31cbiAgICAgICAgICBFUlJPUnsnICd9XG4gICAgICAgIDwvVGV4dD5cblxuICAgICAgICA8VGV4dD4ge2Vycm9yLm1lc3NhZ2V9PC9UZXh0PlxuICAgICAgPC9Cb3g+XG5cbiAgICAgIHtvcmlnaW4gJiYgZmlsZVBhdGggJiYgKFxuICAgICAgICA8Qm94IG1hcmdpblRvcD17MX0+XG4gICAgICAgICAgPFRleHQgZGltPlxuICAgICAgICAgICAge2ZpbGVQYXRofTp7b3JpZ2luLmxpbmV9OntvcmlnaW4uY29sdW1ufVxuICAgICAgICAgIDwvVGV4dD5cbiAgICAgICAgPC9Cb3g+XG4gICAgICApfVxuXG4gICAgICB7b3JpZ2luICYmIGV4Y2VycHQgJiYgKFxuICAgICAgICA8Qm94IG1hcmdpblRvcD17MX0gZmxleERpcmVjdGlvbj1cImNvbHVtblwiPlxuICAgICAgICAgIHtleGNlcnB0Lm1hcCgoeyBsaW5lLCB2YWx1ZSB9KSA9PiAoXG4gICAgICAgICAgICA8Qm94IGtleT17bGluZX0+XG4gICAgICAgICAgICAgIDxCb3ggd2lkdGg9e2xpbmVXaWR0aCArIDF9PlxuICAgICAgICAgICAgICAgIDxUZXh0XG4gICAgICAgICAgICAgICAgICBkaW09e2xpbmUgIT09IG9yaWdpbi5saW5lfVxuICAgICAgICAgICAgICAgICAgYmFja2dyb3VuZENvbG9yPXtcbiAgICAgICAgICAgICAgICAgICAgbGluZSA9PT0gb3JpZ2luLmxpbmUgPyAnYW5zaTpyZWQnIDogdW5kZWZpbmVkXG4gICAgICAgICAgICAgICAgICB9XG4gICAgICAgICAgICAgICAgICBjb2xvcj17bGluZSA9PT0gb3JpZ2luLmxpbmUgPyAnYW5zaTp3aGl0ZScgOiB1bmRlZmluZWR9XG4gICAgICAgICAgICAgICAgPlxuICAgICAgICAgICAgICAgICAge1N0cmluZyhsaW5lKS5wYWRTdGFydChsaW5lV2lkdGgsICcgJyl9OlxuICAgICAgICAgICAgICAgIDwvVGV4dD5cbiAgICAgICAgICAgICAgPC9Cb3g+XG5cbiAgICAgICAgICAgICAgPFRleHRcbiAgICAgICAgICAgICAgICBrZXk9e2xpbmV9XG4gICAgICAgICAgICAgICAgYmFja2dyb3VuZENvbG9yPXtsaW5lID09PSBvcmlnaW4ubGluZSA/ICdhbnNpOnJlZCcgOiB1bmRlZmluZWR9XG4gICAgICAgICAgICAgICAgY29sb3I9e2xpbmUgPT09IG9yaWdpbi5saW5lID8gJ2Fuc2k6d2hpdGUnIDogdW5kZWZpbmVkfVxuICAgICAgICAgICAgICA+XG4gICAgICAgICAgICAgICAgeycgJyArIHZhbHVlfVxuICAgICAgICAgICAgICA8L1RleHQ+XG4gICAgICAgICAgICA8L0JveD5cbiAgICAgICAgICApKX1cbiAgICAgICAgPC9Cb3g+XG4gICAgICApfVxuXG4gICAgICB7ZXJyb3Iuc3RhY2sgJiYgKFxuICAgICAgICA8Qm94IG1hcmdpblRvcD17MX0gZmxleERpcmVjdGlvbj1cImNvbHVtblwiPlxuICAgICAgICAgIHtlcnJvci5zdGFja1xuICAgICAgICAgICAgLnNwbGl0KCdcXG4nKVxuICAgICAgICAgICAgLnNsaWNlKDEpXG4gICAgICAgICAgICAubWFwKGxpbmUgPT4ge1xuICAgICAgICAgICAgICBjb25zdCBwYXJzZWRMaW5lID0gZ2V0U3RhY2tVdGlscygpLnBhcnNlTGluZShsaW5lKVxuXG4gICAgICAgICAgICAgIC8vIElmIHRoZSBsaW5lIGZyb20gdGhlIHN0YWNrIGNhbm5vdCBiZSBwYXJzZWQsIHdlIHByaW50IG91dCB0aGUgdW5wYXJzZWQgbGluZS5cbiAgICAgICAgICAgICAgaWYgKCFwYXJzZWRMaW5lKSB7XG4gICAgICAgICAgICAgICAgcmV0dXJuIChcbiAgICAgICAgICAgICAgICAgIDxCb3gga2V5PXtsaW5lfT5cbiAgICAgICAgICAgICAgICAgICAgPFRleHQgZGltPi0gPC9UZXh0PlxuICAgICAgICAgICAgICAgICAgICA8VGV4dCBib2xkPntsaW5lfTwvVGV4dD5cbiAgICAgICAgICAgICAgICAgIDwvQm94PlxuICAgICAgICAgICAgICAgIClcbiAgICAgICAgICAgICAgfVxuXG4gICAgICAgICAgICAgIHJldHVybiAoXG4gICAgICAgICAgICAgICAgPEJveCBrZXk9e2xpbmV9PlxuICAgICAgICAgICAgICAgICAgPFRleHQgZGltPi0gPC9UZXh0PlxuICAgICAgICAgICAgICAgICAgPFRleHQgYm9sZD57cGFyc2VkTGluZS5mdW5jdGlvbn08L1RleHQ+XG4gICAgICAgICAgICAgICAgICA8VGV4dCBkaW0+XG4gICAgICAgICAgICAgICAgICAgIHsnICd9XG4gICAgICAgICAgICAgICAgICAgICh7Y2xlYW51cFBhdGgocGFyc2VkTGluZS5maWxlKSA/PyAnJ306e3BhcnNlZExpbmUubGluZX06XG4gICAgICAgICAgICAgICAgICAgIHtwYXJzZWRMaW5lLmNvbHVtbn0pXG4gICAgICAgICAgICAgICAgICA8L1RleHQ+XG4gICAgICAgICAgICAgICAgPC9Cb3g+XG4gICAgICAgICAgICAgIClcbiAgICAgICAgICAgIH0pfVxuICAgICAgICA8L0JveD5cbiAgICAgICl9XG4gICAgPC9Cb3g+XG4gIClcbn1cbiJdLCJtYXBwaW5ncyI6IkFBQUEsT0FBT0EsV0FBVyxJQUFJLEtBQUtDLFdBQVcsUUFBUSxjQUFjO0FBQzVELFNBQVNDLFlBQVksUUFBUSxJQUFJO0FBQ2pDLE9BQU9DLEtBQUssTUFBTSxPQUFPO0FBQ3pCLE9BQU9DLFVBQVUsTUFBTSxhQUFhO0FBQ3BDLE9BQU9DLEdBQUcsTUFBTSxVQUFVO0FBQzFCLE9BQU9DLElBQUksTUFBTSxXQUFXOztBQUU1Qjs7QUFFQTtBQUNBO0FBQ0EsTUFBTUMsV0FBVyxHQUFHQSxDQUFDQyxJQUFJLEVBQUUsTUFBTSxHQUFHLFNBQVMsQ0FBQyxFQUFFLE1BQU0sR0FBRyxTQUFTLElBQUk7RUFDcEUsT0FBT0EsSUFBSSxFQUFFQyxPQUFPLENBQUMsVUFBVUMsT0FBTyxDQUFDQyxHQUFHLENBQUMsQ0FBQyxHQUFHLEVBQUUsRUFBRSxDQUFDO0FBQ3RELENBQUM7QUFFRCxJQUFJQyxVQUFVLEVBQUVSLFVBQVUsR0FBRyxTQUFTO0FBQ3RDLFNBQVNTLGFBQWFBLENBQUEsQ0FBRSxFQUFFVCxVQUFVLENBQUM7RUFDbkMsT0FBUVEsVUFBVSxLQUFLLElBQUlSLFVBQVUsQ0FBQztJQUNwQ08sR0FBRyxFQUFFRCxPQUFPLENBQUNDLEdBQUcsQ0FBQyxDQUFDO0lBQ2xCRyxTQUFTLEVBQUVWLFVBQVUsQ0FBQ1csYUFBYSxDQUFDO0VBQ3RDLENBQUMsQ0FBQztBQUNKOztBQUVBOztBQUVBLEtBQUtDLEtBQUssR0FBRztFQUNYLFNBQVNDLEtBQUssRUFBRUMsS0FBSztBQUN2QixDQUFDO0FBRUQsZUFBZSxTQUFTQyxhQUFhQSxDQUFDO0VBQUVGO0FBQWEsQ0FBTixFQUFFRCxLQUFLLEVBQUU7RUFDdEQsTUFBTUksS0FBSyxHQUFHSCxLQUFLLENBQUNHLEtBQUssR0FBR0gsS0FBSyxDQUFDRyxLQUFLLENBQUNDLEtBQUssQ0FBQyxJQUFJLENBQUMsQ0FBQ0MsS0FBSyxDQUFDLENBQUMsQ0FBQyxHQUFHQyxTQUFTO0VBQ3hFLE1BQU1DLE1BQU0sR0FBR0osS0FBSyxHQUFHUCxhQUFhLENBQUMsQ0FBQyxDQUFDWSxTQUFTLENBQUNMLEtBQUssQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLEdBQUdHLFNBQVM7RUFDdkUsTUFBTUcsUUFBUSxHQUFHbkIsV0FBVyxDQUFDaUIsTUFBTSxFQUFFRyxJQUFJLENBQUM7RUFDMUMsSUFBSUMsT0FBTyxFQUFFM0IsV0FBVyxFQUFFLEdBQUcsU0FBUztFQUN0QyxJQUFJNEIsU0FBUyxHQUFHLENBQUM7RUFFakIsSUFBSUgsUUFBUSxJQUFJRixNQUFNLEVBQUVNLElBQUksRUFBRTtJQUM1QixJQUFJO01BQ0Y7TUFDQSxNQUFNQyxVQUFVLEdBQUc3QixZQUFZLENBQUN3QixRQUFRLEVBQUUsTUFBTSxDQUFDO01BQ2pERSxPQUFPLEdBQUc1QixXQUFXLENBQUMrQixVQUFVLEVBQUVQLE1BQU0sQ0FBQ00sSUFBSSxDQUFDO01BRTlDLElBQUlGLE9BQU8sRUFBRTtRQUNYLEtBQUssTUFBTTtVQUFFRTtRQUFLLENBQUMsSUFBSUYsT0FBTyxFQUFFO1VBQzlCQyxTQUFTLEdBQUdHLElBQUksQ0FBQ0MsR0FBRyxDQUFDSixTQUFTLEVBQUVLLE1BQU0sQ0FBQ0osSUFBSSxDQUFDLENBQUNLLE1BQU0sQ0FBQztRQUN0RDtNQUNGO0lBQ0YsQ0FBQyxDQUFDLE1BQU07TUFDTjtJQUFBO0VBRUo7RUFFQSxPQUNFLENBQUMsR0FBRyxDQUFDLGFBQWEsQ0FBQyxRQUFRLENBQUMsT0FBTyxDQUFDLENBQUMsQ0FBQyxDQUFDO0FBQzNDLE1BQU0sQ0FBQyxHQUFHO0FBQ1YsUUFBUSxDQUFDLElBQUksQ0FBQyxlQUFlLENBQUMsVUFBVSxDQUFDLEtBQUssQ0FBQyxZQUFZO0FBQzNELFVBQVUsQ0FBQyxHQUFHO0FBQ2QsZUFBZSxDQUFDLEdBQUc7QUFDbkIsUUFBUSxFQUFFLElBQUk7QUFDZDtBQUNBLFFBQVEsQ0FBQyxJQUFJLENBQUMsQ0FBQyxDQUFDbEIsS0FBSyxDQUFDbUIsT0FBTyxDQUFDLEVBQUUsSUFBSTtBQUNwQyxNQUFNLEVBQUUsR0FBRztBQUNYO0FBQ0EsTUFBTSxDQUFDWixNQUFNLElBQUlFLFFBQVEsSUFDakIsQ0FBQyxHQUFHLENBQUMsU0FBUyxDQUFDLENBQUMsQ0FBQyxDQUFDO0FBQzFCLFVBQVUsQ0FBQyxJQUFJLENBQUMsR0FBRztBQUNuQixZQUFZLENBQUNBLFFBQVEsQ0FBQyxDQUFDLENBQUNGLE1BQU0sQ0FBQ00sSUFBSSxDQUFDLENBQUMsQ0FBQ04sTUFBTSxDQUFDYSxNQUFNO0FBQ25ELFVBQVUsRUFBRSxJQUFJO0FBQ2hCLFFBQVEsRUFBRSxHQUFHLENBQ047QUFDUDtBQUNBLE1BQU0sQ0FBQ2IsTUFBTSxJQUFJSSxPQUFPLElBQ2hCLENBQUMsR0FBRyxDQUFDLFNBQVMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLGFBQWEsQ0FBQyxRQUFRO0FBQ2pELFVBQVUsQ0FBQ0EsT0FBTyxDQUFDVSxHQUFHLENBQUMsQ0FBQztRQUFFUixJQUFJLEVBQUpBLE1BQUk7UUFBRVM7TUFBTSxDQUFDLEtBQzNCLENBQUMsR0FBRyxDQUFDLEdBQUcsQ0FBQyxDQUFDVCxNQUFJLENBQUM7QUFDM0IsY0FBYyxDQUFDLEdBQUcsQ0FBQyxLQUFLLENBQUMsQ0FBQ0QsU0FBUyxHQUFHLENBQUMsQ0FBQztBQUN4QyxnQkFBZ0IsQ0FBQyxJQUFJLENBQ0gsR0FBRyxDQUFDLENBQUNDLE1BQUksS0FBS04sTUFBTSxDQUFDTSxJQUFJLENBQUMsQ0FDMUIsZUFBZSxDQUFDLENBQ2RBLE1BQUksS0FBS04sTUFBTSxDQUFDTSxJQUFJLEdBQUcsVUFBVSxHQUFHUCxTQUN0QyxDQUFDLENBQ0QsS0FBSyxDQUFDLENBQUNPLE1BQUksS0FBS04sTUFBTSxDQUFDTSxJQUFJLEdBQUcsWUFBWSxHQUFHUCxTQUFTLENBQUM7QUFFekUsa0JBQWtCLENBQUNXLE1BQU0sQ0FBQ0osTUFBSSxDQUFDLENBQUNVLFFBQVEsQ0FBQ1gsU0FBUyxFQUFFLEdBQUcsQ0FBQyxDQUFDO0FBQ3pELGdCQUFnQixFQUFFLElBQUk7QUFDdEIsY0FBYyxFQUFFLEdBQUc7QUFDbkI7QUFDQSxjQUFjLENBQUMsSUFBSSxDQUNILEdBQUcsQ0FBQyxDQUFDQyxNQUFJLENBQUMsQ0FDVixlQUFlLENBQUMsQ0FBQ0EsTUFBSSxLQUFLTixNQUFNLENBQUNNLElBQUksR0FBRyxVQUFVLEdBQUdQLFNBQVMsQ0FBQyxDQUMvRCxLQUFLLENBQUMsQ0FBQ08sTUFBSSxLQUFLTixNQUFNLENBQUNNLElBQUksR0FBRyxZQUFZLEdBQUdQLFNBQVMsQ0FBQztBQUV2RSxnQkFBZ0IsQ0FBQyxHQUFHLEdBQUdnQixLQUFLO0FBQzVCLGNBQWMsRUFBRSxJQUFJO0FBQ3BCLFlBQVksRUFBRSxHQUFHLENBQ04sQ0FBQztBQUNaLFFBQVEsRUFBRSxHQUFHLENBQ047QUFDUDtBQUNBLE1BQU0sQ0FBQ3RCLEtBQUssQ0FBQ0csS0FBSyxJQUNWLENBQUMsR0FBRyxDQUFDLFNBQVMsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLGFBQWEsQ0FBQyxRQUFRO0FBQ2pELFVBQVUsQ0FBQ0gsS0FBSyxDQUFDRyxLQUFLLENBQ1RDLEtBQUssQ0FBQyxJQUFJLENBQUMsQ0FDWEMsS0FBSyxDQUFDLENBQUMsQ0FBQyxDQUNSZ0IsR0FBRyxDQUFDUixNQUFJLElBQUk7UUFDWCxNQUFNVyxVQUFVLEdBQUc1QixhQUFhLENBQUMsQ0FBQyxDQUFDWSxTQUFTLENBQUNLLE1BQUksQ0FBQzs7UUFFbEQ7UUFDQSxJQUFJLENBQUNXLFVBQVUsRUFBRTtVQUNmLE9BQ0UsQ0FBQyxHQUFHLENBQUMsR0FBRyxDQUFDLENBQUNYLE1BQUksQ0FBQztBQUNqQyxvQkFBb0IsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLEVBQUUsRUFBRSxJQUFJO0FBQ3RDLG9CQUFvQixDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsQ0FBQ0EsTUFBSSxDQUFDLEVBQUUsSUFBSTtBQUMzQyxrQkFBa0IsRUFBRSxHQUFHLENBQUM7UUFFVjtRQUVBLE9BQ0UsQ0FBQyxHQUFHLENBQUMsR0FBRyxDQUFDLENBQUNBLE1BQUksQ0FBQztBQUMvQixrQkFBa0IsQ0FBQyxJQUFJLENBQUMsR0FBRyxDQUFDLEVBQUUsRUFBRSxJQUFJO0FBQ3BDLGtCQUFrQixDQUFDLElBQUksQ0FBQyxJQUFJLENBQUMsQ0FBQ1csVUFBVSxDQUFDQyxRQUFRLENBQUMsRUFBRSxJQUFJO0FBQ3hELGtCQUFrQixDQUFDLElBQUksQ0FBQyxHQUFHO0FBQzNCLG9CQUFvQixDQUFDLEdBQUc7QUFDeEIscUJBQXFCLENBQUNuQyxXQUFXLENBQUNrQyxVQUFVLENBQUNkLElBQUksQ0FBQyxJQUFJLEVBQUUsQ0FBQyxDQUFDLENBQUNjLFVBQVUsQ0FBQ1gsSUFBSSxDQUFDO0FBQzNFLG9CQUFvQixDQUFDVyxVQUFVLENBQUNKLE1BQU0sQ0FBQztBQUN2QyxrQkFBa0IsRUFBRSxJQUFJO0FBQ3hCLGdCQUFnQixFQUFFLEdBQUcsQ0FBQztNQUVWLENBQUMsQ0FBQztBQUNkLFFBQVEsRUFBRSxHQUFHLENBQ047QUFDUCxJQUFJLEVBQUUsR0FBRyxDQUFDO0FBRVYiLCJpZ25vcmVMaXN0IjpbXX0=

--- a/packages/renderer/src/components/ErrorOverview.tsx
+++ b/packages/renderer/src/components/ErrorOverview.tsx
@@ -1,6 +1,5 @@
-import codeExcerpt, { type CodeExcerpt } from 'code-excerpt'
 import { readFileSync } from 'fs'
-import React from 'react'
+import codeExcerpt, { type CodeExcerpt } from 'code-excerpt'
 import StackUtils from 'stack-utils'
 import Box from './Box'
 import Text from './Text'

--- a/packages/renderer/src/components/ErrorOverview.tsx
+++ b/packages/renderer/src/components/ErrorOverview.tsx
@@ -1,4 +1,4 @@
-import { readFileSync } from 'fs'
+import { readFileSync } from 'node:fs'
 import codeExcerpt, { type CodeExcerpt } from 'code-excerpt'
 import StackUtils from 'stack-utils'
 import Box from './Box'
@@ -82,7 +82,7 @@ export default function ErrorOverview({ error }: Props) {
                 backgroundColor={line_0 === origin.line ? 'ansi:red' : undefined}
                 color={line_0 === origin.line ? 'ansi:white' : undefined}
               >
-                {' ' + value}
+                {` ${value}`}
               </Text>
             </Box>
           ))}

--- a/packages/renderer/src/components/ErrorOverview.tsx
+++ b/packages/renderer/src/components/ErrorOverview.tsx
@@ -13,10 +13,13 @@ const cleanupPath = (path: string | undefined): string | undefined => {
 }
 let stackUtils: StackUtils | undefined
 function getStackUtils(): StackUtils {
-  return (stackUtils ??= new StackUtils({
-    cwd: process.cwd(),
-    internals: StackUtils.nodeInternals(),
-  }))
+  if (!stackUtils) {
+    stackUtils = new StackUtils({
+      cwd: process.cwd(),
+      internals: StackUtils.nodeInternals(),
+    })
+  }
+  return stackUtils
 }
 
 /* eslint-enable custom-rules/no-process-cwd */

--- a/packages/renderer/src/components/Link.tsx
+++ b/packages/renderer/src/components/Link.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import React from 'react'
+import type React from 'react'
 import { supportsHyperlinks } from '../supports-hyperlinks.js'
 import Text from './Text.js'
 

--- a/packages/renderer/src/components/Link.tsx
+++ b/packages/renderer/src/components/Link.tsx
@@ -9,11 +9,7 @@ export type Props = {
   readonly fallback?: ReactNode
 }
 
-export default function Link({
-  children,
-  url,
-  fallback,
-}: Props): React.ReactNode {
+export default function Link({ children, url, fallback }: Props): React.ReactNode {
   // Use children if provided, otherwise display the URL
   const content = children ?? url
 

--- a/packages/renderer/src/components/Newline.tsx
+++ b/packages/renderer/src/components/Newline.tsx
@@ -1,5 +1,3 @@
-import React from 'react'
-
 export type Props = {
   /**
    * Number of newlines to insert.

--- a/packages/renderer/src/components/NoSelect.tsx
+++ b/packages/renderer/src/components/NoSelect.tsx
@@ -1,4 +1,5 @@
-import React, { type PropsWithChildren } from 'react'
+import type React from 'react'
+import type { PropsWithChildren } from 'react'
 import Box, { type Props as BoxProps } from './Box.js'
 
 type Props = Omit<BoxProps, 'noSelect'> & {

--- a/packages/renderer/src/components/RawAnsi.tsx
+++ b/packages/renderer/src/components/RawAnsi.tsx
@@ -1,4 +1,4 @@
-import React from 'react'
+import type React from 'react'
 
 type Props = {
   /**

--- a/packages/renderer/src/components/RawAnsi.tsx
+++ b/packages/renderer/src/components/RawAnsi.tsx
@@ -29,11 +29,5 @@ export function RawAnsi({ lines, width }: Props): React.ReactNode {
   if (lines.length === 0) {
     return null
   }
-  return (
-    <ink-raw-ansi
-      rawText={lines.join('\n')}
-      rawWidth={width}
-      rawHeight={lines.length}
-    />
-  )
+  return <ink-raw-ansi rawText={lines.join('\n')} rawWidth={width} rawHeight={lines.length} />
 }

--- a/packages/renderer/src/components/ScrollBox.tsx
+++ b/packages/renderer/src/components/ScrollBox.tsx
@@ -184,7 +184,7 @@ function ScrollBox({
       isSticky() {
         const el = domRef.current
         if (!el) return false
-        return el.stickyScroll ?? Boolean(el.attributes['stickyScroll'])
+        return el.stickyScroll ?? Boolean(el.attributes.stickyScroll)
       },
       subscribe(listener: () => void) {
         listenersRef.current.add(listener)

--- a/packages/renderer/src/components/ScrollBox.tsx
+++ b/packages/renderer/src/components/ScrollBox.tsx
@@ -1,13 +1,19 @@
-import React, { type PropsWithChildren, type Ref, useImperativeHandle, useRef, useState } from 'react';
-import type { Except } from 'type-fest';
-import type { DOMElement } from '../dom';
-import { markDirty, scheduleRenderFrom } from '../dom';
-import { markCommitStart } from '../reconciler';
-import type { Styles } from '../styles';
-import Box from './Box';
+import React, {
+  type PropsWithChildren,
+  type Ref,
+  useImperativeHandle,
+  useRef,
+  useState,
+} from 'react'
+import type { Except } from 'type-fest'
+import type { DOMElement } from '../dom'
+import { markDirty, scheduleRenderFrom } from '../dom'
+import { markCommitStart } from '../reconciler'
+import type { Styles } from '../styles'
+import Box from './Box'
 export type ScrollBoxHandle = {
-  scrollTo: (y: number) => void;
-  scrollBy: (dy: number) => void;
+  scrollTo: (y: number) => void
+  scrollBy: (dy: number) => void
   /**
    * Scroll so `el`'s top is at the viewport top (plus `offset`). Unlike
    * scrollTo which bakes a number that's stale by the time the throttled
@@ -15,24 +21,24 @@ export type ScrollBoxHandle = {
    * render-node-to-output reads `el.yogaNode.getComputedTop()` in the
    * SAME Yoga pass that computes scrollHeight. Deterministic. One-shot.
    */
-  scrollToElement: (el: DOMElement, offset?: number) => void;
-  scrollToBottom: () => void;
-  getScrollTop: () => number;
-  getPendingDelta: () => number;
-  getScrollHeight: () => number;
+  scrollToElement: (el: DOMElement, offset?: number) => void
+  scrollToBottom: () => void
+  getScrollTop: () => number
+  getPendingDelta: () => number
+  getScrollHeight: () => number
   /**
    * Like getScrollHeight, but reads Yoga directly instead of the cached
    * value written by render-node-to-output (throttled, up to 16ms stale).
    * Use when you need a fresh value in useLayoutEffect after a React commit
    * that grew content. Slightly more expensive (native Yoga call).
    */
-  getFreshScrollHeight: () => number;
-  getViewportHeight: () => number;
+  getFreshScrollHeight: () => number
+  getViewportHeight: () => number
   /**
    * Absolute screen-buffer row of the first visible content line (inside
    * padding). Used for drag-to-scroll edge detection.
    */
-  getViewportTop: () => number;
+  getViewportTop: () => number
   /**
    * True when scroll is pinned to the bottom. Set by scrollToBottom, the
    * initial stickyScroll attribute, and by the renderer when positional
@@ -40,14 +46,14 @@ export type ScrollBoxHandle = {
    * scrollTo/scrollBy. Stable signal for "at bottom" that doesn't depend on
    * layout values (unlike scrollTop+viewportH >= scrollHeight).
    */
-  isSticky: () => boolean;
+  isSticky: () => boolean
   /**
    * Subscribe to imperative scroll changes (scrollTo/scrollBy/scrollToBottom).
    * Does NOT fire for stickyScroll updates done by the Ink renderer — those
    * happen during Ink's render phase after React has committed. Callers that
    * care about the sticky case should treat "at bottom" as a fallback.
    */
-  subscribe: (listener: () => void) => () => void;
+  subscribe: (listener: () => void) => () => void
   /**
    * Set the render-time scrollTop clamp to the currently-mounted children's
    * coverage span. Called by useVirtualScroll after computing its range;
@@ -56,16 +62,16 @@ export type ScrollBoxHandle = {
    * content instead of blank spacer. Pass undefined to disable (sticky,
    * cold start).
    */
-  setClampBounds: (min: number | undefined, max: number | undefined) => void;
-};
+  setClampBounds: (min: number | undefined, max: number | undefined) => void
+}
 export type ScrollBoxProps = Except<Styles, 'textWrap' | 'overflow' | 'overflowX' | 'overflowY'> & {
-  ref?: Ref<ScrollBoxHandle>;
+  ref?: Ref<ScrollBoxHandle>
   /**
    * When true, automatically pins scroll position to the bottom when content
    * grows. Unset manually via scrollTo/scrollBy to break the stickiness.
    */
-  stickyScroll?: boolean;
-};
+  stickyScroll?: boolean
+}
 
 /**
  * A Box with `overflow: scroll` and an imperative scroll API.
@@ -83,7 +89,7 @@ function ScrollBox({
   stickyScroll,
   ...style
 }: PropsWithChildren<ScrollBoxProps>): React.ReactNode {
-  const domRef = useRef<DOMElement>(null);
+  const domRef = useRef<DOMElement>(null)
   // scrollTo/scrollBy bypass React: they mutate scrollTop on the DOM node,
   // mark it dirty, and call the root's throttled scheduleRender directly.
   // The Ink renderer reads scrollTop from the node — no React state needed,
@@ -92,113 +98,116 @@ function ScrollBox({
   // render — otherwise scheduleRender's leading edge fires on the FIRST
   // event before subsequent events mutate scrollTop. scrollToBottom still
   // forces a React render: sticky is attribute-observed, no DOM-only path.
-  const [, forceRender] = useState(0);
-  const listenersRef = useRef(new Set<() => void>());
-  const renderQueuedRef = useRef(false);
+  const [, forceRender] = useState(0)
+  const listenersRef = useRef(new Set<() => void>())
+  const renderQueuedRef = useRef(false)
   const notify = () => {
-    for (const l of listenersRef.current) l();
-  };
+    for (const l of listenersRef.current) l()
+  }
   function scrollMutated(el: DOMElement): void {
     // Signal background intervals (IDE poll, LSP poll, GCS fetch, orphan
     // check) to skip their next tick — they compete for the event loop and
     // contributed to 1402ms max frame gaps during scroll drain.
-    markDirty(el);
-    markCommitStart();
-    notify();
-    if (renderQueuedRef.current) return;
-    renderQueuedRef.current = true;
+    markDirty(el)
+    markCommitStart()
+    notify()
+    if (renderQueuedRef.current) return
+    renderQueuedRef.current = true
     queueMicrotask(() => {
-      renderQueuedRef.current = false;
-      scheduleRenderFrom(el);
-    });
+      renderQueuedRef.current = false
+      scheduleRenderFrom(el)
+    })
   }
-  useImperativeHandle(ref, (): ScrollBoxHandle => ({
-    scrollTo(y: number) {
-      const el = domRef.current;
-      if (!el) return;
-      // Explicit false overrides the DOM attribute so manual scroll
-      // breaks stickiness. Render code checks ?? precedence.
-      el.stickyScroll = false;
-      el.pendingScrollDelta = undefined;
-      el.scrollAnchor = undefined;
-      el.scrollTop = Math.max(0, Math.floor(y));
-      scrollMutated(el);
-    },
-    scrollToElement(el: DOMElement, offset = 0) {
-      const box = domRef.current;
-      if (!box) return;
-      box.stickyScroll = false;
-      box.pendingScrollDelta = undefined;
-      box.scrollAnchor = {
-        el,
-        offset
-      };
-      scrollMutated(box);
-    },
-    scrollBy(dy: number) {
-      const el = domRef.current;
-      if (!el) return;
-      el.stickyScroll = false;
-      // Wheel input cancels any in-flight anchor seek — user override.
-      el.scrollAnchor = undefined;
-      // Accumulate in pendingScrollDelta; renderer drains it at a capped
-      // rate so fast flicks show intermediate frames. Pure accumulator:
-      // scroll-up followed by scroll-down naturally cancels.
-      el.pendingScrollDelta = (el.pendingScrollDelta ?? 0) + Math.floor(dy);
-      scrollMutated(el);
-    },
-    scrollToBottom() {
-      const el = domRef.current;
-      if (!el) return;
-      el.pendingScrollDelta = undefined;
-      el.stickyScroll = true;
-      markDirty(el);
-      notify();
-      forceRender(n => n + 1);
-    },
-    getScrollTop() {
-      return domRef.current?.scrollTop ?? 0;
-    },
-    getPendingDelta() {
-      // Accumulated-but-not-yet-drained delta. useVirtualScroll needs
-      // this to mount the union [committed, committed+pending] range —
-      // otherwise intermediate drain frames find no children (blank).
-      return domRef.current?.pendingScrollDelta ?? 0;
-    },
-    getScrollHeight() {
-      return domRef.current?.scrollHeight ?? 0;
-    },
-    getFreshScrollHeight() {
-      const content = domRef.current?.childNodes[0] as DOMElement | undefined;
-      return content?.yogaNode?.getComputedHeight() ?? domRef.current?.scrollHeight ?? 0;
-    },
-    getViewportHeight() {
-      return domRef.current?.scrollViewportHeight ?? 0;
-    },
-    getViewportTop() {
-      return domRef.current?.scrollViewportTop ?? 0;
-    },
-    isSticky() {
-      const el = domRef.current;
-      if (!el) return false;
-      return el.stickyScroll ?? Boolean(el.attributes['stickyScroll']);
-    },
-    subscribe(listener: () => void) {
-      listenersRef.current.add(listener);
-      return () => listenersRef.current.delete(listener);
-    },
-    setClampBounds(min, max) {
-      const el = domRef.current;
-      if (!el) return;
-      el.scrollClampMin = min;
-      el.scrollClampMax = max;
-    }
-  }),
-  // notify/scrollMutated are inline (no useCallback) but only close over
-  // refs + imports — stable. Empty deps avoids rebuilding the handle on
-  // every render (which re-registers the ref = churn).
-  // eslint-disable-next-line react-hooks/exhaustive-deps
-  []);
+  useImperativeHandle(
+    ref,
+    (): ScrollBoxHandle => ({
+      scrollTo(y: number) {
+        const el = domRef.current
+        if (!el) return
+        // Explicit false overrides the DOM attribute so manual scroll
+        // breaks stickiness. Render code checks ?? precedence.
+        el.stickyScroll = false
+        el.pendingScrollDelta = undefined
+        el.scrollAnchor = undefined
+        el.scrollTop = Math.max(0, Math.floor(y))
+        scrollMutated(el)
+      },
+      scrollToElement(el: DOMElement, offset = 0) {
+        const box = domRef.current
+        if (!box) return
+        box.stickyScroll = false
+        box.pendingScrollDelta = undefined
+        box.scrollAnchor = {
+          el,
+          offset,
+        }
+        scrollMutated(box)
+      },
+      scrollBy(dy: number) {
+        const el = domRef.current
+        if (!el) return
+        el.stickyScroll = false
+        // Wheel input cancels any in-flight anchor seek — user override.
+        el.scrollAnchor = undefined
+        // Accumulate in pendingScrollDelta; renderer drains it at a capped
+        // rate so fast flicks show intermediate frames. Pure accumulator:
+        // scroll-up followed by scroll-down naturally cancels.
+        el.pendingScrollDelta = (el.pendingScrollDelta ?? 0) + Math.floor(dy)
+        scrollMutated(el)
+      },
+      scrollToBottom() {
+        const el = domRef.current
+        if (!el) return
+        el.pendingScrollDelta = undefined
+        el.stickyScroll = true
+        markDirty(el)
+        notify()
+        forceRender((n) => n + 1)
+      },
+      getScrollTop() {
+        return domRef.current?.scrollTop ?? 0
+      },
+      getPendingDelta() {
+        // Accumulated-but-not-yet-drained delta. useVirtualScroll needs
+        // this to mount the union [committed, committed+pending] range —
+        // otherwise intermediate drain frames find no children (blank).
+        return domRef.current?.pendingScrollDelta ?? 0
+      },
+      getScrollHeight() {
+        return domRef.current?.scrollHeight ?? 0
+      },
+      getFreshScrollHeight() {
+        const content = domRef.current?.childNodes[0] as DOMElement | undefined
+        return content?.yogaNode?.getComputedHeight() ?? domRef.current?.scrollHeight ?? 0
+      },
+      getViewportHeight() {
+        return domRef.current?.scrollViewportHeight ?? 0
+      },
+      getViewportTop() {
+        return domRef.current?.scrollViewportTop ?? 0
+      },
+      isSticky() {
+        const el = domRef.current
+        if (!el) return false
+        return el.stickyScroll ?? Boolean(el.attributes['stickyScroll'])
+      },
+      subscribe(listener: () => void) {
+        listenersRef.current.add(listener)
+        return () => listenersRef.current.delete(listener)
+      },
+      setClampBounds(min, max) {
+        const el = domRef.current
+        if (!el) return
+        el.scrollClampMin = min
+        el.scrollClampMax = max
+      },
+    }),
+    // notify/scrollMutated are inline (no useCallback) but only close over
+    // refs + imports — stable. Empty deps avoids rebuilding the handle on
+    // every render (which re-registers the ref = churn).
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [],
+  )
 
   // Structure: outer viewport (overflow:scroll, constrained height) >
   // inner content (flexGrow:1, flexShrink:0 — fills at least the viewport
@@ -211,24 +220,32 @@ function ScrollBox({
   // stickyScroll is passed as a DOM attribute (via ink-box directly) so it's
   // available on the first render — ref callbacks fire after the initial
   // commit, which is too late for the first frame.
-  return <ink-box ref={el => {
-    domRef.current = el;
-    if (el) el.scrollTop ??= 0;
-  }} style={{
-    flexWrap: 'nowrap',
-    flexDirection: style.flexDirection ?? 'row',
-    flexGrow: style.flexGrow ?? 0,
-    flexShrink: style.flexShrink ?? 1,
-    ...style,
-    overflowX: 'scroll',
-    overflowY: 'scroll'
-  }} {...stickyScroll ? {
-    stickyScroll: true
-  } : {}}>
+  return (
+    <ink-box
+      ref={(el) => {
+        domRef.current = el
+        if (el) el.scrollTop ??= 0
+      }}
+      style={{
+        flexWrap: 'nowrap',
+        flexDirection: style.flexDirection ?? 'row',
+        flexGrow: style.flexGrow ?? 0,
+        flexShrink: style.flexShrink ?? 1,
+        ...style,
+        overflowX: 'scroll',
+        overflowY: 'scroll',
+      }}
+      {...(stickyScroll
+        ? {
+            stickyScroll: true,
+          }
+        : {})}
+    >
       <Box flexDirection="column" flexGrow={1} flexShrink={0} width="100%">
         {children}
       </Box>
-    </ink-box>;
+    </ink-box>
+  )
 }
-export default ScrollBox;
+export default ScrollBox
 //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJuYW1lcyI6WyJSZWFjdCIsIlByb3BzV2l0aENoaWxkcmVuIiwiUmVmIiwidXNlSW1wZXJhdGl2ZUhhbmRsZSIsInVzZVJlZiIsInVzZVN0YXRlIiwiRXhjZXB0IiwibWFya1Njcm9sbEFjdGl2aXR5IiwiRE9NRWxlbWVudCIsIm1hcmtEaXJ0eSIsInNjaGVkdWxlUmVuZGVyRnJvbSIsIm1hcmtDb21taXRTdGFydCIsIlN0eWxlcyIsIkJveCIsIlNjcm9sbEJveEhhbmRsZSIsInNjcm9sbFRvIiwieSIsInNjcm9sbEJ5IiwiZHkiLCJzY3JvbGxUb0VsZW1lbnQiLCJlbCIsIm9mZnNldCIsInNjcm9sbFRvQm90dG9tIiwiZ2V0U2Nyb2xsVG9wIiwiZ2V0UGVuZGluZ0RlbHRhIiwiZ2V0U2Nyb2xsSGVpZ2h0IiwiZ2V0RnJlc2hTY3JvbGxIZWlnaHQiLCJnZXRWaWV3cG9ydEhlaWdodCIsImdldFZpZXdwb3J0VG9wIiwiaXNTdGlja3kiLCJzdWJzY3JpYmUiLCJsaXN0ZW5lciIsInNldENsYW1wQm91bmRzIiwibWluIiwibWF4IiwiU2Nyb2xsQm94UHJvcHMiLCJyZWYiLCJzdGlja3lTY3JvbGwiLCJTY3JvbGxCb3giLCJjaGlsZHJlbiIsInN0eWxlIiwiUmVhY3ROb2RlIiwiZG9tUmVmIiwiZm9yY2VSZW5kZXIiLCJsaXN0ZW5lcnNSZWYiLCJTZXQiLCJyZW5kZXJRdWV1ZWRSZWYiLCJub3RpZnkiLCJsIiwiY3VycmVudCIsInNjcm9sbE11dGF0ZWQiLCJxdWV1ZU1pY3JvdGFzayIsInBlbmRpbmdTY3JvbGxEZWx0YSIsInVuZGVmaW5lZCIsInNjcm9sbEFuY2hvciIsInNjcm9sbFRvcCIsIk1hdGgiLCJmbG9vciIsImJveCIsIm4iLCJzY3JvbGxIZWlnaHQiLCJjb250ZW50IiwiY2hpbGROb2RlcyIsInlvZ2FOb2RlIiwiZ2V0Q29tcHV0ZWRIZWlnaHQiLCJzY3JvbGxWaWV3cG9ydEhlaWdodCIsInNjcm9sbFZpZXdwb3J0VG9wIiwiQm9vbGVhbiIsImF0dHJpYnV0ZXMiLCJhZGQiLCJkZWxldGUiLCJzY3JvbGxDbGFtcE1pbiIsInNjcm9sbENsYW1wTWF4IiwiZmxleFdyYXAiLCJmbGV4RGlyZWN0aW9uIiwiZmxleEdyb3ciLCJmbGV4U2hyaW5rIiwib3ZlcmZsb3dYIiwib3ZlcmZsb3dZIl0sInNvdXJjZXMiOlsiU2Nyb2xsQm94LnRzeCJdLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgUmVhY3QsIHtcbiAgdHlwZSBQcm9wc1dpdGhDaGlsZHJlbixcbiAgdHlwZSBSZWYsXG4gIHVzZUltcGVyYXRpdmVIYW5kbGUsXG4gIHVzZVJlZixcbiAgdXNlU3RhdGUsXG59IGZyb20gJ3JlYWN0J1xuaW1wb3J0IHR5cGUgeyBFeGNlcHQgfSBmcm9tICd0eXBlLWZlc3QnXG5pbXBvcnQgeyBtYXJrU2Nyb2xsQWN0aXZpdHkgfSBmcm9tICcuLi8uLi9ib290c3RyYXAvc3RhdGUuanMnXG5pbXBvcnQgdHlwZSB7IERPTUVsZW1lbnQgfSBmcm9tICcuLi9kb20uanMnXG5pbXBvcnQgeyBtYXJrRGlydHksIHNjaGVkdWxlUmVuZGVyRnJvbSB9IGZyb20gJy4uL2RvbS5qcydcbmltcG9ydCB7IG1hcmtDb21taXRTdGFydCB9IGZyb20gJy4uL3JlY29uY2lsZXIuanMnXG5pbXBvcnQgdHlwZSB7IFN0eWxlcyB9IGZyb20gJy4uL3N0eWxlcy5qcydcbmltcG9ydCAnLi4vZ2xvYmFsLmQudHMnXG5pbXBvcnQgQm94IGZyb20gJy4vQm94LmpzJ1xuXG5leHBvcnQgdHlwZSBTY3JvbGxCb3hIYW5kbGUgPSB7XG4gIHNjcm9sbFRvOiAoeTogbnVtYmVyKSA9PiB2b2lkXG4gIHNjcm9sbEJ5OiAoZHk6IG51bWJlcikgPT4gdm9pZFxuICAvKipcbiAgICogU2Nyb2xsIHNvIGBlbGAncyB0b3AgaXMgYXQgdGhlIHZpZXdwb3J0IHRvcCAocGx1cyBgb2Zmc2V0YCkuIFVubGlrZVxuICAgKiBzY3JvbGxUbyB3aGljaCBiYWtlcyBhIG51bWJlciB0aGF0J3Mgc3RhbGUgYnkgdGhlIHRpbWUgdGhlIHRocm90dGxlZFxuICAgKiByZW5kZXIgZmlyZXMsIHRoaXMgZGVmZXJzIHRoZSBwb3NpdGlvbiByZWFkIHRvIHJlbmRlciB0aW1lIOKAlFxuICAgKiByZW5kZXItbm9kZS10by1vdXRwdXQgcmVhZHMgYGVsLnlvZ2FOb2RlLmdldENvbXB1dGVkVG9wKClgIGluIHRoZVxuICAgKiBTQU1FIFlvZ2EgcGFzcyB0aGF0IGNvbXB1dGVzIHNjcm9sbEhlaWdodC4gRGV0ZXJtaW5pc3RpYy4gT25lLXNob3QuXG4gICAqL1xuICBzY3JvbGxUb0VsZW1lbnQ6IChlbDogRE9NRWxlbWVudCwgb2Zmc2V0PzogbnVtYmVyKSA9PiB2b2lkXG4gIHNjcm9sbFRvQm90dG9tOiAoKSA9PiB2b2lkXG4gIGdldFNjcm9sbFRvcDogKCkgPT4gbnVtYmVyXG4gIGdldFBlbmRpbmdEZWx0YTogKCkgPT4gbnVtYmVyXG4gIGdldFNjcm9sbEhlaWdodDogKCkgPT4gbnVtYmVyXG4gIC8qKlxuICAgKiBMaWtlIGdldFNjcm9sbEhlaWdodCwgYnV0IHJlYWRzIFlvZ2EgZGlyZWN0bHkgaW5zdGVhZCBvZiB0aGUgY2FjaGVkXG4gICAqIHZhbHVlIHdyaXR0ZW4gYnkgcmVuZGVyLW5vZGUtdG8tb3V0cHV0ICh0aHJvdHRsZWQsIHVwIHRvIDE2bXMgc3RhbGUpLlxuICAgKiBVc2Ugd2hlbiB5b3UgbmVlZCBhIGZyZXNoIHZhbHVlIGluIHVzZUxheW91dEVmZmVjdCBhZnRlciBhIFJlYWN0IGNvbW1pdFxuICAgKiB0aGF0IGdyZXcgY29udGVudC4gU2xpZ2h0bHkgbW9yZSBleHBlbnNpdmUgKG5hdGl2ZSBZb2dhIGNhbGwpLlxuICAgKi9cbiAgZ2V0RnJlc2hTY3JvbGxIZWlnaHQ6ICgpID0+IG51bWJlclxuICBnZXRWaWV3cG9ydEhlaWdodDogKCkgPT4gbnVtYmVyXG4gIC8qKlxuICAgKiBBYnNvbHV0ZSBzY3JlZW4tYnVmZmVyIHJvdyBvZiB0aGUgZmlyc3QgdmlzaWJsZSBjb250ZW50IGxpbmUgKGluc2lkZVxuICAgKiBwYWRkaW5nKS4gVXNlZCBmb3IgZHJhZy10by1zY3JvbGwgZWRnZSBkZXRlY3Rpb24uXG4gICAqL1xuICBnZXRWaWV3cG9ydFRvcDogKCkgPT4gbnVtYmVyXG4gIC8qKlxuICAgKiBUcnVlIHdoZW4gc2Nyb2xsIGlzIHBpbm5lZCB0byB0aGUgYm90dG9tLiBTZXQgYnkgc2Nyb2xsVG9Cb3R0b20sIHRoZVxuICAgKiBpbml0aWFsIHN0aWNreVNjcm9sbCBhdHRyaWJ1dGUsIGFuZCBieSB0aGUgcmVuZGVyZXIgd2hlbiBwb3NpdGlvbmFsXG4gICAqIGZvbGxvdyBmaXJlcyAoc2Nyb2xsVG9wIGF0IHByZXZNYXgsIGNvbnRlbnQgZ3Jvd3MpLiBDbGVhcmVkIGJ5XG4gICAqIHNjcm9sbFRvL3Njcm9sbEJ5LiBTdGFibGUgc2lnbmFsIGZvciBcImF0IGJvdHRvbVwiIHRoYXQgZG9lc24ndCBkZXBlbmQgb25cbiAgICogbGF5b3V0IHZhbHVlcyAodW5saWtlIHNjcm9sbFRvcCt2aWV3cG9ydEggPj0gc2Nyb2xsSGVpZ2h0KS5cbiAgICovXG4gIGlzU3RpY2t5OiAoKSA9PiBib29sZWFuXG4gIC8qKlxuICAgKiBTdWJzY3JpYmUgdG8gaW1wZXJhdGl2ZSBzY3JvbGwgY2hhbmdlcyAoc2Nyb2xsVG8vc2Nyb2xsQnkvc2Nyb2xsVG9Cb3R0b20pLlxuICAgKiBEb2VzIE5PVCBmaXJlIGZvciBzdGlja3lTY3JvbGwgdXBkYXRlcyBkb25lIGJ5IHRoZSBJbmsgcmVuZGVyZXIg4oCUIHRob3NlXG4gICAqIGhhcHBlbiBkdXJpbmcgSW5rJ3MgcmVuZGVyIHBoYXNlIGFmdGVyIFJlYWN0IGhhcyBjb21taXR0ZWQuIENhbGxlcnMgdGhhdFxuICAgKiBjYXJlIGFib3V0IHRoZSBzdGlja3kgY2FzZSBzaG91bGQgdHJlYXQgXCJhdCBib3R0b21cIiBhcyBhIGZhbGxiYWNrLlxuICAgKi9cbiAgc3Vic2NyaWJlOiAobGlzdGVuZXI6ICgpID0+IHZvaWQpID0+ICgpID0+IHZvaWRcbiAgLyoqXG4gICAqIFNldCB0aGUgcmVuZGVyLXRpbWUgc2Nyb2xsVG9wIGNsYW1wIHRvIHRoZSBjdXJyZW50bHktbW91bnRlZCBjaGlsZHJlbidzXG4gICAqIGNvdmVyYWdlIHNwYW4uIENhbGxlZCBieSB1c2VWaXJ0dWFsU2Nyb2xsIGFmdGVyIGNvbXB1dGluZyBpdHMgcmFuZ2U7XG4gICAqIHJlbmRlci1ub2RlLXRvLW91dHB1dCBjbGFtcHMgc2Nyb2xsVG9wIHRvIFttaW4sIG1heF0gc28gYnVyc3Qgc2Nyb2xsVG9cbiAgICogY2FsbHMgdGhhdCByYWNlIHBhc3QgUmVhY3QncyBhc3luYyByZS1yZW5kZXIgc2hvdyB0aGUgZWRnZSBvZiBtb3VudGVkXG4gICAqIGNvbnRlbnQgaW5zdGVhZCBvZiBibGFuayBzcGFjZXIuIFBhc3MgdW5kZWZpbmVkIHRvIGRpc2FibGUgKHN0aWNreSxcbiAgICogY29sZCBzdGFydCkuXG4gICAqL1xuICBzZXRDbGFtcEJvdW5kczogKG1pbjogbnVtYmVyIHwgdW5kZWZpbmVkLCBtYXg6IG51bWJlciB8IHVuZGVmaW5lZCkgPT4gdm9pZFxufVxuXG5leHBvcnQgdHlwZSBTY3JvbGxCb3hQcm9wcyA9IEV4Y2VwdDxcbiAgU3R5bGVzLFxuICAndGV4dFdyYXAnIHwgJ292ZXJmbG93JyB8ICdvdmVyZmxvd1gnIHwgJ292ZXJmbG93WSdcbj4gJiB7XG4gIHJlZj86IFJlZjxTY3JvbGxCb3hIYW5kbGU+XG4gIC8qKlxuICAgKiBXaGVuIHRydWUsIGF1dG9tYXRpY2FsbHkgcGlucyBzY3JvbGwgcG9zaXRpb24gdG8gdGhlIGJvdHRvbSB3aGVuIGNvbnRlbnRcbiAgICogZ3Jvd3MuIFVuc2V0IG1hbnVhbGx5IHZpYSBzY3JvbGxUby9zY3JvbGxCeSB0byBicmVhayB0aGUgc3RpY2tpbmVzcy5cbiAgICovXG4gIHN0aWNreVNjcm9sbD86IGJvb2xlYW5cbn1cblxuLyoqXG4gKiBBIEJveCB3aXRoIGBvdmVyZmxvdzogc2Nyb2xsYCBhbmQgYW4gaW1wZXJhdGl2ZSBzY3JvbGwgQVBJLlxuICpcbiAqIENoaWxkcmVuIGFyZSBsYWlkIG91dCBhdCB0aGVpciBmdWxsIFlvZ2EtY29tcHV0ZWQgaGVpZ2h0IGluc2lkZSBhXG4gKiBjb25zdHJhaW5lZCBjb250YWluZXIuIEF0IHJlbmRlciB0aW1lLCBvbmx5IGNoaWxkcmVuIGludGVyc2VjdGluZyB0aGVcbiAqIHZpc2libGUgd2luZG93IChzY3JvbGxUb3AuLnNjcm9sbFRvcCtoZWlnaHQpIGFyZSByZW5kZXJlZCAodmlld3BvcnRcbiAqIGN1bGxpbmcpLiBDb250ZW50IGlzIHRyYW5zbGF0ZWQgYnkgLXNjcm9sbFRvcCBhbmQgY2xpcHBlZCB0byB0aGUgYm94IGJvdW5kcy5cbiAqXG4gKiBXb3JrcyBiZXN0IGluc2lkZSBhIGZ1bGxzY3JlZW4gKGNvbnN0cmFpbmVkLWhlaWdodCByb290KSBJbmsgdHJlZS5cbiAqL1xuZnVuY3Rpb24gU2Nyb2xsQm94KHtcbiAgY2hpbGRyZW4sXG4gIHJlZixcbiAgc3RpY2t5U2Nyb2xsLFxuICAuLi5zdHlsZVxufTogUHJvcHNXaXRoQ2hpbGRyZW48U2Nyb2xsQm94UHJvcHM+KTogUmVhY3QuUmVhY3ROb2RlIHtcbiAgY29uc3QgZG9tUmVmID0gdXNlUmVmPERPTUVsZW1lbnQ+KG51bGwpXG4gIC8vIHNjcm9sbFRvL3Njcm9sbEJ5IGJ5cGFzcyBSZWFjdDogdGhleSBtdXRhdGUgc2Nyb2xsVG9wIG9uIHRoZSBET00gbm9kZSxcbiAgLy8gbWFyayBpdCBkaXJ0eSwgYW5kIGNhbGwgdGhlIHJvb3QncyB0aHJvdHRsZWQgc2NoZWR1bGVSZW5kZXIgZGlyZWN0bHkuXG4gIC8vIFRoZSBJbmsgcmVuZGVyZXIgcmVhZHMgc2Nyb2xsVG9wIGZyb20gdGhlIG5vZGUg4oCUIG5vIFJlYWN0IHN0YXRlIG5lZWRlZCxcbiAgLy8gbm8gcmVjb25jaWxlciBvdmVyaGVhZCBwZXIgd2hlZWwgZXZlbnQuIFRoZSBtaWNyb3Rhc2sgZGVmZXIgY29hbGVzY2VzXG4gIC8vIG11bHRpcGxlIHNjcm9sbEJ5IGNhbGxzIGluIG9uZSBpbnB1dCBiYXRjaCAoZGlzY3JldGVVcGRhdGVzKSBpbnRvIG9uZVxuICAvLyByZW5kZXIg4oCUIG90aGVyd2lzZSBzY2hlZHVsZVJlbmRlcidzIGxlYWRpbmcgZWRnZSBmaXJlcyBvbiB0aGUgRklSU1RcbiAgLy8gZXZlbnQgYmVmb3JlIHN1YnNlcXVlbnQgZXZlbnRzIG11dGF0ZSBzY3JvbGxUb3AuIHNjcm9sbFRvQm90dG9tIHN0aWxsXG4gIC8vIGZvcmNlcyBhIFJlYWN0IHJlbmRlcjogc3RpY2t5IGlzIGF0dHJpYnV0ZS1vYnNlcnZlZCwgbm8gRE9NLW9ubHkgcGF0aC5cbiAgY29uc3QgWywgZm9yY2VSZW5kZXJdID0gdXNlU3RhdGUoMClcbiAgY29uc3QgbGlzdGVuZXJzUmVmID0gdXNlUmVmKG5ldyBTZXQ8KCkgPT4gdm9pZD4oKSlcbiAgY29uc3QgcmVuZGVyUXVldWVkUmVmID0gdXNlUmVmKGZhbHNlKVxuXG4gIGNvbnN0IG5vdGlmeSA9ICgpID0+IHtcbiAgICBmb3IgKGNvbnN0IGwgb2YgbGlzdGVuZXJzUmVmLmN1cnJlbnQpIGwoKVxuICB9XG5cbiAgZnVuY3Rpb24gc2Nyb2xsTXV0YXRlZChlbDogRE9NRWxlbWVudCk6IHZvaWQge1xuICAgIC8vIFNpZ25hbCBiYWNrZ3JvdW5kIGludGVydmFscyAoSURFIHBvbGwsIExTUCBwb2xsLCBHQ1MgZmV0Y2gsIG9ycGhhblxuICAgIC8vIGNoZWNrKSB0byBza2lwIHRoZWlyIG5leHQgdGljayDigJQgdGhleSBjb21wZXRlIGZvciB0aGUgZXZlbnQgbG9vcCBhbmRcbiAgICAvLyBjb250cmlidXRlZCB0byAxNDAybXMgbWF4IGZyYW1lIGdhcHMgZHVyaW5nIHNjcm9sbCBkcmFpbi5cbiAgICBtYXJrU2Nyb2xsQWN0aXZpdHkoKVxuICAgIG1hcmtEaXJ0eShlbClcbiAgICBtYXJrQ29tbWl0U3RhcnQoKVxuICAgIG5vdGlmeSgpXG4gICAgaWYgKHJlbmRlclF1ZXVlZFJlZi5jdXJyZW50KSByZXR1cm5cbiAgICByZW5kZXJRdWV1ZWRSZWYuY3VycmVudCA9IHRydWVcbiAgICBxdWV1ZU1pY3JvdGFzaygoKSA9PiB7XG4gICAgICByZW5kZXJRdWV1ZWRSZWYuY3VycmVudCA9IGZhbHNlXG4gICAgICBzY2hlZHVsZVJlbmRlckZyb20oZWwpXG4gICAgfSlcbiAgfVxuXG4gIHVzZUltcGVyYXRpdmVIYW5kbGUoXG4gICAgcmVmLFxuICAgICgpOiBTY3JvbGxCb3hIYW5kbGUgPT4gKHtcbiAgICAgIHNjcm9sbFRvKHk6IG51bWJlcikge1xuICAgICAgICBjb25zdCBlbCA9IGRvbVJlZi5jdXJyZW50XG4gICAgICAgIGlmICghZWwpIHJldHVyblxuICAgICAgICAvLyBFeHBsaWNpdCBmYWxzZSBvdmVycmlkZXMgdGhlIERPTSBhdHRyaWJ1dGUgc28gbWFudWFsIHNjcm9sbFxuICAgICAgICAvLyBicmVha3Mgc3RpY2tpbmVzcy4gUmVuZGVyIGNvZGUgY2hlY2tzID8/IHByZWNlZGVuY2UuXG4gICAgICAgIGVsLnN0aWNreVNjcm9sbCA9IGZhbHNlXG4gICAgICAgIGVsLnBlbmRpbmdTY3JvbGxEZWx0YSA9IHVuZGVmaW5lZFxuICAgICAgICBlbC5zY3JvbGxBbmNob3IgPSB1bmRlZmluZWRcbiAgICAgICAgZWwuc2Nyb2xsVG9wID0gTWF0aC5tYXgoMCwgTWF0aC5mbG9vcih5KSlcbiAgICAgICAgc2Nyb2xsTXV0YXRlZChlbClcbiAgICAgIH0sXG4gICAgICBzY3JvbGxUb0VsZW1lbnQoZWw6IERPTUVsZW1lbnQsIG9mZnNldCA9IDApIHtcbiAgICAgICAgY29uc3QgYm94ID0gZG9tUmVmLmN1cnJlbnRcbiAgICAgICAgaWYgKCFib3gpIHJldHVyblxuICAgICAgICBib3guc3RpY2t5U2Nyb2xsID0gZmFsc2VcbiAgICAgICAgYm94LnBlbmRpbmdTY3JvbGxEZWx0YSA9IHVuZGVmaW5lZFxuICAgICAgICBib3guc2Nyb2xsQW5jaG9yID0geyBlbCwgb2Zmc2V0IH1cbiAgICAgICAgc2Nyb2xsTXV0YXRlZChib3gpXG4gICAgICB9LFxuICAgICAgc2Nyb2xsQnkoZHk6IG51bWJlcikge1xuICAgICAgICBjb25zdCBlbCA9IGRvbVJlZi5jdXJyZW50XG4gICAgICAgIGlmICghZWwpIHJldHVyblxuICAgICAgICBlbC5zdGlja3lTY3JvbGwgPSBmYWxzZVxuICAgICAgICAvLyBXaGVlbCBpbnB1dCBjYW5jZWxzIGFueSBpbi1mbGlnaHQgYW5jaG9yIHNlZWsg4oCUIHVzZXIgb3ZlcnJpZGUuXG4gICAgICAgIGVsLnNjcm9sbEFuY2hvciA9IHVuZGVmaW5lZFxuICAgICAgICAvLyBBY2N1bXVsYXRlIGluIHBlbmRpbmdTY3JvbGxEZWx0YTsgcmVuZGVyZXIgZHJhaW5zIGl0IGF0IGEgY2FwcGVkXG4gICAgICAgIC8vIHJhdGUgc28gZmFzdCBmbGlja3Mgc2hvdyBpbnRlcm1lZGlhdGUgZnJhbWVzLiBQdXJlIGFjY3VtdWxhdG9yOlxuICAgICAgICAvLyBzY3JvbGwtdXAgZm9sbG93ZWQgYnkgc2Nyb2xsLWRvd24gbmF0dXJhbGx5IGNhbmNlbHMuXG4gICAgICAgIGVsLnBlbmRpbmdTY3JvbGxEZWx0YSA9IChlbC5wZW5kaW5nU2Nyb2xsRGVsdGEgPz8gMCkgKyBNYXRoLmZsb29yKGR5KVxuICAgICAgICBzY3JvbGxNdXRhdGVkKGVsKVxuICAgICAgfSxcbiAgICAgIHNjcm9sbFRvQm90dG9tKCkge1xuICAgICAgICBjb25zdCBlbCA9IGRvbVJlZi5jdXJyZW50XG4gICAgICAgIGlmICghZWwpIHJldHVyblxuICAgICAgICBlbC5wZW5kaW5nU2Nyb2xsRGVsdGEgPSB1bmRlZmluZWRcbiAgICAgICAgZWwuc3RpY2t5U2Nyb2xsID0gdHJ1ZVxuICAgICAgICBtYXJrRGlydHkoZWwpXG4gICAgICAgIG5vdGlmeSgpXG4gICAgICAgIGZvcmNlUmVuZGVyKG4gPT4gbiArIDEpXG4gICAgICB9LFxuICAgICAgZ2V0U2Nyb2xsVG9wKCkge1xuICAgICAgICByZXR1cm4gZG9tUmVmLmN1cnJlbnQ/LnNjcm9sbFRvcCA/PyAwXG4gICAgICB9LFxuICAgICAgZ2V0UGVuZGluZ0RlbHRhKCkge1xuICAgICAgICAvLyBBY2N1bXVsYXRlZC1idXQtbm90LXlldC1kcmFpbmVkIGRlbHRhLiB1c2VWaXJ0dWFsU2Nyb2xsIG5lZWRzXG4gICAgICAgIC8vIHRoaXMgdG8gbW91bnQgdGhlIHVuaW9uIFtjb21taXR0ZWQsIGNvbW1pdHRlZCtwZW5kaW5nXSByYW5nZSDigJRcbiAgICAgICAgLy8gb3RoZXJ3aXNlIGludGVybWVkaWF0ZSBkcmFpbiBmcmFtZXMgZmluZCBubyBjaGlsZHJlbiAoYmxhbmspLlxuICAgICAgICByZXR1cm4gZG9tUmVmLmN1cnJlbnQ/LnBlbmRpbmdTY3JvbGxEZWx0YSA/PyAwXG4gICAgICB9LFxuICAgICAgZ2V0U2Nyb2xsSGVpZ2h0KCkge1xuICAgICAgICByZXR1cm4gZG9tUmVmLmN1cnJlbnQ/LnNjcm9sbEhlaWdodCA/PyAwXG4gICAgICB9LFxuICAgICAgZ2V0RnJlc2hTY3JvbGxIZWlnaHQoKSB7XG4gICAgICAgIGNvbnN0IGNvbnRlbnQgPSBkb21SZWYuY3VycmVudD8uY2hpbGROb2Rlc1swXSBhcyBET01FbGVtZW50IHwgdW5kZWZpbmVkXG4gICAgICAgIHJldHVybiAoXG4gICAgICAgICAgY29udGVudD8ueW9nYU5vZGU/LmdldENvbXB1dGVkSGVpZ2h0KCkgPz9cbiAgICAgICAgICBkb21SZWYuY3VycmVudD8uc2Nyb2xsSGVpZ2h0ID8/XG4gICAgICAgICAgMFxuICAgICAgICApXG4gICAgICB9LFxuICAgICAgZ2V0Vmlld3BvcnRIZWlnaHQoKSB7XG4gICAgICAgIHJldHVybiBkb21SZWYuY3VycmVudD8uc2Nyb2xsVmlld3BvcnRIZWlnaHQgPz8gMFxuICAgICAgfSxcbiAgICAgIGdldFZpZXdwb3J0VG9wKCkge1xuICAgICAgICByZXR1cm4gZG9tUmVmLmN1cnJlbnQ/LnNjcm9sbFZpZXdwb3J0VG9wID8/IDBcbiAgICAgIH0sXG4gICAgICBpc1N0aWNreSgpIHtcbiAgICAgICAgY29uc3QgZWwgPSBkb21SZWYuY3VycmVudFxuICAgICAgICBpZiAoIWVsKSByZXR1cm4gZmFsc2VcbiAgICAgICAgcmV0dXJuIGVsLnN0aWNreVNjcm9sbCA/PyBCb29sZWFuKGVsLmF0dHJpYnV0ZXNbJ3N0aWNreVNjcm9sbCddKVxuICAgICAgfSxcbiAgICAgIHN1YnNjcmliZShsaXN0ZW5lcjogKCkgPT4gdm9pZCkge1xuICAgICAgICBsaXN0ZW5lcnNSZWYuY3VycmVudC5hZGQobGlzdGVuZXIpXG4gICAgICAgIHJldHVybiAoKSA9PiBsaXN0ZW5lcnNSZWYuY3VycmVudC5kZWxldGUobGlzdGVuZXIpXG4gICAgICB9LFxuICAgICAgc2V0Q2xhbXBCb3VuZHMobWluLCBtYXgpIHtcbiAgICAgICAgY29uc3QgZWwgPSBkb21SZWYuY3VycmVudFxuICAgICAgICBpZiAoIWVsKSByZXR1cm5cbiAgICAgICAgZWwuc2Nyb2xsQ2xhbXBNaW4gPSBtaW5cbiAgICAgICAgZWwuc2Nyb2xsQ2xhbXBNYXggPSBtYXhcbiAgICAgIH0sXG4gICAgfSksXG4gICAgLy8gbm90aWZ5L3Njcm9sbE11dGF0ZWQgYXJlIGlubGluZSAobm8gdXNlQ2FsbGJhY2spIGJ1dCBvbmx5IGNsb3NlIG92ZXJcbiAgICAvLyByZWZzICsgaW1wb3J0cyDigJQgc3RhYmxlLiBFbXB0eSBkZXBzIGF2b2lkcyByZWJ1aWxkaW5nIHRoZSBoYW5kbGUgb25cbiAgICAvLyBldmVyeSByZW5kZXIgKHdoaWNoIHJlLXJlZ2lzdGVycyB0aGUgcmVmID0gY2h1cm4pLlxuICAgIC8vIGVzbGludC1kaXNhYmxlLW5leHQtbGluZSByZWFjdC1ob29rcy9leGhhdXN0aXZlLWRlcHNcbiAgICBbXSxcbiAgKVxuXG4gIC8vIFN0cnVjdHVyZTogb3V0ZXIgdmlld3BvcnQgKG92ZXJmbG93OnNjcm9sbCwgY29uc3RyYWluZWQgaGVpZ2h0KSA+XG4gIC8vIGlubmVyIGNvbnRlbnQgKGZsZXhHcm93OjEsIGZsZXhTaHJpbms6MCDigJQgZmlsbHMgYXQgbGVhc3QgdGhlIHZpZXdwb3J0XG4gIC8vIGJ1dCBncm93cyBiZXlvbmQgaXQgZm9yIHRhbGwgY29udGVudCkuIGZsZXhHcm93OjEgbGV0cyBjaGlsZHJlbiB1c2VcbiAgLy8gc3BhY2VycyB0byBwaW4gZWxlbWVudHMgdG8gdGhlIGJvdHRvbSBvZiB0aGUgc2Nyb2xsIGFyZWEuIFlvZ2Enc1xuICAvLyBPdmVyZmxvdy5TY3JvbGwgcHJldmVudHMgdGhlIHZpZXdwb3J0IGZyb20gZ3Jvd2luZyB0byBmaXQgdGhlIGNvbnRlbnQuXG4gIC8vIFRoZSByZW5kZXJlciBjb21wdXRlcyBzY3JvbGxIZWlnaHQgZnJvbSB0aGUgY29udGVudCBib3ggYW5kIGN1bGxzXG4gIC8vIGNvbnRlbnQncyBjaGlsZHJlbiBiYXNlZCBvbiBzY3JvbGxUb3AuXG4gIC8vXG4gIC8vIHN0aWNreVNjcm9sbCBpcyBwYXNzZWQgYXMgYSBET00gYXR0cmlidXRlICh2aWEgaW5rLWJveCBkaXJlY3RseSkgc28gaXQnc1xuICAvLyBhdmFpbGFibGUgb24gdGhlIGZpcnN0IHJlbmRlciDigJQgcmVmIGNhbGxiYWNrcyBmaXJlIGFmdGVyIHRoZSBpbml0aWFsXG4gIC8vIGNvbW1pdCwgd2hpY2ggaXMgdG9vIGxhdGUgZm9yIHRoZSBmaXJzdCBmcmFtZS5cbiAgcmV0dXJuIChcbiAgICA8aW5rLWJveFxuICAgICAgcmVmPXtlbCA9PiB7XG4gICAgICAgIGRvbVJlZi5jdXJyZW50ID0gZWxcbiAgICAgICAgaWYgKGVsKSBlbC5zY3JvbGxUb3AgPz89IDBcbiAgICAgIH19XG4gICAgICBzdHlsZT17e1xuICAgICAgICBmbGV4V3JhcDogJ25vd3JhcCcsXG4gICAgICAgIGZsZXhEaXJlY3Rpb246IHN0eWxlLmZsZXhEaXJlY3Rpb24gPz8gJ3JvdycsXG4gICAgICAgIGZsZXhHcm93OiBzdHlsZS5mbGV4R3JvdyA/PyAwLFxuICAgICAgICBmbGV4U2hyaW5rOiBzdHlsZS5mbGV4U2hyaW5rID8/IDEsXG4gICAgICAgIC4uLnN0eWxlLFxuICAgICAgICBvdmVyZmxvd1g6ICdzY3JvbGwnLFxuICAgICAgICBvdmVyZmxvd1k6ICdzY3JvbGwnLFxuICAgICAgfX1cbiAgICAgIHsuLi4oc3RpY2t5U2Nyb2xsID8geyBzdGlja3lTY3JvbGw6IHRydWUgfSA6IHt9KX1cbiAgICA+XG4gICAgICA8Qm94IGZsZXhEaXJlY3Rpb249XCJjb2x1bW5cIiBmbGV4R3Jvdz17MX0gZmxleFNocmluaz17MH0gd2lkdGg9XCIxMDAlXCI+XG4gICAgICAgIHtjaGlsZHJlbn1cbiAgICAgIDwvQm94PlxuICAgIDwvaW5rLWJveD5cbiAgKVxufVxuXG5leHBvcnQgZGVmYXVsdCBTY3JvbGxCb3hcbiJdLCJtYXBwaW5ncyI6IkFBQUEsT0FBT0EsS0FBSyxJQUNWLEtBQUtDLGlCQUFpQixFQUN0QixLQUFLQyxHQUFHLEVBQ1JDLG1CQUFtQixFQUNuQkMsTUFBTSxFQUNOQyxRQUFRLFFBQ0gsT0FBTztBQUNkLGNBQWNDLE1BQU0sUUFBUSxXQUFXO0FBQ3ZDLFNBQVNDLGtCQUFrQixRQUFRLDBCQUEwQjtBQUM3RCxjQUFjQyxVQUFVLFFBQVEsV0FBVztBQUMzQyxTQUFTQyxTQUFTLEVBQUVDLGtCQUFrQixRQUFRLFdBQVc7QUFDekQsU0FBU0MsZUFBZSxRQUFRLGtCQUFrQjtBQUNsRCxjQUFjQyxNQUFNLFFBQVEsY0FBYztBQUMxQyxPQUFPLGdCQUFnQjtBQUN2QixPQUFPQyxHQUFHLE1BQU0sVUFBVTtBQUUxQixPQUFPLEtBQUtDLGVBQWUsR0FBRztFQUM1QkMsUUFBUSxFQUFFLENBQUNDLENBQUMsRUFBRSxNQUFNLEVBQUUsR0FBRyxJQUFJO0VBQzdCQyxRQUFRLEVBQUUsQ0FBQ0MsRUFBRSxFQUFFLE1BQU0sRUFBRSxHQUFHLElBQUk7RUFDOUI7QUFDRjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7RUFDRUMsZUFBZSxFQUFFLENBQUNDLEVBQUUsRUFBRVosVUFBVSxFQUFFYSxNQUFlLENBQVIsRUFBRSxNQUFNLEVBQUUsR0FBRyxJQUFJO0VBQzFEQyxjQUFjLEVBQUUsR0FBRyxHQUFHLElBQUk7RUFDMUJDLFlBQVksRUFBRSxHQUFHLEdBQUcsTUFBTTtFQUMxQkMsZUFBZSxFQUFFLEdBQUcsR0FBRyxNQUFNO0VBQzdCQyxlQUFlLEVBQUUsR0FBRyxHQUFHLE1BQU07RUFDN0I7QUFDRjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0VDLG9CQUFvQixFQUFFLEdBQUcsR0FBRyxNQUFNO0VBQ2xDQyxpQkFBaUIsRUFBRSxHQUFHLEdBQUcsTUFBTTtFQUMvQjtBQUNGO0FBQ0E7QUFDQTtFQUNFQyxjQUFjLEVBQUUsR0FBRyxHQUFHLE1BQU07RUFDNUI7QUFDRjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7RUFDRUMsUUFBUSxFQUFFLEdBQUcsR0FBRyxPQUFPO0VBQ3ZCO0FBQ0Y7QUFDQTtBQUNBO0FBQ0E7QUFDQTtFQUNFQyxTQUFTLEVBQUUsQ0FBQ0MsUUFBUSxFQUFFLEdBQUcsR0FBRyxJQUFJLEVBQUUsR0FBRyxHQUFHLEdBQUcsSUFBSTtFQUMvQztBQUNGO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0VDLGNBQWMsRUFBRSxDQUFDQyxHQUFHLEVBQUUsTUFBTSxHQUFHLFNBQVMsRUFBRUMsR0FBRyxFQUFFLE1BQU0sR0FBRyxTQUFTLEVBQUUsR0FBRyxJQUFJO0FBQzVFLENBQUM7QUFFRCxPQUFPLEtBQUtDLGNBQWMsR0FBRzdCLE1BQU0sQ0FDakNNLE1BQU0sRUFDTixVQUFVLEdBQUcsVUFBVSxHQUFHLFdBQVcsR0FBRyxXQUFXLENBQ3BELEdBQUc7RUFDRndCLEdBQUcsQ0FBQyxFQUFFbEMsR0FBRyxDQUFDWSxlQUFlLENBQUM7RUFDMUI7QUFDRjtBQUNBO0FBQ0E7RUFDRXVCLFlBQVksQ0FBQyxFQUFFLE9BQU87QUFDeEIsQ0FBQzs7QUFFRDtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBLFNBQVNDLFNBQVNBLENBQUM7RUFDakJDLFFBQVE7RUFDUkgsR0FBRztFQUNIQyxZQUFZO0VBQ1osR0FBR0c7QUFDOEIsQ0FBbEMsRUFBRXZDLGlCQUFpQixDQUFDa0MsY0FBYyxDQUFDLENBQUMsRUFBRW5DLEtBQUssQ0FBQ3lDLFNBQVMsQ0FBQztFQUNyRCxNQUFNQyxNQUFNLEdBQUd0QyxNQUFNLENBQUNJLFVBQVUsQ0FBQyxDQUFDLElBQUksQ0FBQztFQUN2QztFQUNBO0VBQ0E7RUFDQTtFQUNBO0VBQ0E7RUFDQTtFQUNBO0VBQ0EsTUFBTSxHQUFHbUMsV0FBVyxDQUFDLEdBQUd0QyxRQUFRLENBQUMsQ0FBQyxDQUFDO0VBQ25DLE1BQU11QyxZQUFZLEdBQUd4QyxNQUFNLENBQUMsSUFBSXlDLEdBQUcsQ0FBQyxHQUFHLEdBQUcsSUFBSSxDQUFDLENBQUMsQ0FBQyxDQUFDO0VBQ2xELE1BQU1DLGVBQWUsR0FBRzFDLE1BQU0sQ0FBQyxLQUFLLENBQUM7RUFFckMsTUFBTTJDLE1BQU0sR0FBR0EsQ0FBQSxLQUFNO0lBQ25CLEtBQUssTUFBTUMsQ0FBQyxJQUFJSixZQUFZLENBQUNLLE9BQU8sRUFBRUQsQ0FBQyxDQUFDLENBQUM7RUFDM0MsQ0FBQztFQUVELFNBQVNFLGFBQWFBLENBQUM5QixFQUFFLEVBQUVaLFVBQVUsQ0FBQyxFQUFFLElBQUksQ0FBQztJQUMzQztJQUNBO0lBQ0E7SUFDQUQsa0JBQWtCLENBQUMsQ0FBQztJQUNwQkUsU0FBUyxDQUFDVyxFQUFFLENBQUM7SUFDYlQsZUFBZSxDQUFDLENBQUM7SUFDakJvQyxNQUFNLENBQUMsQ0FBQztJQUNSLElBQUlELGVBQWUsQ0FBQ0csT0FBTyxFQUFFO0lBQzdCSCxlQUFlLENBQUNHLE9BQU8sR0FBRyxJQUFJO0lBQzlCRSxjQUFjLENBQUMsTUFBTTtNQUNuQkwsZUFBZSxDQUFDRyxPQUFPLEdBQUcsS0FBSztNQUMvQnZDLGtCQUFrQixDQUFDVSxFQUFFLENBQUM7SUFDeEIsQ0FBQyxDQUFDO0VBQ0o7RUFFQWpCLG1CQUFtQixDQUNqQmlDLEdBQUcsRUFDSCxFQUFFLEVBQUV0QixlQUFlLEtBQUs7SUFDdEJDLFFBQVFBLENBQUNDLENBQUMsRUFBRSxNQUFNLEVBQUU7TUFDbEIsTUFBTUksRUFBRSxHQUFHc0IsTUFBTSxDQUFDTyxPQUFPO01BQ3pCLElBQUksQ0FBQzdCLEVBQUUsRUFBRTtNQUNUO01BQ0E7TUFDQUEsRUFBRSxDQUFDaUIsWUFBWSxHQUFHLEtBQUs7TUFDdkJqQixFQUFFLENBQUNnQyxrQkFBa0IsR0FBR0MsU0FBUztNQUNqQ2pDLEVBQUUsQ0FBQ2tDLFlBQVksR0FBR0QsU0FBUztNQUMzQmpDLEVBQUUsQ0FBQ21DLFNBQVMsR0FBR0MsSUFBSSxDQUFDdEIsR0FBRyxDQUFDLENBQUMsRUFBRXNCLElBQUksQ0FBQ0MsS0FBSyxDQUFDekMsQ0FBQyxDQUFDLENBQUM7TUFDekNrQyxhQUFhLENBQUM5QixFQUFFLENBQUM7SUFDbkIsQ0FBQztJQUNERCxlQUFlQSxDQUFDQyxFQUFFLEVBQUVaLFVBQVUsRUFBRWEsTUFBTSxHQUFHLENBQUMsRUFBRTtNQUMxQyxNQUFNcUMsR0FBRyxHQUFHaEIsTUFBTSxDQUFDTyxPQUFPO01BQzFCLElBQUksQ0FBQ1MsR0FBRyxFQUFFO01BQ1ZBLEdBQUcsQ0FBQ3JCLFlBQVksR0FBRyxLQUFLO01BQ3hCcUIsR0FBRyxDQUFDTixrQkFBa0IsR0FBR0MsU0FBUztNQUNsQ0ssR0FBRyxDQUFDSixZQUFZLEdBQUc7UUFBRWxDLEVBQUU7UUFBRUM7TUFBTyxDQUFDO01BQ2pDNkIsYUFBYSxDQUFDUSxHQUFHLENBQUM7SUFDcEIsQ0FBQztJQUNEekMsUUFBUUEsQ0FBQ0MsRUFBRSxFQUFFLE1BQU0sRUFBRTtNQUNuQixNQUFNRSxFQUFFLEdBQUdzQixNQUFNLENBQUNPLE9BQU87TUFDekIsSUFBSSxDQUFDN0IsRUFBRSxFQUFFO01BQ1RBLEVBQUUsQ0FBQ2lCLFlBQVksR0FBRyxLQUFLO01BQ3ZCO01BQ0FqQixFQUFFLENBQUNrQyxZQUFZLEdBQUdELFNBQVM7TUFDM0I7TUFDQTtNQUNBO01BQ0FqQyxFQUFFLENBQUNnQyxrQkFBa0IsR0FBRyxDQUFDaEMsRUFBRSxDQUFDZ0Msa0JBQWtCLElBQUksQ0FBQyxJQUFJSSxJQUFJLENBQUNDLEtBQUssQ0FBQ3ZDLEVBQUUsQ0FBQztNQUNyRWdDLGFBQWEsQ0FBQzlCLEVBQUUsQ0FBQztJQUNuQixDQUFDO0lBQ0RFLGNBQWNBLENBQUEsRUFBRztNQUNmLE1BQU1GLEVBQUUsR0FBR3NCLE1BQU0sQ0FBQ08sT0FBTztNQUN6QixJQUFJLENBQUM3QixFQUFFLEVBQUU7TUFDVEEsRUFBRSxDQUFDZ0Msa0JBQWtCLEdBQUdDLFNBQVM7TUFDakNqQyxFQUFFLENBQUNpQixZQUFZLEdBQUcsSUFBSTtNQUN0QjVCLFNBQVMsQ0FBQ1csRUFBRSxDQUFDO01BQ2IyQixNQUFNLENBQUMsQ0FBQztNQUNSSixXQUFXLENBQUNnQixDQUFDLElBQUlBLENBQUMsR0FBRyxDQUFDLENBQUM7SUFDekIsQ0FBQztJQUNEcEMsWUFBWUEsQ0FBQSxFQUFHO01BQ2IsT0FBT21CLE1BQU0sQ0FBQ08sT0FBTyxFQUFFTSxTQUFTLElBQUksQ0FBQztJQUN2QyxDQUFDO0lBQ0QvQixlQUFlQSxDQUFBLEVBQUc7TUFDaEI7TUFDQTtNQUNBO01BQ0EsT0FBT2tCLE1BQU0sQ0FBQ08sT0FBTyxFQUFFRyxrQkFBa0IsSUFBSSxDQUFDO0lBQ2hELENBQUM7SUFDRDNCLGVBQWVBLENBQUEsRUFBRztNQUNoQixPQUFPaUIsTUFBTSxDQUFDTyxPQUFPLEVBQUVXLFlBQVksSUFBSSxDQUFDO0lBQzFDLENBQUM7SUFDRGxDLG9CQUFvQkEsQ0FBQSxFQUFHO01BQ3JCLE1BQU1tQyxPQUFPLEdBQUduQixNQUFNLENBQUNPLE9BQU8sRUFBRWEsVUFBVSxDQUFDLENBQUMsQ0FBQyxJQUFJdEQsVUFBVSxHQUFHLFNBQVM7TUFDdkUsT0FDRXFELE9BQU8sRUFBRUUsUUFBUSxFQUFFQyxpQkFBaUIsQ0FBQyxDQUFDLElBQ3RDdEIsTUFBTSxDQUFDTyxPQUFPLEVBQUVXLFlBQVksSUFDNUIsQ0FBQztJQUVMLENBQUM7SUFDRGpDLGlCQUFpQkEsQ0FBQSxFQUFHO01BQ2xCLE9BQU9lLE1BQU0sQ0FBQ08sT0FBTyxFQUFFZ0Isb0JBQW9CLElBQUksQ0FBQztJQUNsRCxDQUFDO0lBQ0RyQyxjQUFjQSxDQUFBLEVBQUc7TUFDZixPQUFPYyxNQUFNLENBQUNPLE9BQU8sRUFBRWlCLGlCQUFpQixJQUFJLENBQUM7SUFDL0MsQ0FBQztJQUNEckMsUUFBUUEsQ0FBQSxFQUFHO01BQ1QsTUFBTVQsRUFBRSxHQUFHc0IsTUFBTSxDQUFDTyxPQUFPO01BQ3pCLElBQUksQ0FBQzdCLEVBQUUsRUFBRSxPQUFPLEtBQUs7TUFDckIsT0FBT0EsRUFBRSxDQUFDaUIsWUFBWSxJQUFJOEIsT0FBTyxDQUFDL0MsRUFBRSxDQUFDZ0QsVUFBVSxDQUFDLGNBQWMsQ0FBQyxDQUFDO0lBQ2xFLENBQUM7SUFDRHRDLFNBQVNBLENBQUNDLFFBQVEsRUFBRSxHQUFHLEdBQUcsSUFBSSxFQUFFO01BQzlCYSxZQUFZLENBQUNLLE9BQU8sQ0FBQ29CLEdBQUcsQ0FBQ3RDLFFBQVEsQ0FBQztNQUNsQyxPQUFPLE1BQU1hLFlBQVksQ0FBQ0ssT0FBTyxDQUFDcUIsTUFBTSxDQUFDdkMsUUFBUSxDQUFDO0lBQ3BELENBQUM7SUFDREMsY0FBY0EsQ0FBQ0MsR0FBRyxFQUFFQyxHQUFHLEVBQUU7TUFDdkIsTUFBTWQsRUFBRSxHQUFHc0IsTUFBTSxDQUFDTyxPQUFPO01BQ3pCLElBQUksQ0FBQzdCLEVBQUUsRUFBRTtNQUNUQSxFQUFFLENBQUNtRCxjQUFjLEdBQUd0QyxHQUFHO01BQ3ZCYixFQUFFLENBQUNvRCxjQUFjLEdBQUd0QyxHQUFHO0lBQ3pCO0VBQ0YsQ0FBQyxDQUFDO0VBQ0Y7RUFDQTtFQUNBO0VBQ0E7RUFDQSxFQUNGLENBQUM7O0VBRUQ7RUFDQTtFQUNBO0VBQ0E7RUFDQTtFQUNBO0VBQ0E7RUFDQTtFQUNBO0VBQ0E7RUFDQTtFQUNBLE9BQ0UsQ0FBQyxPQUFPLENBQ04sR0FBRyxDQUFDLENBQUNkLEVBQUUsSUFBSTtJQUNUc0IsTUFBTSxDQUFDTyxPQUFPLEdBQUc3QixFQUFFO0lBQ25CLElBQUlBLEVBQUUsRUFBRUEsRUFBRSxDQUFDbUMsU0FBUyxLQUFLLENBQUM7RUFDNUIsQ0FBQyxDQUFDLENBQ0YsS0FBSyxDQUFDLENBQUM7SUFDTGtCLFFBQVEsRUFBRSxRQUFRO0lBQ2xCQyxhQUFhLEVBQUVsQyxLQUFLLENBQUNrQyxhQUFhLElBQUksS0FBSztJQUMzQ0MsUUFBUSxFQUFFbkMsS0FBSyxDQUFDbUMsUUFBUSxJQUFJLENBQUM7SUFDN0JDLFVBQVUsRUFBRXBDLEtBQUssQ0FBQ29DLFVBQVUsSUFBSSxDQUFDO0lBQ2pDLEdBQUdwQyxLQUFLO0lBQ1JxQyxTQUFTLEVBQUUsUUFBUTtJQUNuQkMsU0FBUyxFQUFFO0VBQ2IsQ0FBQyxDQUFDLENBQ0YsSUFBS3pDLFlBQVksR0FBRztJQUFFQSxZQUFZLEVBQUU7RUFBSyxDQUFDLEdBQUcsQ0FBQyxDQUFFLENBQUM7QUFFdkQsTUFBTSxDQUFDLEdBQUcsQ0FBQyxhQUFhLENBQUMsUUFBUSxDQUFDLFFBQVEsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLFVBQVUsQ0FBQyxDQUFDLENBQUMsQ0FBQyxDQUFDLEtBQUssQ0FBQyxNQUFNO0FBQzFFLFFBQVEsQ0FBQ0UsUUFBUTtBQUNqQixNQUFNLEVBQUUsR0FBRztBQUNYLElBQUksRUFBRSxPQUFPLENBQUM7QUFFZDtBQUVBLGVBQWVELFNBQVMiLCJpZ25vcmVMaXN0IjpbXX0=

--- a/packages/renderer/src/components/ScrollBox.tsx
+++ b/packages/renderer/src/components/ScrollBox.tsx
@@ -1,10 +1,5 @@
-import React, {
-  type PropsWithChildren,
-  type Ref,
-  useImperativeHandle,
-  useRef,
-  useState,
-} from 'react'
+import type React from 'react'
+import { type PropsWithChildren, type Ref, useImperativeHandle, useRef, useState } from 'react'
 import type { Except } from 'type-fest'
 import type { DOMElement } from '../dom'
 import { markDirty, scheduleRenderFrom } from '../dom'

--- a/packages/renderer/src/components/ScrollBox.tsx
+++ b/packages/renderer/src/components/ScrollBox.tsx
@@ -113,6 +113,7 @@ function ScrollBox({
       scheduleRenderFrom(el)
     })
   }
+  // biome-ignore lint/correctness/useExhaustiveDependencies: notify and scrollMutated are stable closures over refs + imports; rebuilding on every render would re-register the ref every commit (churn). See trailing comment for full rationale.
   useImperativeHandle(
     ref,
     (): ScrollBoxHandle => ({

--- a/packages/renderer/src/components/Spacer.tsx
+++ b/packages/renderer/src/components/Spacer.tsx
@@ -1,4 +1,3 @@
-import React from 'react'
 import Box from './Box.js'
 
 /**

--- a/packages/renderer/src/components/StdinContext.ts
+++ b/packages/renderer/src/components/StdinContext.ts
@@ -47,4 +47,3 @@ const StdinContext = createContext<Props>({
 StdinContext.displayName = 'InternalStdinContext'
 
 export default StdinContext
-

--- a/packages/renderer/src/components/TerminalFocusContext.tsx
+++ b/packages/renderer/src/components/TerminalFocusContext.tsx
@@ -29,25 +29,15 @@ export function TerminalFocusProvider({
 }: {
   children: React.ReactNode
 }): React.ReactNode {
-  const isTerminalFocused = useSyncExternalStore(
-    subscribeTerminalFocus,
-    getTerminalFocused,
-  )
-  const terminalFocusState = useSyncExternalStore(
-    subscribeTerminalFocus,
-    getTerminalFocusState,
-  )
+  const isTerminalFocused = useSyncExternalStore(subscribeTerminalFocus, getTerminalFocused)
+  const terminalFocusState = useSyncExternalStore(subscribeTerminalFocus, getTerminalFocusState)
 
   const value = useMemo(
     () => ({ isTerminalFocused, terminalFocusState }),
     [isTerminalFocused, terminalFocusState],
   )
 
-  return (
-    <TerminalFocusContext.Provider value={value}>
-      {children}
-    </TerminalFocusContext.Provider>
-  )
+  return <TerminalFocusContext.Provider value={value}>{children}</TerminalFocusContext.Provider>
 }
 
 export default TerminalFocusContext

--- a/packages/renderer/src/components/TerminalFocusContext.tsx
+++ b/packages/renderer/src/components/TerminalFocusContext.tsx
@@ -1,9 +1,10 @@
-import React, { createContext, useMemo, useSyncExternalStore } from 'react'
+import type React from 'react'
+import { createContext, useMemo, useSyncExternalStore } from 'react'
 import {
-  getTerminalFocused,
-  getTerminalFocusState,
-  subscribeTerminalFocus,
   type TerminalFocusState,
+  getTerminalFocusState,
+  getTerminalFocused,
+  subscribeTerminalFocus,
 } from '../terminal-focus-state.js'
 
 export type { TerminalFocusState }

--- a/packages/renderer/src/components/TerminalSizeContext.tsx
+++ b/packages/renderer/src/components/TerminalSizeContext.tsx
@@ -1,7 +1,7 @@
-import { createContext } from 'react';
+import { createContext } from 'react'
 export type TerminalSize = {
-  columns: number;
-  rows: number;
-};
-export const TerminalSizeContext = createContext<TerminalSize | null>(null);
+  columns: number
+  rows: number
+}
+export const TerminalSizeContext = createContext<TerminalSize | null>(null)
 //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJuYW1lcyI6WyJjcmVhdGVDb250ZXh0IiwiVGVybWluYWxTaXplIiwiY29sdW1ucyIsInJvd3MiLCJUZXJtaW5hbFNpemVDb250ZXh0Il0sInNvdXJjZXMiOlsiVGVybWluYWxTaXplQ29udGV4dC50c3giXSwic291cmNlc0NvbnRlbnQiOlsiaW1wb3J0IHsgY3JlYXRlQ29udGV4dCB9IGZyb20gJ3JlYWN0J1xuXG5leHBvcnQgdHlwZSBUZXJtaW5hbFNpemUgPSB7XG4gIGNvbHVtbnM6IG51bWJlclxuICByb3dzOiBudW1iZXJcbn1cblxuZXhwb3J0IGNvbnN0IFRlcm1pbmFsU2l6ZUNvbnRleHQgPSBjcmVhdGVDb250ZXh0PFRlcm1pbmFsU2l6ZSB8IG51bGw+KG51bGwpXG4iXSwibWFwcGluZ3MiOiJBQUFBLFNBQVNBLGFBQWEsUUFBUSxPQUFPO0FBRXJDLE9BQU8sS0FBS0MsWUFBWSxHQUFHO0VBQ3pCQyxPQUFPLEVBQUUsTUFBTTtFQUNmQyxJQUFJLEVBQUUsTUFBTTtBQUNkLENBQUM7QUFFRCxPQUFPLE1BQU1DLG1CQUFtQixHQUFHSixhQUFhLENBQUNDLFlBQVksR0FBRyxJQUFJLENBQUMsQ0FBQyxJQUFJLENBQUMiLCJpZ25vcmVMaXN0IjpbXX0=

--- a/packages/renderer/src/components/Text.tsx
+++ b/packages/renderer/src/components/Text.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react'
-import React from 'react'
+import type React from 'react'
 import type { Color, Styles, TextStyles } from '../styles.js'
 
 type BaseProps = {

--- a/packages/renderer/src/constants.ts
+++ b/packages/renderer/src/constants.ts
@@ -1,3 +1,2 @@
 // Shared frame interval for render throttling and animations (~60fps)
 export const FRAME_INTERVAL_MS = 16
-

--- a/packages/renderer/src/dom.ts
+++ b/packages/renderer/src/dom.ts
@@ -109,9 +109,7 @@ export type DOMNodeAttribute = boolean | string | number
 
 export const createNode = (nodeName: ElementNames): DOMElement => {
   const needsYogaNode =
-    nodeName !== 'ink-virtual-text' &&
-    nodeName !== 'ink-link' &&
-    nodeName !== 'ink-progress'
+    nodeName !== 'ink-virtual-text' && nodeName !== 'ink-link' && nodeName !== 'ink-progress'
   const node: DOMElement = {
     nodeName,
     style: {},
@@ -131,10 +129,7 @@ export const createNode = (nodeName: ElementNames): DOMElement => {
   return node
 }
 
-export const appendChildNode = (
-  node: DOMElement,
-  childNode: DOMElement,
-): void => {
+export const appendChildNode = (node: DOMElement, childNode: DOMElement): void => {
   if (childNode.parentNode) {
     removeChildNode(childNode.parentNode, childNode)
   }
@@ -143,10 +138,7 @@ export const appendChildNode = (
   node.childNodes.push(childNode)
 
   if (childNode.yogaNode) {
-    node.yogaNode?.insertChild(
-      childNode.yogaNode,
-      node.yogaNode.getChildCount(),
-    )
+    node.yogaNode?.insertChild(childNode.yogaNode, node.yogaNode.getChildCount())
   }
 
   markDirty(node)
@@ -192,19 +184,13 @@ export const insertBeforeNode = (
   node.childNodes.push(newChildNode)
 
   if (newChildNode.yogaNode) {
-    node.yogaNode?.insertChild(
-      newChildNode.yogaNode,
-      node.yogaNode.getChildCount(),
-    )
+    node.yogaNode?.insertChild(newChildNode.yogaNode, node.yogaNode.getChildCount())
   }
 
   markDirty(node)
 }
 
-export const removeChildNode = (
-  node: DOMElement,
-  removeNode: DOMNode,
-): void => {
+export const removeChildNode = (node: DOMElement, removeNode: DOMNode): void => {
   if (removeNode.yogaNode) {
     removeNode.parentNode?.yogaNode?.removeChild(removeNode.yogaNode)
   }
@@ -222,11 +208,7 @@ export const removeChildNode = (
   markDirty(node)
 }
 
-function collectRemovedRects(
-  parent: DOMElement,
-  removed: DOMNode,
-  underAbsolute = false,
-): void {
+function collectRemovedRects(parent: DOMElement, removed: DOMNode, underAbsolute = false): void {
   if (removed.nodeName === '#text') return
   const elem = removed as DOMElement
   // If this node or any ancestor in the removed subtree was absolute,
@@ -244,11 +226,7 @@ function collectRemovedRects(
   }
 }
 
-export const setAttribute = (
-  node: DOMElement,
-  key: string,
-  value: DOMNodeAttribute,
-): void => {
+export const setAttribute = (node: DOMElement, key: string, value: DOMNodeAttribute): void => {
   // Skip 'children' - React handles children via appendChild/removeChild,
   // not attributes. React always passes a new children reference, so
   // tracking it as an attribute would mark everything dirty every render.
@@ -273,10 +251,7 @@ export const setStyle = (node: DOMNode, style: Styles): void => {
   markDirty(node)
 }
 
-export const setTextStyles = (
-  node: DOMElement,
-  textStyles: TextStyles,
-): void => {
+export const setTextStyles = (node: DOMElement, textStyles: TextStyles): void => {
   // Same dirty-check guard as setStyle: React (and buildTextStyles in Text.tsx)
   // allocate a new textStyles object on every render even when values are
   // unchanged, so compare by value to avoid markDirty -> yoga re-measurement
@@ -292,10 +267,7 @@ function stylesEqual(a: Styles, b: Styles): boolean {
   return shallowEqual(a, b)
 }
 
-function shallowEqual<T extends object>(
-  a: T | undefined,
-  b: T | undefined,
-): boolean {
+function shallowEqual<T extends object>(a: T | undefined, b: T | undefined): boolean {
   // Fast path: same object reference (or both undefined)
   if (a === b) return true
   if (a === undefined || b === undefined) return false
@@ -334,8 +306,7 @@ const measureTextNode = function (
   width: number,
   widthMode: LayoutMeasureMode,
 ): { width: number; height: number } {
-  const rawText =
-    node.nodeName === '#text' ? node.nodeValue : squashTextNodes(node)
+  const rawText = node.nodeName === '#text' ? node.nodeValue : squashTextNodes(node)
 
   // Expand tabs for measurement (worst case: 8 spaces each).
   // Actual tab expansion happens in output.ts based on screen position.
@@ -400,8 +371,7 @@ export const markDirty = (node?: DOMNode): void => {
       // Only mark yoga dirty on leaf nodes that have measure functions
       if (
         !markedYoga &&
-        (current.nodeName === 'ink-text' ||
-          current.nodeName === 'ink-raw-ansi') &&
+        (current.nodeName === 'ink-text' || current.nodeName === 'ink-raw-ansi') &&
         current.yogaNode
       ) {
         current.yogaNode.markDirty()
@@ -482,4 +452,3 @@ export function findOwnerChainAtRow(root: DOMElement, y: number): string[] {
     }
   }
 }
-

--- a/packages/renderer/src/dom.ts
+++ b/packages/renderer/src/dom.ts
@@ -393,16 +393,14 @@ export const scheduleRenderFrom = (node?: DOMNode): void => {
 }
 
 export const setTextNodeValue = (node: TextNode, text: string): void => {
-  if (typeof text !== 'string') {
-    text = String(text)
-  }
+  // Coerce non-string inputs at the boundary. The signature claims string
+  // but React can hand us numbers/booleans during JSX child flattening.
+  const value = typeof text === 'string' ? text : String(text)
 
   // Skip if unchanged
-  if (node.nodeValue === text) {
-    return
-  }
+  if (node.nodeValue === value) return
 
-  node.nodeValue = text
+  node.nodeValue = value
   markDirty(node)
 }
 

--- a/packages/renderer/src/dom.ts
+++ b/packages/renderer/src/dom.ts
@@ -353,8 +353,8 @@ const measureRawAnsiNode = (
   width: number
   height: number
 } => ({
-  width: node.attributes['rawWidth'] as number,
-  height: node.attributes['rawHeight'] as number,
+  width: node.attributes.rawWidth as number,
+  height: node.attributes.rawHeight as number,
 })
 
 /**

--- a/packages/renderer/src/dom.ts
+++ b/packages/renderer/src/dom.ts
@@ -301,11 +301,11 @@ export const createTextNode = (text: string): TextNode => {
   return node
 }
 
-const measureTextNode = function (
+const measureTextNode = (
   node: DOMNode,
   width: number,
   widthMode: LayoutMeasureMode,
-): { width: number; height: number } {
+): { width: number; height: number } => {
   const rawText = node.nodeName === '#text' ? node.nodeValue : squashTextNodes(node)
 
   // Expand tabs for measurement (worst case: 8 spaces each).
@@ -347,15 +347,15 @@ const measureTextNode = function (
 // ink-raw-ansi nodes hold pre-rendered ANSI strings with known dimensions.
 // No stringWidth, no wrapping, no tab expansion — the producer (e.g. ColorDiff)
 // already wrapped to the target width and each line is exactly one terminal row.
-const measureRawAnsiNode = function (node: DOMElement): {
+const measureRawAnsiNode = (
+  node: DOMElement,
+): {
   width: number
   height: number
-} {
-  return {
-    width: node.attributes['rawWidth'] as number,
-    height: node.attributes['rawHeight'] as number,
-  }
-}
+} => ({
+  width: node.attributes['rawWidth'] as number,
+  height: node.attributes['rawHeight'] as number,
+})
 
 /**
  * Mark a node and all its ancestors as dirty for re-rendering.

--- a/packages/renderer/src/events/click-event.ts
+++ b/packages/renderer/src/events/click-event.ts
@@ -36,4 +36,3 @@ export class ClickEvent extends Event {
     this.cellIsBlank = cellIsBlank
   }
 }
-

--- a/packages/renderer/src/events/dispatcher.ts
+++ b/packages/renderer/src/events/dispatcher.ts
@@ -43,10 +43,7 @@ function getHandler(
  *
  * Result: [root-cap, ..., parent-cap, target-cap, target-bub, parent-bub, ..., root-bub]
  */
-function collectListeners(
-  target: EventTarget,
-  event: TerminalEvent,
-): DispatchListener[] {
+function collectListeners(target: EventTarget, event: TerminalEvent): DispatchListener[] {
   const listeners: DispatchListener[] = []
 
   let node: EventTarget | undefined = target
@@ -84,10 +81,7 @@ function collectListeners(
  * Before each handler, calls event._prepareForTarget(node) so event
  * subclasses can do per-node setup.
  */
-function processDispatchQueue(
-  listeners: DispatchListener[],
-  event: TerminalEvent,
-): void {
+function processDispatchQueue(listeners: DispatchListener[], event: TerminalEvent): void {
   let previousNode: EventTarget | undefined
 
   for (const { node, handler, phase } of listeners) {
@@ -208,13 +202,7 @@ export class Dispatcher {
     if (!this.discreteUpdates) {
       return this.dispatch(target, event)
     }
-    return this.discreteUpdates(
-      (t, e) => this.dispatch(t, e),
-      target,
-      event,
-      undefined,
-      undefined,
-    )
+    return this.discreteUpdates((t, e) => this.dispatch(t, e), target, event, undefined, undefined)
   }
 
   /**

--- a/packages/renderer/src/events/dispatcher.ts
+++ b/packages/renderer/src/events/dispatcher.ts
@@ -1,10 +1,10 @@
+import { logError } from '@yokai/shared'
 import {
   ContinuousEventPriority,
   DefaultEventPriority,
   DiscreteEventPriority,
   NoEventPriority,
 } from 'react-reconciler/constants.js'
-import { logError } from '@yokai/shared'
 import { HANDLER_FOR_EVENT } from './event-handlers.js'
 import type { EventTarget, TerminalEvent } from './terminal-event.js'
 

--- a/packages/renderer/src/events/emitter.ts
+++ b/packages/renderer/src/events/emitter.ts
@@ -37,4 +37,3 @@ export class EventEmitter extends NodeEventEmitter {
     return true
   }
 }
-

--- a/packages/renderer/src/events/emitter.ts
+++ b/packages/renderer/src/events/emitter.ts
@@ -1,4 +1,4 @@
-import { EventEmitter as NodeEventEmitter } from 'events'
+import { EventEmitter as NodeEventEmitter } from 'node:events'
 import { Event } from './event'
 
 // Similar to node's builtin EventEmitter, but is also aware of our `Event`

--- a/packages/renderer/src/events/event-handlers.ts
+++ b/packages/renderer/src/events/event-handlers.ts
@@ -71,4 +71,3 @@ export const EVENT_HANDLER_PROPS = new Set<string>([
   'onMouseEnter',
   'onMouseLeave',
 ])
-

--- a/packages/renderer/src/events/event.ts
+++ b/packages/renderer/src/events/event.ts
@@ -9,4 +9,3 @@ export class Event {
     this._didStopImmediatePropagation = true
   }
 }
-

--- a/packages/renderer/src/events/focus-event.ts
+++ b/packages/renderer/src/events/focus-event.ts
@@ -11,12 +11,8 @@ import { type EventTarget, TerminalEvent } from './terminal-event'
 export class FocusEvent extends TerminalEvent {
   readonly relatedTarget: EventTarget | null
 
-  constructor(
-    type: 'focus' | 'blur',
-    relatedTarget: EventTarget | null = null,
-  ) {
+  constructor(type: 'focus' | 'blur', relatedTarget: EventTarget | null = null) {
     super(type, { bubbles: true, cancelable: false })
     this.relatedTarget = relatedTarget
   }
 }
-

--- a/packages/renderer/src/events/input-event.ts
+++ b/packages/renderer/src/events/input-event.ts
@@ -1,4 +1,4 @@
-import { nonAlphanumericKeys, type ParsedKey } from '../parse-keypress'
+import { type ParsedKey, nonAlphanumericKeys } from '../parse-keypress'
 import { Event } from './event'
 
 export type Key = {

--- a/packages/renderer/src/events/input-event.ts
+++ b/packages/renderer/src/events/input-event.ts
@@ -119,12 +119,7 @@ function parseKey(keypress: ParsedKey): [Key, string] {
       // processedAsSpecialSequence bypasses the nonAlphanumericKeys
       // clear below, so we must handle it explicitly here);
       // otherwise use key name.
-      input =
-        keypress.name === 'space'
-          ? ' '
-          : keypress.name === 'escape'
-            ? ''
-            : keypress.name
+      input = keypress.name === 'space' ? ' ' : keypress.name === 'escape' ? '' : keypress.name
     }
     processedAsSpecialSequence = true
   }
@@ -141,12 +136,7 @@ function parseKey(keypress: ParsedKey): [Key, string] {
       // guards against future terminal behavior.
       input = ''
     } else {
-      input =
-        keypress.name === 'space'
-          ? ' '
-          : keypress.name === 'escape'
-            ? ''
-            : keypress.name
+      input = keypress.name === 'space' ? ' ' : keypress.name === 'escape' ? '' : keypress.name
     }
     processedAsSpecialSequence = true
   }
@@ -154,12 +144,7 @@ function parseKey(keypress: ParsedKey): [Key, string] {
   // Handle application keypad mode sequences: after stripping ESC,
   // we're left with "O<letter>" (e.g., "Op" for numpad 0, "Oy" for numpad 9).
   // Use the parsed key name (the digit character) for input handling.
-  if (
-    input.startsWith('O') &&
-    input.length === 2 &&
-    keypress.name &&
-    keypress.name.length === 1
-  ) {
+  if (input.startsWith('O') && input.length === 2 && keypress.name && keypress.name.length === 1) {
     input = keypress.name
     processedAsSpecialSequence = true
   }
@@ -167,22 +152,13 @@ function parseKey(keypress: ParsedKey): [Key, string] {
   // Clear input for non-alphanumeric keys (arrows, function keys, etc.)
   // Skip this for CSI u and application keypad mode sequences since
   // those were already converted to their proper input characters.
-  if (
-    !processedAsSpecialSequence &&
-    keypress.name &&
-    nonAlphanumericKeys.includes(keypress.name)
-  ) {
+  if (!processedAsSpecialSequence && keypress.name && nonAlphanumericKeys.includes(keypress.name)) {
     input = ''
   }
 
   // Set shift=true for uppercase letters (A-Z)
   // Must check it's actually a letter, not just any char unchanged by toUpperCase
-  if (
-    input.length === 1 &&
-    typeof input[0] === 'string' &&
-    input[0] >= 'A' &&
-    input[0] <= 'Z'
-  ) {
+  if (input.length === 1 && typeof input[0] === 'string' && input[0] >= 'A' && input[0] <= 'Z') {
     key.shift = true
   }
 
@@ -203,4 +179,3 @@ export class InputEvent extends Event {
     this.input = input
   }
 }
-

--- a/packages/renderer/src/events/keyboard-event.ts
+++ b/packages/renderer/src/events/keyboard-event.ts
@@ -49,4 +49,3 @@ function keyFromParsed(parsed: ParsedKey): string {
   // the parsed name. Browsers report e.key === 'ArrowDown'.
   return name || seq
 }
-

--- a/packages/renderer/src/events/terminal-focus-event.ts
+++ b/packages/renderer/src/events/terminal-focus-event.ts
@@ -17,4 +17,3 @@ export class TerminalFocusEvent extends Event {
     this.type = type
   }
 }
-

--- a/packages/renderer/src/focus.ts
+++ b/packages/renderer/src/focus.ts
@@ -18,9 +18,7 @@ export class FocusManager {
   private enabled = true
   private focusStack: DOMElement[] = []
 
-  constructor(
-    dispatchFocusEvent: (target: DOMElement, event: FocusEvent) => boolean,
-  ) {
+  constructor(dispatchFocusEvent: (target: DOMElement, event: FocusEvent) => boolean) {
     this.dispatchFocusEvent = dispatchFocusEvent
   }
 
@@ -56,9 +54,7 @@ export class FocusManager {
    */
   handleNodeRemoved(node: DOMElement, root: DOMElement): void {
     // Remove the node and any descendants from the stack
-    this.focusStack = this.focusStack.filter(
-      n => n !== node && isInTree(n, root),
-    )
+    this.focusStack = this.focusStack.filter((n) => n !== node && isInTree(n, root))
 
     // Check if activeElement is the removed node OR a descendant
     if (!this.activeElement) return
@@ -113,9 +109,7 @@ export class FocusManager {
     const tabbable = collectTabbable(root)
     if (tabbable.length === 0) return
 
-    const currentIndex = this.activeElement
-      ? tabbable.indexOf(this.activeElement)
-      : -1
+    const currentIndex = this.activeElement ? tabbable.indexOf(this.activeElement) : -1
 
     const nextIndex =
       currentIndex === -1
@@ -179,4 +173,3 @@ export function getRootNode(node: DOMElement): DOMElement {
 export function getFocusManager(node: DOMElement): FocusManager {
   return getRootNode(node).focusManager!
 }
-

--- a/packages/renderer/src/focus.ts
+++ b/packages/renderer/src/focus.ts
@@ -82,7 +82,7 @@ export class FocusManager {
   }
 
   handleClickFocus(node: DOMElement): void {
-    const tabIndex = node.attributes['tabIndex']
+    const tabIndex = node.attributes.tabIndex
     if (typeof tabIndex !== 'number') return
     this.focus(node)
   }
@@ -132,7 +132,7 @@ function collectTabbable(root: DOMElement): DOMElement[] {
 }
 
 function walkTree(node: DOMElement, result: DOMElement[]): void {
-  const tabIndex = node.attributes['tabIndex']
+  const tabIndex = node.attributes.tabIndex
   if (typeof tabIndex === 'number' && tabIndex >= 0) {
     result.push(node)
   }

--- a/packages/renderer/src/frame.ts
+++ b/packages/renderer/src/frame.ts
@@ -3,10 +3,10 @@ import type { Size } from './layout/geometry'
 import type { ScrollHint } from './render-node-to-output'
 import {
   type CharPool,
-  createScreen,
   type HyperlinkPool,
   type Screen,
   type StylePool,
+  createScreen,
 } from './screen'
 
 export type Frame = {

--- a/packages/renderer/src/frame.ts
+++ b/packages/renderer/src/frame.ts
@@ -102,10 +102,7 @@ export type Diff = Patch[]
  * 2. Current frame screen height exceeds available terminal rows → 'offscreen'
  * 3. Previous frame screen height exceeded available terminal rows → 'offscreen'
  */
-export function shouldClearScreen(
-  prevFrame: Frame,
-  frame: Frame,
-): FlickerReason | undefined {
+export function shouldClearScreen(prevFrame: Frame, frame: Frame): FlickerReason | undefined {
   const didResize =
     frame.viewport.height !== prevFrame.viewport.height ||
     frame.viewport.width !== prevFrame.viewport.width
@@ -114,12 +111,10 @@ export function shouldClearScreen(
   }
 
   const currentFrameOverflows = frame.screen.height >= frame.viewport.height
-  const previousFrameOverflowed =
-    prevFrame.screen.height >= prevFrame.viewport.height
+  const previousFrameOverflowed = prevFrame.screen.height >= prevFrame.viewport.height
   if (currentFrameOverflows || previousFrameOverflowed) {
     return 'offscreen'
   }
 
   return undefined
 }
-

--- a/packages/renderer/src/get-max-width.ts
+++ b/packages/renderer/src/get-max-width.ts
@@ -25,4 +25,3 @@ const getMaxWidth = (yogaNode: LayoutNode): number => {
 }
 
 export default getMaxWidth
-

--- a/packages/renderer/src/hit-test.ts
+++ b/packages/renderer/src/hit-test.ts
@@ -15,19 +15,10 @@ import { nodeCache } from './node-cache'
  * Returns the hit node even if it has no onClick — dispatchClick walks up
  * via parentNode to find handlers.
  */
-export function hitTest(
-  node: DOMElement,
-  col: number,
-  row: number,
-): DOMElement | null {
+export function hitTest(node: DOMElement, col: number, row: number): DOMElement | null {
   const rect = nodeCache.get(node)
   if (!rect) return null
-  if (
-    col < rect.x ||
-    col >= rect.x + rect.width ||
-    row < rect.y ||
-    row >= rect.y + rect.height
-  ) {
+  if (col < rect.x || col >= rect.x + rect.width || row < rect.y || row >= rect.y + rect.height) {
     return null
   }
   // Later siblings paint on top; reversed traversal returns topmost hit.
@@ -70,9 +61,7 @@ export function dispatchClick(
   const event = new ClickEvent(col, row, cellIsBlank)
   let handled = false
   while (target) {
-    const handler = target._eventHandlers?.onClick as
-      | ((event: ClickEvent) => void)
-      | undefined
+    const handler = target._eventHandlers?.onClick as ((event: ClickEvent) => void) | undefined
     if (handler) {
       handled = true
       const rect = nodeCache.get(target)
@@ -128,4 +117,3 @@ export function dispatchHover(
     }
   }
 }
-

--- a/packages/renderer/src/hit-test.ts
+++ b/packages/renderer/src/hit-test.ts
@@ -51,7 +51,7 @@ export function dispatchClick(
   if (root.focusManager) {
     let focusTarget: DOMElement | undefined = target
     while (focusTarget) {
-      if (typeof focusTarget.attributes['tabIndex'] === 'number') {
+      if (typeof focusTarget.attributes.tabIndex === 'number') {
         root.focusManager.handleClickFocus(focusTarget)
         break
       }

--- a/packages/renderer/src/hooks/use-animation-frame.ts
+++ b/packages/renderer/src/hooks/use-animation-frame.ts
@@ -55,4 +55,3 @@ export function useAnimationFrame(
 
   return [viewportRef, time]
 }
-

--- a/packages/renderer/src/hooks/use-app.ts
+++ b/packages/renderer/src/hooks/use-app.ts
@@ -6,4 +6,3 @@ import AppContext from '../components/AppContext'
  */
 const useApp = () => useContext(AppContext)
 export default useApp
-

--- a/packages/renderer/src/hooks/use-declared-cursor.ts
+++ b/packages/renderer/src/hooks/use-declared-cursor.ts
@@ -71,4 +71,3 @@ export function useDeclaredCursor({
 
   return setNode
 }
-

--- a/packages/renderer/src/hooks/use-input.ts
+++ b/packages/renderer/src/hooks/use-input.ts
@@ -90,4 +90,3 @@ const useInput = (inputHandler: Handler, options: Options = {}) => {
 }
 
 export default useInput
-

--- a/packages/renderer/src/hooks/use-interval.ts
+++ b/packages/renderer/src/hooks/use-interval.ts
@@ -40,10 +40,7 @@ export function useAnimationTimer(intervalMs: number): number {
  * this piggybacks on the single shared clock so all timers consolidate into
  * one wake-up. Pass `null` for intervalMs to pause.
  */
-export function useInterval(
-  callback: () => void,
-  intervalMs: number | null,
-): void {
+export function useInterval(callback: () => void, intervalMs: number | null): void {
   const callbackRef = useRef(callback)
   callbackRef.current = callback
 
@@ -65,4 +62,3 @@ export function useInterval(
     return clock.subscribe(onChange, false)
   }, [clock, intervalMs])
 }
-

--- a/packages/renderer/src/hooks/use-search-highlight.ts
+++ b/packages/renderer/src/hooks/use-search-highlight.ts
@@ -47,8 +47,7 @@ export function useSearchHighlight(): {
     return {
       setQuery: (query: string) => ink.setSearchHighlight(query),
       scanElement: (el: DOMElement) => ink.scanElementSubtree(el),
-      setPositions: state => ink.setSearchPositions(state),
+      setPositions: (state) => ink.setSearchPositions(state),
     }
   }, [ink])
 }
-

--- a/packages/renderer/src/hooks/use-selection.ts
+++ b/packages/renderer/src/hooks/use-selection.ts
@@ -1,11 +1,7 @@
 import { useContext, useMemo, useSyncExternalStore } from 'react'
 import StdinContext from '../components/StdinContext'
 import instances from '../instances'
-import {
-  type FocusMove,
-  type SelectionState,
-  shiftAnchor,
-} from '../selection'
+import { type FocusMove, type SelectionState, shiftAnchor } from '../selection'
 
 /**
  * Access to text selection operations on the Ink instance (fullscreen only).
@@ -33,11 +29,7 @@ export function useSelection(): {
   moveFocus: (move: FocusMove) => void
   /** Capture text from rows about to scroll out of the viewport (call
    *  BEFORE scrollBy so the screen buffer still has the outgoing rows). */
-  captureScrolledRows: (
-    firstRow: number,
-    lastRow: number,
-    side: 'above' | 'below',
-  ) => void
+  captureScrolledRows: (firstRow: number, lastRow: number, side: 'above' | 'below') => void
   /** Set the selection highlight bg color (theme-piping; solid bg
    *  replaces the old SGR-7 inverse so syntax highlighting stays readable
    *  under selection). Call once on mount + whenever theme changes. */
@@ -76,8 +68,7 @@ export function useSelection(): {
       subscribe: (cb: () => void) => ink.subscribeToSelectionChange(cb),
       shiftAnchor: (dRow: number, minRow: number, maxRow: number) =>
         shiftAnchor(ink.selection, dRow, minRow, maxRow),
-      shiftSelection: (dRow, minRow, maxRow) =>
-        ink.shiftSelectionForScroll(dRow, minRow, maxRow),
+      shiftSelection: (dRow, minRow, maxRow) => ink.shiftSelectionForScroll(dRow, minRow, maxRow),
       moveFocus: (move: FocusMove) => ink.moveSelectionFocus(move),
       captureScrolledRows: (firstRow, lastRow, side) =>
         ink.captureScrolledRows(firstRow, lastRow, side),
@@ -102,4 +93,3 @@ export function useHasSelection(): boolean {
     ink ? ink.hasTextSelection : ALWAYS_FALSE,
   )
 }
-

--- a/packages/renderer/src/hooks/use-stdin.ts
+++ b/packages/renderer/src/hooks/use-stdin.ts
@@ -6,4 +6,3 @@ import StdinContext from '../components/StdinContext'
  */
 const useStdin = () => useContext(StdinContext)
 export default useStdin
-

--- a/packages/renderer/src/hooks/use-tab-status.ts
+++ b/packages/renderer/src/hooks/use-tab-status.ts
@@ -1,10 +1,5 @@
 import { useContext, useEffect, useRef } from 'react'
-import {
-  CLEAR_TAB_STATUS,
-  supportsTabStatus,
-  tabStatus,
-  wrapForMultiplexer,
-} from '../termio/osc'
+import { CLEAR_TAB_STATUS, supportsTabStatus, tabStatus, wrapForMultiplexer } from '../termio/osc'
 import type { Color } from '../termio/types'
 import { TerminalWriteContext } from '../useTerminalNotification'
 
@@ -70,4 +65,3 @@ export function useTabStatus(kind: TabStatusKind | null): void {
     writeRaw(wrapForMultiplexer(tabStatus(TAB_STATUS_PRESETS[kind])))
   }, [kind, writeRaw])
 }
-

--- a/packages/renderer/src/hooks/use-terminal-focus.ts
+++ b/packages/renderer/src/hooks/use-terminal-focus.ts
@@ -14,4 +14,3 @@ export function useTerminalFocus(): boolean {
   const { isTerminalFocused } = useContext(TerminalFocusContext)
   return isTerminalFocused
 }
-

--- a/packages/renderer/src/hooks/use-terminal-title.ts
+++ b/packages/renderer/src/hooks/use-terminal-title.ts
@@ -29,4 +29,3 @@ export function useTerminalTitle(title: string | null): void {
     }
   }, [title, writeRaw])
 }
-

--- a/packages/renderer/src/hooks/use-terminal-viewport.ts
+++ b/packages/renderer/src/hooks/use-terminal-viewport.ts
@@ -94,4 +94,3 @@ export function useTerminalViewport(): [
 
   return [setElement, entryRef.current]
 }
-

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -19,7 +19,9 @@ export { default as ErrorOverview } from './components/ErrorOverview'
 export { Ansi } from './Ansi'
 
 // Theme hook stub (returns [themeName, setThemeName])
-export function useTheme(): [string, (name: string) => void] { return ['default', () => {}] }
+export function useTheme(): [string, (name: string) => void] {
+  return ['default', () => {}]
+}
 
 // Hooks
 export { default as useInput } from './hooks/use-input'

--- a/packages/renderer/src/ink.tsx
+++ b/packages/renderer/src/ink.tsx
@@ -1,14 +1,13 @@
-import autoBind from 'auto-bind'
 import { closeSync, constants as fsConstants, openSync, readSync, writeSync } from 'fs'
-import { noop, throttle } from './lodash-replacements'
-import React, { type ReactNode } from 'react'
+import { format } from 'util'
+import { logForDebugging } from '@yokai/shared'
+import { logError } from '@yokai/shared'
+import { getYogaCounters } from '@yokai/shared/yoga-layout'
+import autoBind from 'auto-bind'
+import type { ReactNode } from 'react'
 import type { FiberRoot } from 'react-reconciler'
 import { ConcurrentRoot } from 'react-reconciler/constants.js'
 import { onExit } from 'signal-exit'
-import { getYogaCounters } from '@yokai/shared/yoga-layout'
-import { logForDebugging } from '@yokai/shared'
-import { logError } from '@yokai/shared'
-import { format } from 'util'
 import { colorize } from './colorize'
 import App from './components/App'
 import type {
@@ -19,9 +18,10 @@ import { FRAME_INTERVAL_MS } from './constants'
 import * as dom from './dom'
 import { KeyboardEvent } from './events/keyboard-event'
 import { FocusManager } from './focus'
-import { emptyFrame, type Frame, type FrameEvent } from './frame'
+import { type Frame, type FrameEvent, emptyFrame } from './frame'
 import { dispatchClick, dispatchHover } from './hit-test'
 import instances from './instances'
+import { noop, throttle } from './lodash-replacements'
 import { LogUpdate } from './log-update'
 import { nodeCache } from './node-cache'
 import { optimize } from './optimizer'
@@ -36,31 +36,31 @@ import reconciler, {
   resetProfileCounters,
 } from './reconciler'
 import renderNodeToOutput, { consumeFollowScroll, didLayoutShift } from './render-node-to-output'
-import { applyPositionedHighlight, type MatchPosition, scanPositions } from './render-to-screen'
+import { type MatchPosition, applyPositionedHighlight, scanPositions } from './render-to-screen'
 import createRenderer, { type Renderer } from './renderer'
 import {
   CellWidth,
   CharPool,
+  HyperlinkPool,
+  StylePool,
   cellAt,
   createScreen,
-  HyperlinkPool,
   isEmptyCellAt,
   migrateScreenPools,
-  StylePool,
 } from './screen'
 import { applySearchHighlight } from './searchHighlight'
 import {
+  type FocusMove,
+  type SelectionState,
   applySelectionOverlay,
   captureScrolledRows,
   clearSelection,
   createSelectionState,
   extendSelection,
-  type FocusMove,
   findPlainTextUrlAt,
   getSelectedText,
   hasSelection,
   moveFocus,
-  type SelectionState,
   selectLineAt,
   selectWordAt,
   shiftAnchor,
@@ -71,19 +71,19 @@ import {
 } from './selection'
 import {
   SYNC_OUTPUT_SUPPORTED,
-  supportsExtendedKeys,
   type Terminal,
+  supportsExtendedKeys,
   writeDiffToTerminal,
 } from './terminal'
 import {
   CURSOR_HOME,
-  cursorMove,
-  cursorPosition,
   DISABLE_KITTY_KEYBOARD,
   DISABLE_MODIFY_OTHER_KEYS,
   ENABLE_KITTY_KEYBOARD,
   ENABLE_MODIFY_OTHER_KEYS,
   ERASE_SCREEN,
+  cursorMove,
+  cursorPosition,
 } from './termio/csi'
 import {
   DBP,

--- a/packages/renderer/src/ink.tsx
+++ b/packages/renderer/src/ink.tsx
@@ -1,41 +1,107 @@
-import autoBind from 'auto-bind';
-import { closeSync, constants as fsConstants, openSync, readSync, writeSync } from 'fs';
-import { noop, throttle } from './lodash-replacements';
-import React, { type ReactNode } from 'react';
-import type { FiberRoot } from 'react-reconciler';
-import { ConcurrentRoot } from 'react-reconciler/constants.js';
-import { onExit } from 'signal-exit';
-import { getYogaCounters } from '@yokai/shared/yoga-layout';
-import { logForDebugging } from '@yokai/shared';
-import { logError } from '@yokai/shared';
-import { format } from 'util';
-import { colorize } from './colorize';
-import App from './components/App';
-import type { CursorDeclaration, CursorDeclarationSetter } from './components/CursorDeclarationContext';
-import { FRAME_INTERVAL_MS } from './constants';
-import * as dom from './dom';
-import { KeyboardEvent } from './events/keyboard-event';
-import { FocusManager } from './focus';
-import { emptyFrame, type Frame, type FrameEvent } from './frame';
-import { dispatchClick, dispatchHover } from './hit-test';
-import instances from './instances';
-import { LogUpdate } from './log-update';
-import { nodeCache } from './node-cache';
-import { optimize } from './optimizer';
-import Output from './output';
-import type { ParsedKey } from './parse-keypress';
-import reconciler, { dispatcher, getLastCommitMs, getLastYogaMs, isDebugRepaintsEnabled, recordYogaMs, resetProfileCounters } from './reconciler';
-import renderNodeToOutput, { consumeFollowScroll, didLayoutShift } from './render-node-to-output';
-import { applyPositionedHighlight, type MatchPosition, scanPositions } from './render-to-screen';
-import createRenderer, { type Renderer } from './renderer';
-import { CellWidth, CharPool, cellAt, createScreen, HyperlinkPool, isEmptyCellAt, migrateScreenPools, StylePool } from './screen';
-import { applySearchHighlight } from './searchHighlight';
-import { applySelectionOverlay, captureScrolledRows, clearSelection, createSelectionState, extendSelection, type FocusMove, findPlainTextUrlAt, getSelectedText, hasSelection, moveFocus, type SelectionState, selectLineAt, selectWordAt, shiftAnchor, shiftSelection, shiftSelectionForFollow, startSelection, updateSelection } from './selection';
-import { SYNC_OUTPUT_SUPPORTED, supportsExtendedKeys, type Terminal, writeDiffToTerminal } from './terminal';
-import { CURSOR_HOME, cursorMove, cursorPosition, DISABLE_KITTY_KEYBOARD, DISABLE_MODIFY_OTHER_KEYS, ENABLE_KITTY_KEYBOARD, ENABLE_MODIFY_OTHER_KEYS, ERASE_SCREEN } from './termio/csi';
-import { DBP, DFE, DISABLE_MOUSE_TRACKING, ENABLE_MOUSE_TRACKING, ENTER_ALT_SCREEN, EXIT_ALT_SCREEN, SHOW_CURSOR } from './termio/dec';
-import { CLEAR_ITERM2_PROGRESS, CLEAR_TAB_STATUS, setClipboard, supportsTabStatus, wrapForMultiplexer } from './termio/osc';
-import { TerminalWriteProvider } from './useTerminalNotification';
+import autoBind from 'auto-bind'
+import { closeSync, constants as fsConstants, openSync, readSync, writeSync } from 'fs'
+import { noop, throttle } from './lodash-replacements'
+import React, { type ReactNode } from 'react'
+import type { FiberRoot } from 'react-reconciler'
+import { ConcurrentRoot } from 'react-reconciler/constants.js'
+import { onExit } from 'signal-exit'
+import { getYogaCounters } from '@yokai/shared/yoga-layout'
+import { logForDebugging } from '@yokai/shared'
+import { logError } from '@yokai/shared'
+import { format } from 'util'
+import { colorize } from './colorize'
+import App from './components/App'
+import type {
+  CursorDeclaration,
+  CursorDeclarationSetter,
+} from './components/CursorDeclarationContext'
+import { FRAME_INTERVAL_MS } from './constants'
+import * as dom from './dom'
+import { KeyboardEvent } from './events/keyboard-event'
+import { FocusManager } from './focus'
+import { emptyFrame, type Frame, type FrameEvent } from './frame'
+import { dispatchClick, dispatchHover } from './hit-test'
+import instances from './instances'
+import { LogUpdate } from './log-update'
+import { nodeCache } from './node-cache'
+import { optimize } from './optimizer'
+import Output from './output'
+import type { ParsedKey } from './parse-keypress'
+import reconciler, {
+  dispatcher,
+  getLastCommitMs,
+  getLastYogaMs,
+  isDebugRepaintsEnabled,
+  recordYogaMs,
+  resetProfileCounters,
+} from './reconciler'
+import renderNodeToOutput, { consumeFollowScroll, didLayoutShift } from './render-node-to-output'
+import { applyPositionedHighlight, type MatchPosition, scanPositions } from './render-to-screen'
+import createRenderer, { type Renderer } from './renderer'
+import {
+  CellWidth,
+  CharPool,
+  cellAt,
+  createScreen,
+  HyperlinkPool,
+  isEmptyCellAt,
+  migrateScreenPools,
+  StylePool,
+} from './screen'
+import { applySearchHighlight } from './searchHighlight'
+import {
+  applySelectionOverlay,
+  captureScrolledRows,
+  clearSelection,
+  createSelectionState,
+  extendSelection,
+  type FocusMove,
+  findPlainTextUrlAt,
+  getSelectedText,
+  hasSelection,
+  moveFocus,
+  type SelectionState,
+  selectLineAt,
+  selectWordAt,
+  shiftAnchor,
+  shiftSelection,
+  shiftSelectionForFollow,
+  startSelection,
+  updateSelection,
+} from './selection'
+import {
+  SYNC_OUTPUT_SUPPORTED,
+  supportsExtendedKeys,
+  type Terminal,
+  writeDiffToTerminal,
+} from './terminal'
+import {
+  CURSOR_HOME,
+  cursorMove,
+  cursorPosition,
+  DISABLE_KITTY_KEYBOARD,
+  DISABLE_MODIFY_OTHER_KEYS,
+  ENABLE_KITTY_KEYBOARD,
+  ENABLE_MODIFY_OTHER_KEYS,
+  ERASE_SCREEN,
+} from './termio/csi'
+import {
+  DBP,
+  DFE,
+  DISABLE_MOUSE_TRACKING,
+  ENABLE_MOUSE_TRACKING,
+  ENTER_ALT_SCREEN,
+  EXIT_ALT_SCREEN,
+  SHOW_CURSOR,
+} from './termio/dec'
+import {
+  CLEAR_ITERM2_PROGRESS,
+  CLEAR_TAB_STATUS,
+  setClipboard,
+  supportsTabStatus,
+  wrapForMultiplexer,
+} from './termio/osc'
+import { TerminalWriteProvider } from './useTerminalNotification'
 
 // Alt-screen: renderer.ts sets cursor.visible = !isTTY || screen.height===0,
 // which is always false in alt-screen (TTY + content fills screen).
@@ -43,85 +109,85 @@ import { TerminalWriteProvider } from './useTerminalNotification';
 const ALT_SCREEN_ANCHOR_CURSOR = Object.freeze({
   x: 0,
   y: 0,
-  visible: false
-});
+  visible: false,
+})
 const CURSOR_HOME_PATCH = Object.freeze({
   type: 'stdout' as const,
-  content: CURSOR_HOME
-});
+  content: CURSOR_HOME,
+})
 const ERASE_THEN_HOME_PATCH = Object.freeze({
   type: 'stdout' as const,
-  content: ERASE_SCREEN + CURSOR_HOME
-});
+  content: ERASE_SCREEN + CURSOR_HOME,
+})
 
 // Cached per-Ink-instance, invalidated on resize. frame.cursor.y for
 // alt-screen is always terminalRows - 1 (renderer.ts).
 function makeAltScreenParkPatch(terminalRows: number) {
   return Object.freeze({
     type: 'stdout' as const,
-    content: cursorPosition(terminalRows, 1)
-  });
+    content: cursorPosition(terminalRows, 1),
+  })
 }
 export type Options = {
-  stdout: NodeJS.WriteStream;
-  stdin: NodeJS.ReadStream;
-  stderr: NodeJS.WriteStream;
-  exitOnCtrlC: boolean;
-  patchConsole: boolean;
-  waitUntilExit?: () => Promise<void>;
-  onFrame?: (event: FrameEvent) => void;
-};
+  stdout: NodeJS.WriteStream
+  stdin: NodeJS.ReadStream
+  stderr: NodeJS.WriteStream
+  exitOnCtrlC: boolean
+  patchConsole: boolean
+  waitUntilExit?: () => Promise<void>
+  onFrame?: (event: FrameEvent) => void
+}
 export default class Ink {
-  private readonly log: LogUpdate;
-  private readonly terminal: Terminal;
+  private readonly log: LogUpdate
+  private readonly terminal: Terminal
   private scheduleRender: (() => void) & {
-    cancel?: () => void;
-  };
+    cancel?: () => void
+  }
   // Ignore last render after unmounting a tree to prevent empty output before exit
-  private isUnmounted = false;
-  private isPaused = false;
-  private readonly container: FiberRoot;
-  private rootNode: dom.DOMElement;
-  readonly focusManager: FocusManager;
-  private renderer: Renderer;
-  private readonly stylePool: StylePool;
-  private charPool: CharPool;
-  private hyperlinkPool: HyperlinkPool;
-  private exitPromise?: Promise<void>;
-  private restoreConsole?: () => void;
-  private restoreStderr?: () => void;
-  private readonly unsubscribeTTYHandlers?: () => void;
-  private terminalColumns: number;
-  private terminalRows: number;
-  private currentNode: ReactNode = null;
-  private frontFrame: Frame;
-  private backFrame: Frame;
-  private lastPoolResetTime = performance.now();
-  private drainTimer: ReturnType<typeof setTimeout> | null = null;
+  private isUnmounted = false
+  private isPaused = false
+  private readonly container: FiberRoot
+  private rootNode: dom.DOMElement
+  readonly focusManager: FocusManager
+  private renderer: Renderer
+  private readonly stylePool: StylePool
+  private charPool: CharPool
+  private hyperlinkPool: HyperlinkPool
+  private exitPromise?: Promise<void>
+  private restoreConsole?: () => void
+  private restoreStderr?: () => void
+  private readonly unsubscribeTTYHandlers?: () => void
+  private terminalColumns: number
+  private terminalRows: number
+  private currentNode: ReactNode = null
+  private frontFrame: Frame
+  private backFrame: Frame
+  private lastPoolResetTime = performance.now()
+  private drainTimer: ReturnType<typeof setTimeout> | null = null
   private lastYogaCounters: {
-    ms: number;
-    visited: number;
-    measured: number;
-    cacheHits: number;
-    live: number;
+    ms: number
+    visited: number
+    measured: number
+    cacheHits: number
+    live: number
   } = {
     ms: 0,
     visited: 0,
     measured: 0,
     cacheHits: 0,
-    live: 0
-  };
+    live: 0,
+  }
   private altScreenParkPatch: Readonly<{
-    type: 'stdout';
-    content: string;
-  }>;
+    type: 'stdout'
+    content: string
+  }>
   // Text selection state (alt-screen only). Owned here so the overlay
   // pass in onRender can read it and App.tsx can update it from mouse
   // events. Public so instances.get() callers can access.
-  readonly selection: SelectionState = createSelectionState();
+  readonly selection: SelectionState = createSelectionState()
   // Search highlight query (alt-screen only). Setter below triggers
   // scheduleRender; applySearchHighlight in onRender inverts matching cells.
-  private searchHighlightQuery = '';
+  private searchHighlightQuery = ''
   // Position-based highlight. VML scans positions ONCE (via
   // scanElementSubtree, when the target message is mounted), stores them
   // message-relative, sets this for every-frame apply. rowOffset =
@@ -129,74 +195,86 @@ export default class Ink {
   // "current" (yellow). null clears. Positions are known upfront —
   // navigation is index arithmetic, no scan-feedback loop.
   private searchPositions: {
-    positions: MatchPosition[];
-    rowOffset: number;
-    currentIdx: number;
-  } | null = null;
+    positions: MatchPosition[]
+    rowOffset: number
+    currentIdx: number
+  } | null = null
   // React-land subscribers for selection state changes (useHasSelection).
   // Fired alongside the terminal repaint whenever the selection mutates
   // so UI (e.g. footer hints) can react to selection appearing/clearing.
-  private readonly selectionListeners = new Set<() => void>();
+  private readonly selectionListeners = new Set<() => void>()
   // DOM nodes currently under the pointer (mode-1003 motion). Held here
   // so App.tsx's handleMouseEvent is stateless — dispatchHover diffs
   // against this set and mutates it in place.
-  private readonly hoveredNodes = new Set<dom.DOMElement>();
+  private readonly hoveredNodes = new Set<dom.DOMElement>()
   // Set by <AlternateScreen> via setAltScreenActive(). Controls the
   // renderer's cursor.y clamping (keeps cursor in-viewport to avoid
   // LF-induced scroll when screen.height === terminalRows) and gates
   // alt-screen-aware SIGCONT/resize/unmount handling.
-  private altScreenActive = false;
+  private altScreenActive = false
   // Set alongside altScreenActive so SIGCONT resume knows whether to
   // re-enable mouse tracking (not all <AlternateScreen> uses want it).
-  private altScreenMouseTracking = false;
+  private altScreenMouseTracking = false
   // True when the previous frame's screen buffer cannot be trusted for
   // blit — selection overlay mutated it, resetFramesForAltScreen()
   // replaced it with blanks, or forceRedraw() reset it to 0×0. Forces
   // one full-render frame; steady-state frames after clear it and regain
   // the blit + narrow-damage fast path.
-  private prevFrameContaminated = false;
+  private prevFrameContaminated = false
   // Set by handleResize: prepend ERASE_SCREEN to the next onRender's patches
   // INSIDE the BSU/ESU block so clear+paint is atomic. Writing ERASE_SCREEN
   // synchronously in handleResize would leave the screen blank for the ~80ms
   // render() takes; deferring into the atomic block means old content stays
   // visible until the new frame is fully ready.
-  private needsEraseBeforePaint = false;
+  private needsEraseBeforePaint = false
   // Native cursor positioning: a component (via useDeclaredCursor) declares
   // where the terminal cursor should be parked after each frame. Terminal
   // emulators render IME preedit text at the physical cursor position, and
   // screen readers / screen magnifiers track it — so parking at the text
   // input's caret makes CJK input appear inline and lets a11y tools follow.
-  private cursorDeclaration: CursorDeclaration | null = null;
+  private cursorDeclaration: CursorDeclaration | null = null
   // Main-screen: physical cursor position after the declared-cursor move,
   // tracked separately from frame.cursor (which must stay at content-bottom
   // for log-update's relative-move invariants). Alt-screen doesn't need
   // this — every frame begins with CSI H. null = no move emitted last frame.
   private displayCursor: {
-    x: number;
-    y: number;
-  } | null = null;
+    x: number
+    y: number
+  } | null = null
   constructor(private readonly options: Options) {
-    autoBind(this);
+    autoBind(this)
     if (this.options.patchConsole) {
-      this.restoreConsole = this.patchConsole();
-      this.restoreStderr = this.patchStderr();
+      this.restoreConsole = this.patchConsole()
+      this.restoreStderr = this.patchStderr()
     }
     this.terminal = {
       stdout: options.stdout,
-      stderr: options.stderr
-    };
-    this.terminalColumns = options.stdout.columns || 80;
-    this.terminalRows = options.stdout.rows || 24;
-    this.altScreenParkPatch = makeAltScreenParkPatch(this.terminalRows);
-    this.stylePool = new StylePool();
-    this.charPool = new CharPool();
-    this.hyperlinkPool = new HyperlinkPool();
-    this.frontFrame = emptyFrame(this.terminalRows, this.terminalColumns, this.stylePool, this.charPool, this.hyperlinkPool);
-    this.backFrame = emptyFrame(this.terminalRows, this.terminalColumns, this.stylePool, this.charPool, this.hyperlinkPool);
+      stderr: options.stderr,
+    }
+    this.terminalColumns = options.stdout.columns || 80
+    this.terminalRows = options.stdout.rows || 24
+    this.altScreenParkPatch = makeAltScreenParkPatch(this.terminalRows)
+    this.stylePool = new StylePool()
+    this.charPool = new CharPool()
+    this.hyperlinkPool = new HyperlinkPool()
+    this.frontFrame = emptyFrame(
+      this.terminalRows,
+      this.terminalColumns,
+      this.stylePool,
+      this.charPool,
+      this.hyperlinkPool,
+    )
+    this.backFrame = emptyFrame(
+      this.terminalRows,
+      this.terminalColumns,
+      this.stylePool,
+      this.charPool,
+      this.hyperlinkPool,
+    )
     this.log = new LogUpdate({
-      isTTY: options.stdout.isTTY as boolean | undefined || false,
-      stylePool: this.stylePool
-    });
+      isTTY: (options.stdout.isTTY as boolean | undefined) || false,
+      stylePool: this.stylePool,
+    })
 
     // scheduleRender is called from the reconciler's resetAfterCommit, which
     // runs BEFORE React's layout phase (ref attach + useLayoutEffect). Any
@@ -207,97 +285,118 @@ export default class Ink {
     // a one-keystroke lag. Same event-loop tick, so throughput is unchanged.
     // Test env uses onImmediateRender (direct onRender, no throttle) so
     // existing synchronous lastFrame() tests are unaffected.
-    const deferredRender = (): void => queueMicrotask(this.onRender);
+    const deferredRender = (): void => queueMicrotask(this.onRender)
     this.scheduleRender = throttle(deferredRender, FRAME_INTERVAL_MS, {
       leading: true,
-      trailing: true
-    });
+      trailing: true,
+    })
 
     // Ignore last render after unmounting a tree to prevent empty output before exit
-    this.isUnmounted = false;
+    this.isUnmounted = false
 
     // Unmount when process exits
     this.unsubscribeExit = onExit(this.unmount, {
-      alwaysLast: false
-    });
+      alwaysLast: false,
+    })
     if (options.stdout.isTTY) {
-      options.stdout.on('resize', this.handleResize);
-      process.on('SIGCONT', this.handleResume);
+      options.stdout.on('resize', this.handleResize)
+      process.on('SIGCONT', this.handleResume)
       this.unsubscribeTTYHandlers = () => {
-        options.stdout.off('resize', this.handleResize);
-        process.off('SIGCONT', this.handleResume);
-      };
+        options.stdout.off('resize', this.handleResize)
+        process.off('SIGCONT', this.handleResume)
+      }
     }
-    this.rootNode = dom.createNode('ink-root');
-    this.focusManager = new FocusManager((target, event) => dispatcher.dispatchDiscrete(target, event));
-    this.rootNode.focusManager = this.focusManager;
-    this.renderer = createRenderer(this.rootNode, this.stylePool);
-    this.rootNode.onRender = this.scheduleRender;
-    this.rootNode.onImmediateRender = this.onRender;
+    this.rootNode = dom.createNode('ink-root')
+    this.focusManager = new FocusManager((target, event) =>
+      dispatcher.dispatchDiscrete(target, event),
+    )
+    this.rootNode.focusManager = this.focusManager
+    this.renderer = createRenderer(this.rootNode, this.stylePool)
+    this.rootNode.onRender = this.scheduleRender
+    this.rootNode.onImmediateRender = this.onRender
     this.rootNode.onComputeLayout = () => {
       // Calculate layout during React's commit phase so useLayoutEffect hooks
       // have access to fresh layout data
       // Guard against accessing freed Yoga nodes after unmount
       if (this.isUnmounted) {
-        return;
+        return
       }
       if (this.rootNode.yogaNode) {
-        const t0 = performance.now();
-        this.rootNode.yogaNode.setWidth(this.terminalColumns);
-        this.rootNode.yogaNode.calculateLayout(this.terminalColumns);
-        const ms = performance.now() - t0;
-        recordYogaMs(ms);
-        const c = getYogaCounters();
+        const t0 = performance.now()
+        this.rootNode.yogaNode.setWidth(this.terminalColumns)
+        this.rootNode.yogaNode.calculateLayout(this.terminalColumns)
+        const ms = performance.now() - t0
+        recordYogaMs(ms)
+        const c = getYogaCounters()
         this.lastYogaCounters = {
           ms,
-          ...c
-        };
+          ...c,
+        }
       }
-    };
+    }
 
     // @ts-ignore @types/react-reconciler@0.32.3 declares 11 args with transitionCallbacks,
     // but react-reconciler 0.33.0 source only accepts 10 args (no transitionCallbacks)
-    this.container = reconciler.createContainer(this.rootNode, ConcurrentRoot, null, false, null, 'id', noop,
-    // onUncaughtError
-    noop,
-    // onCaughtError
-    noop,
-    // onRecoverableError
-    noop // onDefaultTransitionIndicator
-    );
+    this.container = reconciler.createContainer(
+      this.rootNode,
+      ConcurrentRoot,
+      null,
+      false,
+      null,
+      'id',
+      noop,
+      // onUncaughtError
+      noop,
+      // onCaughtError
+      noop,
+      // onRecoverableError
+      noop, // onDefaultTransitionIndicator
+    )
     // @ts-ignore dead code from production build
-    if ("production" === 'development') {
+    if ('production' === 'development') {
       reconciler.injectIntoDevTools({
         bundleType: 0,
         // Reporting React DOM's version, not Ink's
         // See https://github.com/facebook/react/issues/16666#issuecomment-532639905
         version: '16.13.1',
-        rendererPackageName: 'ink'
-      });
+        rendererPackageName: 'ink',
+      })
     }
   }
   private handleResume = () => {
     if (!this.options.stdout.isTTY) {
-      return;
+      return
     }
 
     // Alt screen: after SIGCONT, content is stale (shell may have written
     // to main screen, switching focus away) and mouse tracking was
     // disabled by handleSuspend.
     if (this.altScreenActive) {
-      this.reenterAltScreen();
-      return;
+      this.reenterAltScreen()
+      return
     }
 
     // Main screen: start fresh to prevent clobbering terminal content
-    this.frontFrame = emptyFrame(this.frontFrame.viewport.height, this.frontFrame.viewport.width, this.stylePool, this.charPool, this.hyperlinkPool);
-    this.backFrame = emptyFrame(this.backFrame.viewport.height, this.backFrame.viewport.width, this.stylePool, this.charPool, this.hyperlinkPool);
-    this.log.reset();
+    this.frontFrame = emptyFrame(
+      this.frontFrame.viewport.height,
+      this.frontFrame.viewport.width,
+      this.stylePool,
+      this.charPool,
+      this.hyperlinkPool,
+    )
+    this.backFrame = emptyFrame(
+      this.backFrame.viewport.height,
+      this.backFrame.viewport.width,
+      this.stylePool,
+      this.charPool,
+      this.hyperlinkPool,
+    )
+    this.log.reset()
     // Physical cursor position is unknown after the shell took over during
     // suspend. Clear displayCursor so the next frame's cursor preamble
     // doesn't emit a relative move from a stale park position.
-    this.displayCursor = null;
-  };
+    this.displayCursor = null
+  }
 
   // NOT debounced. A debounce opens a window where stdout.columns is NEW
   // but this.terminalColumns/Yoga are OLD — any scheduleRender during that
@@ -306,15 +405,15 @@ export default class Ink {
   // blank→paint flicker). useVirtualScroll's height scaling already bounds
   // the per-resize cost; synchronous handling keeps dimensions consistent.
   private handleResize = () => {
-    const cols = this.options.stdout.columns || 80;
-    const rows = this.options.stdout.rows || 24;
+    const cols = this.options.stdout.columns || 80
+    const rows = this.options.stdout.rows || 24
     // Terminals often emit 2+ resize events for one user action (window
     // settling). Same-dimension events are no-ops; skip to avoid redundant
     // frame resets and renders.
-    if (cols === this.terminalColumns && rows === this.terminalRows) return;
-    this.terminalColumns = cols;
-    this.terminalRows = rows;
-    this.altScreenParkPatch = makeAltScreenParkPatch(this.terminalRows);
+    if (cols === this.terminalColumns && rows === this.terminalRows) return
+    this.terminalColumns = cols
+    this.terminalRows = rows
+    this.altScreenParkPatch = makeAltScreenParkPatch(this.terminalRows)
 
     // Alt screen: reset frame buffers so the next render repaints from
     // scratch (prevFrameContaminated → every cell written, wrapped in
@@ -328,10 +427,10 @@ export default class Ink {
     // can take ~80ms; erasing first leaves the screen blank that whole time.
     if (this.altScreenActive && !this.isPaused && this.options.stdout.isTTY) {
       if (this.altScreenMouseTracking) {
-        this.options.stdout.write(ENABLE_MOUSE_TRACKING);
+        this.options.stdout.write(ENABLE_MOUSE_TRACKING)
       }
-      this.resetFramesForAltScreen();
-      this.needsEraseBeforePaint = true;
+      this.resetFramesForAltScreen()
+      this.needsEraseBeforePaint = true
     }
 
     // Re-render the React tree with updated props so the context value changes.
@@ -340,12 +439,12 @@ export default class Ink {
     // We don't call scheduleRender() here because that would render before the
     // layout is updated, causing a mismatch between viewport and content dimensions.
     if (this.currentNode !== null) {
-      this.render(this.currentNode);
+      this.render(this.currentNode)
     }
-  };
-  resolveExitPromise: () => void = () => {};
-  rejectExitPromise: (reason?: Error) => void = () => {};
-  unsubscribeExit: () => void = () => {};
+  }
+  resolveExitPromise: () => void = () => {}
+  rejectExitPromise: (reason?: Error) => void = () => {}
+  unsubscribeExit: () => void = () => {}
 
   /**
    * Pause Ink and hand the terminal over to an external TUI (e.g. git
@@ -354,26 +453,28 @@ export default class Ink {
    * Call `exitAlternateScreen()` when done to restore Ink.
    */
   enterAlternateScreen(): void {
-    this.pause();
-    this.suspendStdin();
+    this.pause()
+    this.suspendStdin()
     this.options.stdout.write(
-    // Disable extended key reporting first — editors that don't speak
-    // CSI-u (e.g. nano) show "Unknown sequence" for every Ctrl-<key> if
-    // kitty/modifyOtherKeys stays active. exitAlternateScreen re-enables.
-    DISABLE_KITTY_KEYBOARD + DISABLE_MODIFY_OTHER_KEYS + (this.altScreenMouseTracking ? DISABLE_MOUSE_TRACKING : '') + (
-    // disable mouse (no-op if off)
-    this.altScreenActive ? '' : '\x1b[?1049h') +
-    // enter alt (already in alt if fullscreen)
-    '\x1b[?1004l' +
-    // disable focus reporting
-    '\x1b[0m' +
-    // reset attributes
-    '\x1b[?25h' +
-    // show cursor
-    '\x1b[2J' +
-    // clear screen
-    '\x1b[H' // cursor home
-    );
+      // Disable extended key reporting first — editors that don't speak
+      // CSI-u (e.g. nano) show "Unknown sequence" for every Ctrl-<key> if
+      // kitty/modifyOtherKeys stays active. exitAlternateScreen re-enables.
+      DISABLE_KITTY_KEYBOARD +
+        DISABLE_MODIFY_OTHER_KEYS +
+        (this.altScreenMouseTracking ? DISABLE_MOUSE_TRACKING : '') +
+        // disable mouse (no-op if off)
+        (this.altScreenActive ? '' : '\x1b[?1049h') +
+        // enter alt (already in alt if fullscreen)
+        '\x1b[?1004l' +
+        // disable focus reporting
+        '\x1b[0m' +
+        // reset attributes
+        '\x1b[?25h' +
+        // show cursor
+        '\x1b[2J' +
+        // clear screen
+        '\x1b[H', // cursor home
+    )
   }
 
   /**
@@ -389,52 +490,58 @@ export default class Ink {
    * returns, fullscreen scroll is dead.
    */
   exitAlternateScreen(): void {
-    this.options.stdout.write((this.altScreenActive ? ENTER_ALT_SCREEN : '') +
-    // re-enter alt — vim's rmcup dropped us to main
-    '\x1b[2J' +
-    // clear screen (now alt if fullscreen)
-    '\x1b[H' + (
-    // cursor home
-    this.altScreenMouseTracking ? ENABLE_MOUSE_TRACKING : '') + (
-    // re-enable mouse (skip if CLAUDE_CODE_DISABLE_MOUSE)
-    this.altScreenActive ? '' : '\x1b[?1049l') +
-    // exit alt (non-fullscreen only)
-    '\x1b[?25l' // hide cursor (Ink manages)
-    );
-    this.resumeStdin();
+    this.options.stdout.write(
+      (this.altScreenActive ? ENTER_ALT_SCREEN : '') +
+        // re-enter alt — vim's rmcup dropped us to main
+        '\x1b[2J' +
+        // clear screen (now alt if fullscreen)
+        '\x1b[H' +
+        // cursor home
+        (this.altScreenMouseTracking ? ENABLE_MOUSE_TRACKING : '') +
+        // re-enable mouse (skip if CLAUDE_CODE_DISABLE_MOUSE)
+        (this.altScreenActive ? '' : '\x1b[?1049l') +
+        // exit alt (non-fullscreen only)
+        '\x1b[?25l', // hide cursor (Ink manages)
+    )
+    this.resumeStdin()
     if (this.altScreenActive) {
-      this.resetFramesForAltScreen();
+      this.resetFramesForAltScreen()
     } else {
-      this.repaint();
+      this.repaint()
     }
-    this.resume();
+    this.resume()
     // Re-enable focus reporting and extended key reporting — terminal
     // editors (vim, nano, etc.) write their own modifyOtherKeys level on
     // entry and reset it on exit, leaving us unable to distinguish
     // ctrl+shift+<letter> from ctrl+<letter>. Pop-before-push keeps the
     // Kitty stack balanced (a well-behaved editor restores our entry, so
     // without the pop we'd accumulate depth on each editor round-trip).
-    this.options.stdout.write('\x1b[?1004h' + (supportsExtendedKeys() ? DISABLE_KITTY_KEYBOARD + ENABLE_KITTY_KEYBOARD + ENABLE_MODIFY_OTHER_KEYS : ''));
+    this.options.stdout.write(
+      '\x1b[?1004h' +
+        (supportsExtendedKeys()
+          ? DISABLE_KITTY_KEYBOARD + ENABLE_KITTY_KEYBOARD + ENABLE_MODIFY_OTHER_KEYS
+          : ''),
+    )
   }
   onRender() {
     if (this.isUnmounted || this.isPaused) {
-      return;
+      return
     }
     // Entering a render cancels any pending drain tick — this render will
     // handle the drain (and re-schedule below if needed). Prevents a
     // wheel-event-triggered render AND a drain-timer render both firing.
     if (this.drainTimer !== null) {
-      clearTimeout(this.drainTimer);
-      this.drainTimer = null;
+      clearTimeout(this.drainTimer)
+      this.drainTimer = null
     }
 
     // Flush deferred interaction-time update before rendering so we call
     // Date.now() at most once per frame instead of once per keypress.
     // Done before the render to avoid dirtying state that would trigger
     // an extra React re-render cycle.
-    const renderStart = performance.now();
-    const terminalWidth = this.options.stdout.columns || 80;
-    const terminalRows = this.options.stdout.rows || 24;
+    const renderStart = performance.now()
+    const terminalWidth = this.options.stdout.columns || 80
+    const terminalRows = this.options.stdout.rows || 24
     const frame = this.renderer({
       frontFrame: this.frontFrame,
       backFrame: this.backFrame,
@@ -442,9 +549,9 @@ export default class Ink {
       terminalWidth,
       terminalRows,
       altScreen: this.altScreenActive,
-      prevFrameContaminated: this.prevFrameContaminated
-    });
-    const rendererMs = performance.now() - renderStart;
+      prevFrameContaminated: this.prevFrameContaminated,
+    })
+    const rendererMs = performance.now() - renderStart
 
     // Sticky/auto-follow scrolled the ScrollBox this frame. Translate the
     // selection by the same delta so the highlight stays anchored to the
@@ -457,20 +564,20 @@ export default class Ink {
     // (screen-local) so only anchor shifts — selection grows toward the
     // mouse as the anchor walks up. After release, both ends are text-
     // anchored and move as a block.
-    const follow = consumeFollowScroll();
-    if (follow && this.selection.anchor &&
-    // Only translate if the selection is ON scrollbox content. Selections
-    // in the footer/prompt/StickyPromptHeader are on static text — the
-    // scroll doesn't move what's under them. Without this guard, a
-    // footer selection would be shifted by -delta then clamped to
-    // viewportBottom, teleporting it into the scrollbox. Mirror the
-    // bounds check the deleted check() in ScrollKeybindingHandler had.
-    this.selection.anchor.row >= follow.viewportTop && this.selection.anchor.row <= follow.viewportBottom) {
-      const {
-        delta,
-        viewportTop,
-        viewportBottom
-      } = follow;
+    const follow = consumeFollowScroll()
+    if (
+      follow &&
+      this.selection.anchor &&
+      // Only translate if the selection is ON scrollbox content. Selections
+      // in the footer/prompt/StickyPromptHeader are on static text — the
+      // scroll doesn't move what's under them. Without this guard, a
+      // footer selection would be shifted by -delta then clamped to
+      // viewportBottom, teleporting it into the scrollbox. Mirror the
+      // bounds check the deleted check() in ScrollKeybindingHandler had.
+      this.selection.anchor.row >= follow.viewportTop &&
+      this.selection.anchor.row <= follow.viewportBottom
+    ) {
+      const { delta, viewportTop, viewportBottom } = follow
       // captureScrolledRows and shift* are a pair: capture grabs rows about
       // to scroll off, shift moves the selection endpoint so the same rows
       // won't intersect again next frame. Capturing without shifting leaves
@@ -480,9 +587,15 @@ export default class Ink {
       // each shift branch so the pairing can't be broken by a new guard.
       if (this.selection.isDragging) {
         if (hasSelection(this.selection)) {
-          captureScrolledRows(this.selection, this.frontFrame.screen, viewportTop, viewportTop + delta - 1, 'above');
+          captureScrolledRows(
+            this.selection,
+            this.frontFrame.screen,
+            viewportTop,
+            viewportTop + delta - 1,
+            'above',
+          )
         }
-        shiftAnchor(this.selection, -delta, viewportTop, viewportBottom);
+        shiftAnchor(this.selection, -delta, viewportTop, viewportBottom)
         // Mirror virtualAnchorRow tracking for focus so the drag→follow
         // transition is seamless. During drag, focus stays at the mouse
         // screen position but the TEXT under it shifts by -delta each
@@ -492,33 +605,42 @@ export default class Ink {
         // focus lands delta rows too low. updateSelection clears this when
         // the user actually moves the mouse (new screen position resets debt).
         if (this.selection.focus) {
-          const rawFocus = (this.selection.virtualFocusRow ?? this.selection.focus.row) - delta;
-          this.selection.virtualFocusRow = rawFocus < viewportTop || rawFocus > viewportBottom ? rawFocus : undefined;
+          const rawFocus = (this.selection.virtualFocusRow ?? this.selection.focus.row) - delta
+          this.selection.virtualFocusRow =
+            rawFocus < viewportTop || rawFocus > viewportBottom ? rawFocus : undefined
         }
       } else if (
-      // Flag-3 guard: the anchor check above only proves ONE endpoint is
-      // on scrollbox content. A drag from row 3 (scrollbox) into the
-      // footer at row 6, then release, leaves focus outside the viewport
-      // — shiftSelectionForFollow would clamp it to viewportBottom,
-      // teleporting the highlight from static footer into the scrollbox.
-      // Symmetric check: require BOTH ends inside to translate. A
-      // straddling selection falls through to NEITHER shift NOR capture:
-      // the footer endpoint pins the selection, text scrolls away under
-      // the highlight, and getSelectedText reads the CURRENT screen
-      // contents — no accumulation. Dragging branch doesn't need this:
-      // shiftAnchor ignores focus, and the anchor DOES shift (so capture
-      // is correct there even when focus is in the footer).
-      !this.selection.focus || this.selection.focus.row >= viewportTop && this.selection.focus.row <= viewportBottom) {
+        // Flag-3 guard: the anchor check above only proves ONE endpoint is
+        // on scrollbox content. A drag from row 3 (scrollbox) into the
+        // footer at row 6, then release, leaves focus outside the viewport
+        // — shiftSelectionForFollow would clamp it to viewportBottom,
+        // teleporting the highlight from static footer into the scrollbox.
+        // Symmetric check: require BOTH ends inside to translate. A
+        // straddling selection falls through to NEITHER shift NOR capture:
+        // the footer endpoint pins the selection, text scrolls away under
+        // the highlight, and getSelectedText reads the CURRENT screen
+        // contents — no accumulation. Dragging branch doesn't need this:
+        // shiftAnchor ignores focus, and the anchor DOES shift (so capture
+        // is correct there even when focus is in the footer).
+        !this.selection.focus ||
+        (this.selection.focus.row >= viewportTop && this.selection.focus.row <= viewportBottom)
+      ) {
         if (hasSelection(this.selection)) {
-          captureScrolledRows(this.selection, this.frontFrame.screen, viewportTop, viewportTop + delta - 1, 'above');
+          captureScrolledRows(
+            this.selection,
+            this.frontFrame.screen,
+            viewportTop,
+            viewportTop + delta - 1,
+            'above',
+          )
         }
-        const cleared = shiftSelectionForFollow(this.selection, -delta, viewportTop, viewportBottom);
+        const cleared = shiftSelectionForFollow(this.selection, -delta, viewportTop, viewportBottom)
         // Auto-clear (both ends overshot minRow) must notify React-land
         // so useHasSelection re-renders and the footer copy/escape hint
         // disappears. notifySelectionChange() would recurse into onRender;
         // fire the listeners directly — they schedule a React update for
         // LATER, they don't re-enter this frame.
-        if (cleared) for (const cb of this.selectionListeners) cb();
+        if (cleared) for (const cb of this.selectionListeners) cb()
       }
     }
 
@@ -541,23 +663,29 @@ export default class Ink {
     // which doesn't track damage, and prev-frame overlay cells need to be
     // compared when selection moves/clears. prevFrameContaminated covers
     // the frame-after-selection-clears case.
-    let selActive = false;
-    let hlActive = false;
+    let selActive = false
+    let hlActive = false
     if (this.altScreenActive) {
-      selActive = hasSelection(this.selection);
+      selActive = hasSelection(this.selection)
       if (selActive) {
-        applySelectionOverlay(frame.screen, this.selection, this.stylePool);
+        applySelectionOverlay(frame.screen, this.selection, this.stylePool)
       }
       // Scan-highlight: inverse on ALL visible matches (less/vim style).
       // Position-highlight (below) overlays CURRENT (yellow) on top.
-      hlActive = applySearchHighlight(frame.screen, this.searchHighlightQuery, this.stylePool);
+      hlActive = applySearchHighlight(frame.screen, this.searchHighlightQuery, this.stylePool)
       // Position-based CURRENT: write yellow at positions[currentIdx] +
       // rowOffset. No scanning — positions came from a prior scan when
       // the message first mounted. Message-relative + rowOffset = screen.
       if (this.searchPositions) {
-        const sp = this.searchPositions;
-        const posApplied = applyPositionedHighlight(frame.screen, this.stylePool, sp.positions, sp.rowOffset, sp.currentIdx);
-        hlActive = hlActive || posApplied;
+        const sp = this.searchPositions
+        const posApplied = applyPositionedHighlight(
+          frame.screen,
+          this.stylePool,
+          sp.positions,
+          sp.rowOffset,
+          sp.currentIdx,
+        )
+        hlActive = hlActive || posApplied
       }
     }
 
@@ -571,8 +699,8 @@ export default class Ink {
         x: 0,
         y: 0,
         width: frame.screen.width,
-        height: frame.screen.height
-      };
+        height: frame.screen.height,
+      }
     }
 
     // Alt-screen: anchor the physical cursor to (0,0) before every diff.
@@ -585,52 +713,62 @@ export default class Ink {
     // can't do this — cursor.y tracks scrollback rows CSI H can't reach.
     // The CSI H write is deferred until after the diff is computed so we
     // can skip it for empty diffs (no writes → physical cursor unused).
-    let prevFrame = this.frontFrame;
+    let prevFrame = this.frontFrame
     if (this.altScreenActive) {
       prevFrame = {
         ...this.frontFrame,
-        cursor: ALT_SCREEN_ANCHOR_CURSOR
-      };
+        cursor: ALT_SCREEN_ANCHOR_CURSOR,
+      }
     }
-    const tDiff = performance.now();
-    const diff = this.log.render(prevFrame, frame, this.altScreenActive,
-    // DECSTBM needs BSU/ESU atomicity — without it the outer terminal
-    // renders the scrolled-but-not-yet-repainted intermediate state.
-    // tmux is the main case (re-emits DECSTBM with its own timing and
-    // doesn't implement DEC 2026, so SYNC_OUTPUT_SUPPORTED is false).
-    SYNC_OUTPUT_SUPPORTED);
-    const diffMs = performance.now() - tDiff;
+    const tDiff = performance.now()
+    const diff = this.log.render(
+      prevFrame,
+      frame,
+      this.altScreenActive,
+      // DECSTBM needs BSU/ESU atomicity — without it the outer terminal
+      // renders the scrolled-but-not-yet-repainted intermediate state.
+      // tmux is the main case (re-emits DECSTBM with its own timing and
+      // doesn't implement DEC 2026, so SYNC_OUTPUT_SUPPORTED is false).
+      SYNC_OUTPUT_SUPPORTED,
+    )
+    const diffMs = performance.now() - tDiff
     // Swap buffers
-    this.backFrame = this.frontFrame;
-    this.frontFrame = frame;
+    this.backFrame = this.frontFrame
+    this.frontFrame = frame
 
     // Periodically reset char/hyperlink pools to prevent unbounded growth
     // during long sessions. 5 minutes is infrequent enough that the O(cells)
     // migration cost is negligible. Reuses renderStart to avoid extra clock call.
     if (renderStart - this.lastPoolResetTime > 5 * 60 * 1000) {
-      this.resetPools();
-      this.lastPoolResetTime = renderStart;
+      this.resetPools()
+      this.lastPoolResetTime = renderStart
     }
-    const flickers: FrameEvent['flickers'] = [];
+    const flickers: FrameEvent['flickers'] = []
     for (const patch of diff) {
       if (patch.type === 'clearTerminal') {
         flickers.push({
           desiredHeight: frame.screen.height,
           availableHeight: frame.viewport.height,
-          reason: patch.reason
-        });
+          reason: patch.reason,
+        })
         if (isDebugRepaintsEnabled() && patch.debug) {
-          const chain = dom.findOwnerChainAtRow(this.rootNode, patch.debug.triggerY);
-          logForDebugging(`[REPAINT] full reset · ${patch.reason} · row ${patch.debug.triggerY}\n` + `  prev: "${patch.debug.prevLine}"\n` + `  next: "${patch.debug.nextLine}"\n` + `  culprit: ${chain.length ? chain.join(' < ') : '(no owner chain captured)'}`, {
-            level: 'warn'
-          });
+          const chain = dom.findOwnerChainAtRow(this.rootNode, patch.debug.triggerY)
+          logForDebugging(
+            `[REPAINT] full reset · ${patch.reason} · row ${patch.debug.triggerY}\n` +
+              `  prev: "${patch.debug.prevLine}"\n` +
+              `  next: "${patch.debug.nextLine}"\n` +
+              `  culprit: ${chain.length ? chain.join(' < ') : '(no owner chain captured)'}`,
+            {
+              level: 'warn',
+            },
+          )
         }
       }
     }
-    const tOptimize = performance.now();
-    const optimized = optimize(diff);
-    const optimizeMs = performance.now() - tOptimize;
-    const hasDiff = optimized.length > 0;
+    const tOptimize = performance.now()
+    const optimized = optimize(diff)
+    const optimizeMs = performance.now() - tOptimize
+    const hasDiff = optimized.length > 0
     if (this.altScreenActive && hasDiff) {
       // Prepend CSI H to anchor the physical cursor to (0,0) so
       // log-update's relative moves compute from a known spot (self-healing
@@ -652,12 +790,12 @@ export default class Ink {
       // synchronously in handleResize would blank the screen for the ~80ms
       // render() takes.
       if (this.needsEraseBeforePaint) {
-        this.needsEraseBeforePaint = false;
-        optimized.unshift(ERASE_THEN_HOME_PATCH);
+        this.needsEraseBeforePaint = false
+        optimized.unshift(ERASE_THEN_HOME_PATCH)
       } else {
-        optimized.unshift(CURSOR_HOME_PATCH);
+        optimized.unshift(CURSOR_HOME_PATCH)
       }
-      optimized.push(this.altScreenParkPatch);
+      optimized.push(this.altScreenParkPatch)
     }
 
     // Native cursor positioning: park the terminal cursor at the declared
@@ -667,60 +805,67 @@ export default class Ink {
     // translation) — if the declared node didn't render (stale declaration
     // after remount, or scrolled out of view), it won't be in the cache
     // and no move is emitted.
-    const decl = this.cursorDeclaration;
-    const rect = decl !== null ? nodeCache.get(decl.node) : undefined;
-    const target = decl !== null && rect !== undefined ? {
-      x: rect.x + decl.relativeX,
-      y: rect.y + decl.relativeY
-    } : null;
-    const parked = this.displayCursor;
+    const decl = this.cursorDeclaration
+    const rect = decl !== null ? nodeCache.get(decl.node) : undefined
+    const target =
+      decl !== null && rect !== undefined
+        ? {
+            x: rect.x + decl.relativeX,
+            y: rect.y + decl.relativeY,
+          }
+        : null
+    const parked = this.displayCursor
 
     // Preserve the empty-diff zero-write fast path: skip all cursor writes
     // when nothing rendered AND the park target is unchanged.
-    const targetMoved = target !== null && (parked === null || parked.x !== target.x || parked.y !== target.y);
-    if (hasDiff || targetMoved || target === null && parked !== null) {
+    const targetMoved =
+      target !== null && (parked === null || parked.x !== target.x || parked.y !== target.y)
+    if (hasDiff || targetMoved || (target === null && parked !== null)) {
       // Main-screen preamble: log-update's relative moves assume the
       // physical cursor is at prevFrame.cursor. If last frame parked it
       // elsewhere, move back before the diff runs. Alt-screen's CSI H
       // already resets to (0,0) so no preamble needed.
       if (parked !== null && !this.altScreenActive && hasDiff) {
-        const pdx = prevFrame.cursor.x - parked.x;
-        const pdy = prevFrame.cursor.y - parked.y;
+        const pdx = prevFrame.cursor.x - parked.x
+        const pdy = prevFrame.cursor.y - parked.y
         if (pdx !== 0 || pdy !== 0) {
           optimized.unshift({
             type: 'stdout',
-            content: cursorMove(pdx, pdy)
-          });
+            content: cursorMove(pdx, pdy),
+          })
         }
       }
       if (target !== null) {
         if (this.altScreenActive) {
           // Absolute CUP (1-indexed); next frame's CSI H resets regardless.
           // Emitted after altScreenParkPatch so the declared position wins.
-          const row = Math.min(Math.max(target.y + 1, 1), terminalRows);
-          const col = Math.min(Math.max(target.x + 1, 1), terminalWidth);
+          const row = Math.min(Math.max(target.y + 1, 1), terminalRows)
+          const col = Math.min(Math.max(target.x + 1, 1), terminalWidth)
           optimized.push({
             type: 'stdout',
-            content: cursorPosition(row, col)
-          });
+            content: cursorPosition(row, col),
+          })
         } else {
           // After the diff (or preamble), cursor is at frame.cursor. If no
           // diff AND previously parked, it's still at the old park position
           // (log-update wrote nothing). Otherwise it's at frame.cursor.
-          const from = !hasDiff && parked !== null ? parked : {
-            x: frame.cursor.x,
-            y: frame.cursor.y
-          };
-          const dx = target.x - from.x;
-          const dy = target.y - from.y;
+          const from =
+            !hasDiff && parked !== null
+              ? parked
+              : {
+                  x: frame.cursor.x,
+                  y: frame.cursor.y,
+                }
+          const dx = target.x - from.x
+          const dy = target.y - from.y
           if (dx !== 0 || dy !== 0) {
             optimized.push({
               type: 'stdout',
-              content: cursorMove(dx, dy)
-            });
+              content: cursorMove(dx, dy),
+            })
           }
         }
-        this.displayCursor = target;
+        this.displayCursor = target
       } else {
         // Declaration cleared (input blur, unmount). Restore physical cursor
         // to frame.cursor before forgetting the park position — otherwise
@@ -730,27 +875,27 @@ export default class Ink {
         // !hasDiff (e.g. accessibility mode where blur doesn't change
         // renderedValue since invert is identity).
         if (parked !== null && !this.altScreenActive && !hasDiff) {
-          const rdx = frame.cursor.x - parked.x;
-          const rdy = frame.cursor.y - parked.y;
+          const rdx = frame.cursor.x - parked.x
+          const rdy = frame.cursor.y - parked.y
           if (rdx !== 0 || rdy !== 0) {
             optimized.push({
               type: 'stdout',
-              content: cursorMove(rdx, rdy)
-            });
+              content: cursorMove(rdx, rdy),
+            })
           }
         }
-        this.displayCursor = null;
+        this.displayCursor = null
       }
     }
-    const tWrite = performance.now();
-    writeDiffToTerminal(this.terminal, optimized, this.altScreenActive && !SYNC_OUTPUT_SUPPORTED);
-    const writeMs = performance.now() - tWrite;
+    const tWrite = performance.now()
+    writeDiffToTerminal(this.terminal, optimized, this.altScreenActive && !SYNC_OUTPUT_SUPPORTED)
+    const writeMs = performance.now() - tWrite
 
     // Update blit safety for the NEXT frame. The frame just rendered
     // becomes frontFrame (= next frame's prevScreen). If we applied the
     // selection overlay, that buffer has inverted cells. selActive/hlActive
     // are only ever true in alt-screen; in main-screen this is false→false.
-    this.prevFrameContaminated = selActive || hlActive;
+    this.prevFrameContaminated = selActive || hlActive
 
     // A ScrollBox has pendingScrollDelta left to drain — schedule the next
     // frame. MUST NOT call this.scheduleRender() here: we're inside a
@@ -765,20 +910,20 @@ export default class Ink {
     // quarter interval (~250fps, setTimeout practical floor) for max scroll
     // speed. Regular renders stay at FRAME_INTERVAL_MS via the throttle.
     if (frame.scrollDrainPending) {
-      this.drainTimer = setTimeout(() => this.onRender(), FRAME_INTERVAL_MS >> 2);
+      this.drainTimer = setTimeout(() => this.onRender(), FRAME_INTERVAL_MS >> 2)
     }
-    const yogaMs = getLastYogaMs();
-    const commitMs = getLastCommitMs();
-    const yc = this.lastYogaCounters;
+    const yogaMs = getLastYogaMs()
+    const commitMs = getLastCommitMs()
+    const yc = this.lastYogaCounters
     // Reset so drain-only frames (no React commit) don't repeat stale values.
-    resetProfileCounters();
+    resetProfileCounters()
     this.lastYogaCounters = {
       ms: 0,
       visited: 0,
       measured: 0,
       cacheHits: 0,
-      live: 0
-    };
+      live: 0,
+    }
     this.options.onFrame?.({
       durationMs: performance.now() - renderStart,
       phases: {
@@ -792,21 +937,21 @@ export default class Ink {
         yogaVisited: yc.visited,
         yogaMeasured: yc.measured,
         yogaCacheHits: yc.cacheHits,
-        yogaLive: yc.live
+        yogaLive: yc.live,
       },
-      flickers
-    });
+      flickers,
+    })
   }
   pause(): void {
     // Flush pending React updates and render before pausing.
     // @ts-ignore flushSyncFromReconciler exists in react-reconciler 0.31 but not in @types/react-reconciler
-    reconciler.flushSyncFromReconciler();
-    this.onRender();
-    this.isPaused = true;
+    reconciler.flushSyncFromReconciler()
+    this.onRender()
+    this.isPaused = true
   }
   resume(): void {
-    this.isPaused = false;
-    this.onRender();
+    this.isPaused = false
+    this.onRender()
   }
 
   /**
@@ -815,13 +960,25 @@ export default class Ink {
    * an external process (e.g. tmux, shell, full-screen TUI).
    */
   repaint(): void {
-    this.frontFrame = emptyFrame(this.frontFrame.viewport.height, this.frontFrame.viewport.width, this.stylePool, this.charPool, this.hyperlinkPool);
-    this.backFrame = emptyFrame(this.backFrame.viewport.height, this.backFrame.viewport.width, this.stylePool, this.charPool, this.hyperlinkPool);
-    this.log.reset();
+    this.frontFrame = emptyFrame(
+      this.frontFrame.viewport.height,
+      this.frontFrame.viewport.width,
+      this.stylePool,
+      this.charPool,
+      this.hyperlinkPool,
+    )
+    this.backFrame = emptyFrame(
+      this.backFrame.viewport.height,
+      this.backFrame.viewport.width,
+      this.stylePool,
+      this.charPool,
+      this.hyperlinkPool,
+    )
+    this.log.reset()
     // Physical cursor position is unknown after external terminal corruption.
     // Clear displayCursor so the cursor preamble doesn't emit a stale
     // relative move from where we last parked it.
-    this.displayCursor = null;
+    this.displayCursor = null
   }
 
   /**
@@ -833,18 +990,18 @@ export default class Ink {
    * unchanged cells don't need repainting. Scrollback is preserved.
    */
   forceRedraw(): void {
-    if (!this.options.stdout.isTTY || this.isUnmounted || this.isPaused) return;
-    this.options.stdout.write(ERASE_SCREEN + CURSOR_HOME);
+    if (!this.options.stdout.isTTY || this.isUnmounted || this.isPaused) return
+    this.options.stdout.write(ERASE_SCREEN + CURSOR_HOME)
     if (this.altScreenActive) {
-      this.resetFramesForAltScreen();
+      this.resetFramesForAltScreen()
     } else {
-      this.repaint();
+      this.repaint()
       // repaint() resets frontFrame to 0×0. Without this flag the next
       // frame's blit optimization copies from that empty screen and the
       // diff sees no content. onRender resets the flag at frame end.
-      this.prevFrameContaminated = true;
+      this.prevFrameContaminated = true
     }
-    this.onRender();
+    this.onRender()
   }
 
   /**
@@ -858,7 +1015,7 @@ export default class Ink {
    * onRender resets the flag at frame end so it's one-shot.
    */
   invalidatePrevFrame(): void {
-    this.prevFrameContaminated = true;
+    this.prevFrameContaminated = true
   }
 
   /**
@@ -869,17 +1026,17 @@ export default class Ink {
    * a full redraw with no stale diff state.
    */
   setAltScreenActive(active: boolean, mouseTracking = false): void {
-    if (this.altScreenActive === active) return;
-    this.altScreenActive = active;
-    this.altScreenMouseTracking = active && mouseTracking;
+    if (this.altScreenActive === active) return
+    this.altScreenActive = active
+    this.altScreenMouseTracking = active && mouseTracking
     if (active) {
-      this.resetFramesForAltScreen();
+      this.resetFramesForAltScreen()
     } else {
-      this.repaint();
+      this.repaint()
     }
   }
   get isAltScreenActive(): boolean {
-    return this.altScreenActive;
+    return this.altScreenActive
   }
 
   /**
@@ -904,29 +1061,31 @@ export default class Ink {
    * handleResize.
    */
   reassertTerminalModes = (includeAltScreen = false): void => {
-    if (!this.options.stdout.isTTY) return;
+    if (!this.options.stdout.isTTY) return
     // Don't touch the terminal during an editor handoff — re-enabling kitty
     // keyboard here would undo enterAlternateScreen's disable and nano would
     // start seeing CSI-u sequences again.
-    if (this.isPaused) return;
+    if (this.isPaused) return
     // Extended keys — re-assert if enabled (App.tsx enables these on
     // allowlisted terminals at raw-mode entry; a terminal reset clears them).
     // Pop-before-push keeps Kitty stack depth at 1 instead of accumulating
     // on each call.
     if (supportsExtendedKeys()) {
-      this.options.stdout.write(DISABLE_KITTY_KEYBOARD + ENABLE_KITTY_KEYBOARD + ENABLE_MODIFY_OTHER_KEYS);
+      this.options.stdout.write(
+        DISABLE_KITTY_KEYBOARD + ENABLE_KITTY_KEYBOARD + ENABLE_MODIFY_OTHER_KEYS,
+      )
     }
-    if (!this.altScreenActive) return;
+    if (!this.altScreenActive) return
     // Mouse tracking — idempotent, safe to re-assert on every stdin gap.
     if (this.altScreenMouseTracking) {
-      this.options.stdout.write(ENABLE_MOUSE_TRACKING);
+      this.options.stdout.write(ENABLE_MOUSE_TRACKING)
     }
     // Alt-screen re-entry — destructive (ERASE_SCREEN). Only for callers that
     // have a strong signal the terminal actually dropped mode 1049.
     if (includeAltScreen) {
-      this.reenterAltScreen();
+      this.reenterAltScreen()
     }
-  };
+  }
 
   /**
    * Mark this instance as unmounted so future unmount() calls early-return.
@@ -940,28 +1099,28 @@ export default class Ink {
    * as restoring the saved cursor position — clobbering the resume hint.
    */
   detachForShutdown(): void {
-    this.isUnmounted = true;
+    this.isUnmounted = true
     // Cancel any pending throttled render so it doesn't fire between
     // cleanupTerminalModes() and process.exit() and write to main screen.
-    this.scheduleRender.cancel?.();
+    this.scheduleRender.cancel?.()
     // Restore stdin from raw mode. unmount() used to do this via React
     // unmount (App.componentWillUnmount → handleSetRawMode(false)) but we're
     // short-circuiting that path. Must use this.options.stdin — NOT
     // process.stdin — because getStdinOverride() may have opened /dev/tty
     // when stdin is piped.
     const stdin = this.options.stdin as NodeJS.ReadStream & {
-      isRaw?: boolean;
-      setRawMode?: (m: boolean) => void;
-    };
-    this.drainStdin();
+      isRaw?: boolean
+      setRawMode?: (m: boolean) => void
+    }
+    this.drainStdin()
     if (stdin.isTTY && stdin.isRaw && stdin.setRawMode) {
-      stdin.setRawMode(false);
+      stdin.setRawMode(false)
     }
   }
 
   /** @see drainStdin */
   drainStdin(): void {
-    drainStdin(this.options.stdin);
+    drainStdin(this.options.stdin)
   }
 
   /**
@@ -972,8 +1131,13 @@ export default class Ink {
    * stays true. ENTER_ALT_SCREEN is a terminal-side no-op if already in alt.
    */
   private reenterAltScreen(): void {
-    this.options.stdout.write(ENTER_ALT_SCREEN + ERASE_SCREEN + CURSOR_HOME + (this.altScreenMouseTracking ? ENABLE_MOUSE_TRACKING : ''));
-    this.resetFramesForAltScreen();
+    this.options.stdout.write(
+      ENTER_ALT_SCREEN +
+        ERASE_SCREEN +
+        CURSOR_HOME +
+        (this.altScreenMouseTracking ? ENABLE_MOUSE_TRACKING : ''),
+    )
+    this.resetFramesForAltScreen()
   }
 
   /**
@@ -992,30 +1156,30 @@ export default class Ink {
    * matches the physical cursor after ENTER_ALT_SCREEN + CSI H (home).
    */
   private resetFramesForAltScreen(): void {
-    const rows = this.terminalRows;
-    const cols = this.terminalColumns;
+    const rows = this.terminalRows
+    const cols = this.terminalColumns
     const blank = (): Frame => ({
       screen: createScreen(cols, rows, this.stylePool, this.charPool, this.hyperlinkPool),
       viewport: {
         width: cols,
-        height: rows + 1
+        height: rows + 1,
       },
       cursor: {
         x: 0,
         y: 0,
-        visible: true
-      }
-    });
-    this.frontFrame = blank();
-    this.backFrame = blank();
-    this.log.reset();
+        visible: true,
+      },
+    })
+    this.frontFrame = blank()
+    this.backFrame = blank()
+    this.log.reset()
     // Defense-in-depth: alt-screen skips the cursor preamble anyway (CSI H
     // resets), but a stale displayCursor would be misleading if we later
     // exit to main-screen without an intervening render.
-    this.displayCursor = null;
+    this.displayCursor = null
     // Fresh frontFrame is blank rows×cols — blitting from it would copy
     // blanks over content. Next alt-screen frame must full-render.
-    this.prevFrameContaminated = true;
+    this.prevFrameContaminated = true
   }
 
   /**
@@ -1024,16 +1188,16 @@ export default class Ink {
    * region stays visible after the automatic copy.
    */
   copySelectionNoClear(): string {
-    if (!hasSelection(this.selection)) return '';
-    const text = getSelectedText(this.selection, this.frontFrame.screen);
+    if (!hasSelection(this.selection)) return ''
+    const text = getSelectedText(this.selection, this.frontFrame.screen)
     if (text) {
       // Raw OSC 52, or DCS-passthrough-wrapped OSC 52 inside tmux (tmux
       // drops it silently unless allow-passthrough is on — no regression).
-      void setClipboard(text).then(raw => {
-        if (raw) this.options.stdout.write(raw);
-      });
+      void setClipboard(text).then((raw) => {
+        if (raw) this.options.stdout.write(raw)
+      })
     }
-    return text;
+    return text
   }
 
   /**
@@ -1041,18 +1205,18 @@ export default class Ink {
    * and clear the selection. Returns the copied text (empty if no selection).
    */
   copySelection(): string {
-    if (!hasSelection(this.selection)) return '';
-    const text = this.copySelectionNoClear();
-    clearSelection(this.selection);
-    this.notifySelectionChange();
-    return text;
+    if (!hasSelection(this.selection)) return ''
+    const text = this.copySelectionNoClear()
+    clearSelection(this.selection)
+    this.notifySelectionChange()
+    return text
   }
 
   /** Clear the current text selection without copying. */
   clearTextSelection(): void {
-    if (!hasSelection(this.selection)) return;
-    clearSelection(this.selection);
-    this.notifySelectionChange();
+    if (!hasSelection(this.selection)) return
+    clearSelection(this.selection)
+    this.notifySelectionChange()
   }
 
   /**
@@ -1063,9 +1227,9 @@ export default class Ink {
    * damage, so the overlay forces full-frame damage while active.
    */
   setSearchHighlight(query: string): void {
-    if (this.searchHighlightQuery === query) return;
-    this.searchHighlightQuery = query;
-    this.scheduleRender();
+    if (this.searchHighlightQuery === query) return
+    this.searchHighlightQuery = query
+    this.scheduleRender()
   }
 
   /** Paint an EXISTING DOM subtree to a fresh Screen at its natural
@@ -1079,35 +1243,43 @@ export default class Ink {
    *
    *  ~1-2ms (paint only, no reconcile — the DOM is already built). */
   scanElementSubtree(el: dom.DOMElement): MatchPosition[] {
-    if (!this.searchHighlightQuery || !el.yogaNode) return [];
-    const width = Math.ceil(el.yogaNode.getComputedWidth());
-    const height = Math.ceil(el.yogaNode.getComputedHeight());
-    if (width <= 0 || height <= 0) return [];
+    if (!this.searchHighlightQuery || !el.yogaNode) return []
+    const width = Math.ceil(el.yogaNode.getComputedWidth())
+    const height = Math.ceil(el.yogaNode.getComputedHeight())
+    if (width <= 0 || height <= 0) return []
     // renderNodeToOutput adds el's OWN computedLeft/Top to offsetX/Y.
     // Passing -elLeft/-elTop nets to 0 → paints at (0,0) in our buffer.
-    const elLeft = el.yogaNode.getComputedLeft();
-    const elTop = el.yogaNode.getComputedTop();
-    const screen = createScreen(width, height, this.stylePool, this.charPool, this.hyperlinkPool);
+    const elLeft = el.yogaNode.getComputedLeft()
+    const elTop = el.yogaNode.getComputedTop()
+    const screen = createScreen(width, height, this.stylePool, this.charPool, this.hyperlinkPool)
     const output = new Output({
       width,
       height,
       stylePool: this.stylePool,
-      screen
-    });
+      screen,
+    })
     renderNodeToOutput(el, output, {
       offsetX: -elLeft,
       offsetY: -elTop,
-      prevScreen: undefined
-    });
-    const rendered = output.get();
+      prevScreen: undefined,
+    })
+    const rendered = output.get()
     // renderNodeToOutput wrote our offset positions to nodeCache —
     // corrupts the main render (it'd blit from wrong coords). Mark the
     // subtree dirty so the next main render repaints + re-caches
     // correctly. One extra paint of this message, but correct > fast.
-    dom.markDirty(el);
-    const positions = scanPositions(rendered, this.searchHighlightQuery);
-    logForDebugging(`scanElementSubtree: q='${this.searchHighlightQuery}' ` + `el=${width}x${height}@(${elLeft},${elTop}) n=${positions.length} ` + `[${positions.slice(0, 10).map(p => `${p.row}:${p.col}`).join(',')}` + `${positions.length > 10 ? ',…' : ''}]`);
-    return positions;
+    dom.markDirty(el)
+    const positions = scanPositions(rendered, this.searchHighlightQuery)
+    logForDebugging(
+      `scanElementSubtree: q='${this.searchHighlightQuery}' ` +
+        `el=${width}x${height}@(${elLeft},${elTop}) n=${positions.length} ` +
+        `[${positions
+          .slice(0, 10)
+          .map((p) => `${p.row}:${p.col}`)
+          .join(',')}` +
+        `${positions.length > 10 ? ',…' : ''}]`,
+    )
+    return positions
   }
 
   /** Set the position-based highlight state. Every frame, writes CURRENT
@@ -1115,13 +1287,15 @@ export default class Ink {
    *  highlight (inverse on all matches) still runs — this overlays yellow
    *  on top. rowOffset changes as the user scrolls (= message's current
    *  screen-top); positions stay stable (message-relative). */
-  setSearchPositions(state: {
-    positions: MatchPosition[];
-    rowOffset: number;
-    currentIdx: number;
-  } | null): void {
-    this.searchPositions = state;
-    this.scheduleRender();
+  setSearchPositions(
+    state: {
+      positions: MatchPosition[]
+      rowOffset: number
+      currentIdx: number
+    } | null,
+  ): void {
+    this.searchPositions = state
+    this.scheduleRender()
   }
 
   /**
@@ -1142,17 +1316,17 @@ export default class Ink {
     // Wrap a NUL marker, then split on it to extract the open/close SGR.
     // colorize returns the input unchanged if the color string is bad —
     // no NUL-split then, so fall through to null (inverse fallback).
-    const wrapped = colorize('\0', color, 'background');
-    const nul = wrapped.indexOf('\0');
+    const wrapped = colorize('\0', color, 'background')
+    const nul = wrapped.indexOf('\0')
     if (nul <= 0 || nul === wrapped.length - 1) {
-      this.stylePool.setSelectionBg(null);
-      return;
+      this.stylePool.setSelectionBg(null)
+      return
     }
     this.stylePool.setSelectionBg({
       type: 'ansi',
       code: wrapped.slice(0, nul),
-      endCode: wrapped.slice(nul + 1) // always \x1b[49m for bg
-    });
+      endCode: wrapped.slice(nul + 1), // always \x1b[49m for bg
+    })
     // No scheduleRender: this is called from a React effect that already
     // runs inside the render cycle, and the bg only matters once a
     // selection exists (which itself triggers a full-damage frame).
@@ -1165,7 +1339,7 @@ export default class Ink {
    * the selection state and joined back in by getSelectedText.
    */
   captureScrolledRows(firstRow: number, lastRow: number, side: 'above' | 'below'): void {
-    captureScrolledRows(this.selection, this.frontFrame.screen, firstRow, lastRow, side);
+    captureScrolledRows(this.selection, this.frontFrame.screen, firstRow, lastRow, side)
   }
 
   /**
@@ -1176,14 +1350,14 @@ export default class Ink {
    * edge. Supplies screen.width for the col-reset-on-clamp boundary.
    */
   shiftSelectionForScroll(dRow: number, minRow: number, maxRow: number): void {
-    const hadSel = hasSelection(this.selection);
-    shiftSelection(this.selection, dRow, minRow, maxRow, this.frontFrame.screen.width);
+    const hadSel = hasSelection(this.selection)
+    shiftSelection(this.selection, dRow, minRow, maxRow, this.frontFrame.screen.width)
     // shiftSelection clears when both endpoints overshoot the same edge
     // (Home/g/End/G page-jump past the selection). Notify subscribers so
     // useHasSelection updates. Safe to call notifySelectionChange here —
     // this runs from keyboard handlers, not inside onRender().
     if (hadSel && !hasSelection(this.selection)) {
-      this.notifySelectionChange();
+      this.notifySelectionChange()
     }
   }
 
@@ -1196,55 +1370,49 @@ export default class Ink {
    * char mode. No-op outside alt-screen or without an active selection.
    */
   moveSelectionFocus(move: FocusMove): void {
-    if (!this.altScreenActive) return;
-    const {
-      focus
-    } = this.selection;
-    if (!focus) return;
-    const {
-      width,
-      height
-    } = this.frontFrame.screen;
-    const maxCol = width - 1;
-    const maxRow = height - 1;
-    let {
-      col,
-      row
-    } = focus;
+    if (!this.altScreenActive) return
+    const { focus } = this.selection
+    if (!focus) return
+    const { width, height } = this.frontFrame.screen
+    const maxCol = width - 1
+    const maxRow = height - 1
+    let { col, row } = focus
     switch (move) {
       case 'left':
-        if (col > 0) col--;else if (row > 0) {
-          col = maxCol;
-          row--;
+        if (col > 0) col--
+        else if (row > 0) {
+          col = maxCol
+          row--
         }
-        break;
+        break
       case 'right':
-        if (col < maxCol) col++;else if (row < maxRow) {
-          col = 0;
-          row++;
+        if (col < maxCol) col++
+        else if (row < maxRow) {
+          col = 0
+          row++
         }
-        break;
+        break
       case 'up':
-        if (row > 0) row--;
-        break;
+        if (row > 0) row--
+        break
       case 'down':
-        if (row < maxRow) row++;
-        break;
+        if (row < maxRow) row++
+        break
       case 'lineStart':
-        col = 0;
-        break;
+        col = 0
+        break
       case 'lineEnd':
-        col = maxCol;
-        break;
+        col = maxCol
+        break
     }
-    if (col === focus.col && row === focus.row) return;
-    moveFocus(this.selection, col, row);
-    this.notifySelectionChange();
+    if (col === focus.col && row === focus.row) return
+    moveFocus(this.selection, col, row)
+    this.notifySelectionChange()
   }
 
   /** Whether there is an active text selection. */
   hasTextSelection(): boolean {
-    return hasSelection(this.selection);
+    return hasSelection(this.selection)
   }
 
   /**
@@ -1252,12 +1420,12 @@ export default class Ink {
    * is started, updated, cleared, or copied. Returns an unsubscribe fn.
    */
   subscribeToSelectionChange(cb: () => void): () => void {
-    this.selectionListeners.add(cb);
-    return () => this.selectionListeners.delete(cb);
+    this.selectionListeners.add(cb)
+    return () => this.selectionListeners.delete(cb)
   }
   private notifySelectionChange(): void {
-    this.onRender();
-    for (const cb of this.selectionListeners) cb();
+    this.onRender()
+    for (const cb of this.selectionListeners) cb()
   }
 
   /**
@@ -1268,26 +1436,26 @@ export default class Ink {
    * nodeCache rects map 1:1 to terminal cells (no scrollback offset).
    */
   dispatchClick(col: number, row: number): boolean {
-    if (!this.altScreenActive) return false;
-    const blank = isEmptyCellAt(this.frontFrame.screen, col, row);
-    return dispatchClick(this.rootNode, col, row, blank);
+    if (!this.altScreenActive) return false
+    const blank = isEmptyCellAt(this.frontFrame.screen, col, row)
+    return dispatchClick(this.rootNode, col, row, blank)
   }
   dispatchHover(col: number, row: number): void {
-    if (!this.altScreenActive) return;
-    dispatchHover(this.rootNode, col, row, this.hoveredNodes);
+    if (!this.altScreenActive) return
+    dispatchHover(this.rootNode, col, row, this.hoveredNodes)
   }
   dispatchKeyboardEvent(parsedKey: ParsedKey): void {
-    const target = this.focusManager.activeElement ?? this.rootNode;
-    const event = new KeyboardEvent(parsedKey);
-    dispatcher.dispatchDiscrete(target, event);
+    const target = this.focusManager.activeElement ?? this.rootNode
+    const event = new KeyboardEvent(parsedKey)
+    dispatcher.dispatchDiscrete(target, event)
 
     // Tab cycling is the default action — only fires if no handler
     // called preventDefault(). Mirrors browser behavior.
     if (!event.defaultPrevented && parsedKey.name === 'tab' && !parsedKey.ctrl && !parsedKey.meta) {
       if (parsedKey.shift) {
-        this.focusManager.focusPrevious(this.rootNode);
+        this.focusManager.focusPrevious(this.rootNode)
       } else {
-        this.focusManager.focusNext(this.rootNode);
+        this.focusManager.focusNext(this.rootNode)
       }
     }
   }
@@ -1301,23 +1469,23 @@ export default class Ink {
    * the browser-open action via a timer.
    */
   getHyperlinkAt(col: number, row: number): string | undefined {
-    if (!this.altScreenActive) return undefined;
-    const screen = this.frontFrame.screen;
-    const cell = cellAt(screen, col, row);
-    let url = cell?.hyperlink;
+    if (!this.altScreenActive) return undefined
+    const screen = this.frontFrame.screen
+    const cell = cellAt(screen, col, row)
+    let url = cell?.hyperlink
     // SpacerTail cells (right half of wide/CJK/emoji chars) store the
     // hyperlink on the head cell at col-1.
     if (!url && cell?.width === CellWidth.SpacerTail && col > 0) {
-      url = cellAt(screen, col - 1, row)?.hyperlink;
+      url = cellAt(screen, col - 1, row)?.hyperlink
     }
-    return url ?? findPlainTextUrlAt(screen, col, row);
+    return url ?? findPlainTextUrlAt(screen, col, row)
   }
 
   /**
    * Optional callback fired when clicking an OSC 8 hyperlink in fullscreen
    * mode. Set by FullscreenLayout via useLayoutEffect.
    */
-  onHyperlinkClick: ((url: string) => void) | undefined;
+  onHyperlinkClick: ((url: string) => void) | undefined
 
   /**
    * Stable prototype wrapper for onHyperlinkClick. Passed to <App> as
@@ -1325,7 +1493,7 @@ export default class Ink {
    * the mutable field at call time — not the undefined-at-render value.
    */
   openHyperlink(url: string): void {
-    this.onHyperlinkClick?.(url);
+    this.onHyperlinkClick?.(url)
   }
 
   /**
@@ -1336,17 +1504,18 @@ export default class Ink {
    * char-mode startSelection if the click lands on a noSelect cell.
    */
   handleMultiClick(col: number, row: number, count: 2 | 3): void {
-    if (!this.altScreenActive) return;
-    const screen = this.frontFrame.screen;
+    if (!this.altScreenActive) return
+    const screen = this.frontFrame.screen
     // selectWordAt/selectLineAt no-op on noSelect/out-of-bounds. Seed with
     // a char-mode selection so the press still starts a drag even if the
     // word/line scan finds nothing selectable.
-    startSelection(this.selection, col, row);
-    if (count === 2) selectWordAt(this.selection, screen, col, row);else selectLineAt(this.selection, screen, row);
+    startSelection(this.selection, col, row)
+    if (count === 2) selectWordAt(this.selection, screen, col, row)
+    else selectLineAt(this.selection, screen, row)
     // Ensure hasSelection is true so release doesn't re-dispatch onClickAt.
     // selectWordAt no-ops on noSelect; selectLineAt no-ops out-of-bounds.
-    if (!this.selection.focus) this.selection.focus = this.selection.anchor;
-    this.notifySelectionChange();
+    if (!this.selection.focus) this.selection.focus = this.selection.anchor
+    this.notifySelectionChange()
   }
 
   /**
@@ -1356,83 +1525,91 @@ export default class Ink {
    * altScreenActive for the same reason as dispatchClick.
    */
   handleSelectionDrag(col: number, row: number): void {
-    if (!this.altScreenActive) return;
-    const sel = this.selection;
+    if (!this.altScreenActive) return
+    const sel = this.selection
     if (sel.anchorSpan) {
-      extendSelection(sel, this.frontFrame.screen, col, row);
+      extendSelection(sel, this.frontFrame.screen, col, row)
     } else {
-      updateSelection(sel, col, row);
+      updateSelection(sel, col, row)
     }
-    this.notifySelectionChange();
+    this.notifySelectionChange()
   }
 
   // Methods to properly suspend stdin for external editor usage
   // This is needed to prevent Ink from swallowing keystrokes when an external editor is active
   private stdinListeners: Array<{
-    event: string;
-    listener: (...args: unknown[]) => void;
-  }> = [];
-  private wasRawMode = false;
+    event: string
+    listener: (...args: unknown[]) => void
+  }> = []
+  private wasRawMode = false
   suspendStdin(): void {
-    const stdin = this.options.stdin;
+    const stdin = this.options.stdin
     if (!stdin.isTTY) {
-      return;
+      return
     }
 
     // Store and remove all 'readable' event listeners temporarily
     // This prevents Ink from consuming stdin while the editor is active
-    const readableListeners = stdin.listeners('readable');
-    logForDebugging(`[stdin] suspendStdin: removing ${readableListeners.length} readable listener(s), wasRawMode=${(stdin as NodeJS.ReadStream & {
-      isRaw?: boolean;
-    }).isRaw ?? false}`);
-    readableListeners.forEach(listener => {
+    const readableListeners = stdin.listeners('readable')
+    logForDebugging(
+      `[stdin] suspendStdin: removing ${readableListeners.length} readable listener(s), wasRawMode=${
+        (
+          stdin as NodeJS.ReadStream & {
+            isRaw?: boolean
+          }
+        ).isRaw ?? false
+      }`,
+    )
+    readableListeners.forEach((listener) => {
       this.stdinListeners.push({
         event: 'readable',
-        listener: listener as (...args: unknown[]) => void
-      });
-      stdin.removeListener('readable', listener as (...args: unknown[]) => void);
-    });
+        listener: listener as (...args: unknown[]) => void,
+      })
+      stdin.removeListener('readable', listener as (...args: unknown[]) => void)
+    })
 
     // If raw mode is enabled, disable it temporarily
     const stdinWithRaw = stdin as NodeJS.ReadStream & {
-      isRaw?: boolean;
-      setRawMode?: (mode: boolean) => void;
-    };
+      isRaw?: boolean
+      setRawMode?: (mode: boolean) => void
+    }
     if (stdinWithRaw.isRaw && stdinWithRaw.setRawMode) {
-      stdinWithRaw.setRawMode(false);
-      this.wasRawMode = true;
+      stdinWithRaw.setRawMode(false)
+      this.wasRawMode = true
     }
   }
   resumeStdin(): void {
-    const stdin = this.options.stdin;
+    const stdin = this.options.stdin
     if (!stdin.isTTY) {
-      return;
+      return
     }
 
     // Re-attach all the stored listeners
     if (this.stdinListeners.length === 0 && !this.wasRawMode) {
-      logForDebugging('[stdin] resumeStdin: called with no stored listeners and wasRawMode=false (possible desync)', {
-        level: 'warn'
-      });
+      logForDebugging(
+        '[stdin] resumeStdin: called with no stored listeners and wasRawMode=false (possible desync)',
+        {
+          level: 'warn',
+        },
+      )
     }
-    logForDebugging(`[stdin] resumeStdin: re-attaching ${this.stdinListeners.length} listener(s), wasRawMode=${this.wasRawMode}`);
-    this.stdinListeners.forEach(({
-      event,
-      listener
-    }) => {
-      stdin.addListener(event, listener);
-    });
-    this.stdinListeners = [];
+    logForDebugging(
+      `[stdin] resumeStdin: re-attaching ${this.stdinListeners.length} listener(s), wasRawMode=${this.wasRawMode}`,
+    )
+    this.stdinListeners.forEach(({ event, listener }) => {
+      stdin.addListener(event, listener)
+    })
+    this.stdinListeners = []
 
     // Re-enable raw mode if it was enabled before
     if (this.wasRawMode) {
       const stdinWithRaw = stdin as NodeJS.ReadStream & {
-        setRawMode?: (mode: boolean) => void;
-      };
-      if (stdinWithRaw.setRawMode) {
-        stdinWithRaw.setRawMode(true);
+        setRawMode?: (mode: boolean) => void
       }
-      this.wasRawMode = false;
+      if (stdinWithRaw.setRawMode) {
+        stdinWithRaw.setRawMode(true)
+      }
+      this.wasRawMode = false
     }
   }
 
@@ -1441,43 +1618,66 @@ export default class Ink {
   // cascades through useContext → <AlternateScreen>'s useLayoutEffect dep
   // array → spurious exit+re-enter of the alt screen on every SIGWINCH.
   private writeRaw(data: string): void {
-    this.options.stdout.write(data);
+    this.options.stdout.write(data)
   }
   private setCursorDeclaration: CursorDeclarationSetter = (decl, clearIfNode) => {
-    if (decl === null && clearIfNode !== undefined && this.cursorDeclaration?.node !== clearIfNode) {
-      return;
+    if (
+      decl === null &&
+      clearIfNode !== undefined &&
+      this.cursorDeclaration?.node !== clearIfNode
+    ) {
+      return
     }
-    this.cursorDeclaration = decl;
-  };
+    this.cursorDeclaration = decl
+  }
   render(node: ReactNode): void {
-    this.currentNode = node;
-    const tree = <App stdin={this.options.stdin} stdout={this.options.stdout} stderr={this.options.stderr} exitOnCtrlC={this.options.exitOnCtrlC} onExit={this.unmount} terminalColumns={this.terminalColumns} terminalRows={this.terminalRows} selection={this.selection} onSelectionChange={this.notifySelectionChange} onClickAt={this.dispatchClick} onHoverAt={this.dispatchHover} getHyperlinkAt={this.getHyperlinkAt} onOpenHyperlink={this.openHyperlink} onMultiClick={this.handleMultiClick} onSelectionDrag={this.handleSelectionDrag} onStdinResume={this.reassertTerminalModes} onCursorDeclaration={this.setCursorDeclaration} dispatchKeyboardEvent={this.dispatchKeyboardEvent}>
-        <TerminalWriteProvider value={this.writeRaw}>
-          {node}
-        </TerminalWriteProvider>
-      </App>;
+    this.currentNode = node
+    const tree = (
+      <App
+        stdin={this.options.stdin}
+        stdout={this.options.stdout}
+        stderr={this.options.stderr}
+        exitOnCtrlC={this.options.exitOnCtrlC}
+        onExit={this.unmount}
+        terminalColumns={this.terminalColumns}
+        terminalRows={this.terminalRows}
+        selection={this.selection}
+        onSelectionChange={this.notifySelectionChange}
+        onClickAt={this.dispatchClick}
+        onHoverAt={this.dispatchHover}
+        getHyperlinkAt={this.getHyperlinkAt}
+        onOpenHyperlink={this.openHyperlink}
+        onMultiClick={this.handleMultiClick}
+        onSelectionDrag={this.handleSelectionDrag}
+        onStdinResume={this.reassertTerminalModes}
+        onCursorDeclaration={this.setCursorDeclaration}
+        dispatchKeyboardEvent={this.dispatchKeyboardEvent}
+      >
+        <TerminalWriteProvider value={this.writeRaw}>{node}</TerminalWriteProvider>
+      </App>
+    )
 
     // @ts-ignore updateContainerSync exists in react-reconciler but not in @types/react-reconciler
-    reconciler.updateContainerSync(tree, this.container, null, noop);
+    reconciler.updateContainerSync(tree, this.container, null, noop)
     // @ts-ignore flushSyncWork exists in react-reconciler but not in @types/react-reconciler
-    reconciler.flushSyncWork();
+    reconciler.flushSyncWork()
   }
   unmount(error?: Error | number | null): void {
     if (this.isUnmounted) {
-      return;
+      return
     }
-    this.onRender();
-    this.unsubscribeExit();
+    this.onRender()
+    this.unsubscribeExit()
     if (typeof this.restoreConsole === 'function') {
-      this.restoreConsole();
+      this.restoreConsole()
     }
-    this.restoreStderr?.();
-    this.unsubscribeTTYHandlers?.();
+    this.restoreStderr?.()
+    this.unsubscribeTTYHandlers?.()
 
     // Non-TTY environments don't handle erasing ansi escapes well, so it's better to
     // only render last frame of non-static output
-    const diff = this.log.renderPreviousOutput_DEPRECATED(this.frontFrame);
-    writeDiffToTerminal(this.terminal, optimize(diff));
+    const diff = this.log.renderPreviousOutput_DEPRECATED(this.frontFrame)
+    writeDiffToTerminal(this.terminal, optimize(diff))
 
     // Clean up terminal modes synchronously before process exit.
     // React's componentWillUnmount won't run in time when process.exit() is called,
@@ -1495,71 +1695,77 @@ export default class Ink {
       // on terminals already on the main screen, so sending it unconditionally
       // is safe. <AlternateScreen>'s unmount effect won't run during signal-exit,
       // so this is the only guaranteed cleanup path.
-      writeSync(1, EXIT_ALT_SCREEN);
+      writeSync(1, EXIT_ALT_SCREEN)
       // Disable mouse tracking — unconditional because altScreenActive can be
       // stale if AlternateScreen's unmount (which flips the flag) raced a
       // blocked event loop + SIGINT. No-op if tracking was never enabled.
-      writeSync(1, DISABLE_MOUSE_TRACKING);
+      writeSync(1, DISABLE_MOUSE_TRACKING)
       // Drain stdin so in-flight mouse events don't leak to the shell
-      this.drainStdin();
+      this.drainStdin()
       // Disable extended key reporting (both kitty and modifyOtherKeys)
-      writeSync(1, DISABLE_MODIFY_OTHER_KEYS);
-      writeSync(1, DISABLE_KITTY_KEYBOARD);
+      writeSync(1, DISABLE_MODIFY_OTHER_KEYS)
+      writeSync(1, DISABLE_KITTY_KEYBOARD)
       // Disable focus events (DECSET 1004)
-      writeSync(1, DFE);
+      writeSync(1, DFE)
       // Disable bracketed paste mode
-      writeSync(1, DBP);
+      writeSync(1, DBP)
       // Show cursor
-      writeSync(1, SHOW_CURSOR);
+      writeSync(1, SHOW_CURSOR)
       // Clear iTerm2 progress bar
-      writeSync(1, CLEAR_ITERM2_PROGRESS);
+      writeSync(1, CLEAR_ITERM2_PROGRESS)
       // Clear tab status (OSC 21337) so a stale dot doesn't linger
-      if (supportsTabStatus()) writeSync(1, wrapForMultiplexer(CLEAR_TAB_STATUS));
+      if (supportsTabStatus()) writeSync(1, wrapForMultiplexer(CLEAR_TAB_STATUS))
     }
     /* eslint-enable custom-rules/no-sync-fs */
 
-    this.isUnmounted = true;
+    this.isUnmounted = true
 
     // Cancel any pending throttled renders to prevent accessing freed Yoga nodes
-    this.scheduleRender.cancel?.();
+    this.scheduleRender.cancel?.()
     if (this.drainTimer !== null) {
-      clearTimeout(this.drainTimer);
-      this.drainTimer = null;
+      clearTimeout(this.drainTimer)
+      this.drainTimer = null
     }
 
     // @ts-ignore updateContainerSync exists in react-reconciler but not in @types/react-reconciler
-    reconciler.updateContainerSync(null, this.container, null, noop);
+    reconciler.updateContainerSync(null, this.container, null, noop)
     // @ts-ignore flushSyncWork exists in react-reconciler but not in @types/react-reconciler
-    reconciler.flushSyncWork();
-    instances.delete(this.options.stdout);
+    reconciler.flushSyncWork()
+    instances.delete(this.options.stdout)
 
     // Free the root yoga node, then clear its reference. Children are already
     // freed by the reconciler's removeChildFromContainer; using .free() (not
     // .freeRecursive()) avoids double-freeing them.
-    this.rootNode.yogaNode?.free();
-    this.rootNode.yogaNode = undefined;
+    this.rootNode.yogaNode?.free()
+    this.rootNode.yogaNode = undefined
     if (error instanceof Error) {
-      this.rejectExitPromise(error);
+      this.rejectExitPromise(error)
     } else {
-      this.resolveExitPromise();
+      this.resolveExitPromise()
     }
   }
   async waitUntilExit(): Promise<void> {
     this.exitPromise ||= new Promise((resolve, reject) => {
-      this.resolveExitPromise = resolve;
-      this.rejectExitPromise = reject;
-    });
-    return this.exitPromise;
+      this.resolveExitPromise = resolve
+      this.rejectExitPromise = reject
+    })
+    return this.exitPromise
   }
   resetLineCount(): void {
     if (this.options.stdout.isTTY) {
       // Swap so old front becomes back (for screen reuse), then reset front
-      this.backFrame = this.frontFrame;
-      this.frontFrame = emptyFrame(this.frontFrame.viewport.height, this.frontFrame.viewport.width, this.stylePool, this.charPool, this.hyperlinkPool);
-      this.log.reset();
+      this.backFrame = this.frontFrame
+      this.frontFrame = emptyFrame(
+        this.frontFrame.viewport.height,
+        this.frontFrame.viewport.width,
+        this.stylePool,
+        this.charPool,
+        this.hyperlinkPool,
+      )
+      this.log.reset()
       // frontFrame is reset, so frame.cursor on the next render is (0,0).
       // Clear displayCursor so the preamble doesn't compute a stale delta.
-      this.displayCursor = null;
+      this.displayCursor = null
     }
   }
 
@@ -1572,34 +1778,34 @@ export default class Ink {
    * Call between conversation turns or periodically.
    */
   resetPools(): void {
-    this.charPool = new CharPool();
-    this.hyperlinkPool = new HyperlinkPool();
-    migrateScreenPools(this.frontFrame.screen, this.charPool, this.hyperlinkPool);
+    this.charPool = new CharPool()
+    this.hyperlinkPool = new HyperlinkPool()
+    migrateScreenPools(this.frontFrame.screen, this.charPool, this.hyperlinkPool)
     // Back frame's data is zeroed by resetScreen before reads, but its pool
     // references are used by the renderer to intern new characters. Point
     // them at the new pools so the next frame's IDs are comparable.
-    this.backFrame.screen.charPool = this.charPool;
-    this.backFrame.screen.hyperlinkPool = this.hyperlinkPool;
+    this.backFrame.screen.charPool = this.charPool
+    this.backFrame.screen.hyperlinkPool = this.hyperlinkPool
   }
   patchConsole(): () => void {
     // biome-ignore lint/suspicious/noConsole: intentionally patching global console
-    const con = console;
-    const originals: Partial<Record<keyof Console, Console[keyof Console]>> = {};
-    const toDebug = (...args: unknown[]) => logForDebugging(`console.log: ${format(...args)}`);
-    const toError = (...args: unknown[]) => logError(new Error(`console.error: ${format(...args)}`));
+    const con = console
+    const originals: Partial<Record<keyof Console, Console[keyof Console]>> = {}
+    const toDebug = (...args: unknown[]) => logForDebugging(`console.log: ${format(...args)}`)
+    const toError = (...args: unknown[]) => logError(new Error(`console.error: ${format(...args)}`))
     for (const m of CONSOLE_STDOUT_METHODS) {
-      originals[m] = con[m];
-      con[m] = toDebug;
+      originals[m] = con[m]
+      con[m] = toDebug
     }
     for (const m of CONSOLE_STDERR_METHODS) {
-      originals[m] = con[m];
-      con[m] = toError;
+      originals[m] = con[m]
+      con[m] = toError
     }
-    originals.assert = con.assert;
+    originals.assert = con.assert
     con.assert = (condition: unknown, ...args: unknown[]) => {
-      if (!condition) toError(...args);
-    };
-    return () => Object.assign(con, originals);
+      if (!condition) toError(...args)
+    }
+    return () => Object.assign(con, originals)
   }
 
   /**
@@ -1615,40 +1821,49 @@ export default class Ink {
    * process.stdout — Ink itself writes there.
    */
   private patchStderr(): () => void {
-    const stderr = process.stderr;
-    const originalWrite = stderr.write;
-    let reentered = false;
-    const intercept = (chunk: Uint8Array | string, encodingOrCb?: BufferEncoding | ((err?: Error) => void), cb?: (err?: Error) => void): boolean => {
-      const callback = typeof encodingOrCb === 'function' ? encodingOrCb : cb;
+    const stderr = process.stderr
+    const originalWrite = stderr.write
+    let reentered = false
+    const intercept = (
+      chunk: Uint8Array | string,
+      encodingOrCb?: BufferEncoding | ((err?: Error) => void),
+      cb?: (err?: Error) => void,
+    ): boolean => {
+      const callback = typeof encodingOrCb === 'function' ? encodingOrCb : cb
       // Reentrancy guard: logForDebugging → writeToStderr → here. Pass
       // through to the original so --debug-to-stderr still works and we
       // don't stack-overflow.
       if (reentered) {
-        const encoding = typeof encodingOrCb === 'string' ? encodingOrCb : undefined;
-        return originalWrite.call(stderr, chunk, encoding, callback as ((err?: Error | null) => void) | undefined);
+        const encoding = typeof encodingOrCb === 'string' ? encodingOrCb : undefined
+        return originalWrite.call(
+          stderr,
+          chunk,
+          encoding,
+          callback as ((err?: Error | null) => void) | undefined,
+        )
       }
-      reentered = true;
+      reentered = true
       try {
-        const text = typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8');
+        const text = typeof chunk === 'string' ? chunk : Buffer.from(chunk).toString('utf8')
         logForDebugging(`[stderr] ${text}`, {
-          level: 'warn'
-        });
+          level: 'warn',
+        })
         if (this.altScreenActive && !this.isUnmounted && !this.isPaused) {
-          this.prevFrameContaminated = true;
-          this.scheduleRender();
+          this.prevFrameContaminated = true
+          this.scheduleRender()
         }
       } finally {
-        reentered = false;
-        callback?.();
+        reentered = false
+        callback?.()
       }
-      return true;
-    };
-    stderr.write = intercept;
+      return true
+    }
+    stderr.write = intercept
     return () => {
       if (stderr.write === intercept) {
-        stderr.write = originalWrite;
+        stderr.write = originalWrite
       }
-    };
+    }
   }
 }
 
@@ -1675,7 +1890,7 @@ export default class Ink {
  */
 /* eslint-disable custom-rules/no-sync-fs -- must be sync; called from signal handler / unmount */
 export function drainStdin(stdin: NodeJS.ReadStream = process.stdin): void {
-  if (!stdin.isTTY) return;
+  if (!stdin.isTTY) return
   // Drain Node's stream buffer (bytes libuv already pulled in). read()
   // returns null when empty — never blocks.
   try {
@@ -1687,27 +1902,27 @@ export function drainStdin(stdin: NodeJS.ReadStream = process.stdin): void {
   }
   // No /dev/tty on Windows; CONIN$ doesn't support O_NONBLOCK semantics.
   // Windows Terminal also doesn't buffer mouse reports the same way.
-  if (process.platform === 'win32') return;
+  if (process.platform === 'win32') return
   // termios is per-device: flip stdin to raw so canonical-mode line
   // buffering doesn't hide partial input from the non-blocking read.
   // Restored in the finally block.
   const tty = stdin as NodeJS.ReadStream & {
-    isRaw?: boolean;
-    setRawMode?: (raw: boolean) => void;
-  };
-  const wasRaw = tty.isRaw === true;
+    isRaw?: boolean
+    setRawMode?: (raw: boolean) => void
+  }
+  const wasRaw = tty.isRaw === true
   // Drain the kernel TTY buffer via a fresh O_NONBLOCK fd. Bounded at 64
   // reads (64KB) — a real mouse burst is a few hundred bytes; the cap
   // guards against a terminal that ignores O_NONBLOCK.
-  let fd = -1;
+  let fd = -1
   try {
     // setRawMode inside try: on revoked TTY (SIGHUP/SSH disconnect) the
     // ioctl throws EBADF — same recovery path as openSync/readSync below.
-    if (!wasRaw) tty.setRawMode?.(true);
-    fd = openSync('/dev/tty', fsConstants.O_RDONLY | fsConstants.O_NONBLOCK);
-    const buf = Buffer.alloc(1024);
+    if (!wasRaw) tty.setRawMode?.(true)
+    fd = openSync('/dev/tty', fsConstants.O_RDONLY | fsConstants.O_NONBLOCK)
+    const buf = Buffer.alloc(1024)
     for (let i = 0; i < 64; i++) {
-      if (readSync(fd, buf, 0, buf.length, null) <= 0) break;
+      if (readSync(fd, buf, 0, buf.length, null) <= 0) break
     }
   } catch {
     // EAGAIN (buffer empty — expected), ENXIO/ENOENT (no controlling tty),
@@ -1715,14 +1930,14 @@ export function drainStdin(stdin: NodeJS.ReadStream = process.stdin): void {
   } finally {
     if (fd >= 0) {
       try {
-        closeSync(fd);
+        closeSync(fd)
       } catch {
         /* ignore */
       }
     }
     if (!wasRaw) {
       try {
-        tty.setRawMode?.(false);
+        tty.setRawMode?.(false)
       } catch {
         /* TTY may be gone */
       }
@@ -1731,6 +1946,21 @@ export function drainStdin(stdin: NodeJS.ReadStream = process.stdin): void {
 }
 /* eslint-enable custom-rules/no-sync-fs */
 
-const CONSOLE_STDOUT_METHODS = ['log', 'info', 'debug', 'dir', 'dirxml', 'count', 'countReset', 'group', 'groupCollapsed', 'groupEnd', 'table', 'time', 'timeEnd', 'timeLog'] as const;
-const CONSOLE_STDERR_METHODS = ['warn', 'error', 'trace'] as const;
+const CONSOLE_STDOUT_METHODS = [
+  'log',
+  'info',
+  'debug',
+  'dir',
+  'dirxml',
+  'count',
+  'countReset',
+  'group',
+  'groupCollapsed',
+  'groupEnd',
+  'table',
+  'time',
+  'timeEnd',
+  'timeLog',
+] as const
+const CONSOLE_STDERR_METHODS = ['warn', 'error', 'trace'] as const
 //# sourceMappingURL=data:application/json;charset=utf-8;base64,eyJ2ZXJzaW9uIjozLCJuYW1lcyI6WyJhdXRvQmluZCIsImNsb3NlU3luYyIsImNvbnN0YW50cyIsImZzQ29uc3RhbnRzIiwib3BlblN5bmMiLCJyZWFkU3luYyIsIndyaXRlU3luYyIsIm5vb3AiLCJ0aHJvdHRsZSIsIlJlYWN0IiwiUmVhY3ROb2RlIiwiRmliZXJSb290IiwiQ29uY3VycmVudFJvb3QiLCJvbkV4aXQiLCJmbHVzaEludGVyYWN0aW9uVGltZSIsImdldFlvZ2FDb3VudGVycyIsImxvZ0ZvckRlYnVnZ2luZyIsImxvZ0Vycm9yIiwiZm9ybWF0IiwiY29sb3JpemUiLCJBcHAiLCJDdXJzb3JEZWNsYXJhdGlvbiIsIkN1cnNvckRlY2xhcmF0aW9uU2V0dGVyIiwiRlJBTUVfSU5URVJWQUxfTVMiLCJkb20iLCJLZXlib2FyZEV2ZW50IiwiRm9jdXNNYW5hZ2VyIiwiZW1wdHlGcmFtZSIsIkZyYW1lIiwiRnJhbWVFdmVudCIsImRpc3BhdGNoQ2xpY2siLCJkaXNwYXRjaEhvdmVyIiwiaW5zdGFuY2VzIiwiTG9nVXBkYXRlIiwibm9kZUNhY2hlIiwib3B0aW1pemUiLCJPdXRwdXQiLCJQYXJzZWRLZXkiLCJyZWNvbmNpbGVyIiwiZGlzcGF0Y2hlciIsImdldExhc3RDb21taXRNcyIsImdldExhc3RZb2dhTXMiLCJpc0RlYnVnUmVwYWludHNFbmFibGVkIiwicmVjb3JkWW9nYU1zIiwicmVzZXRQcm9maWxlQ291bnRlcnMiLCJyZW5kZXJOb2RlVG9PdXRwdXQiLCJjb25zdW1lRm9sbG93U2Nyb2xsIiwiZGlkTGF5b3V0U2hpZnQiLCJhcHBseVBvc2l0aW9uZWRIaWdobGlnaHQiLCJNYXRjaFBvc2l0aW9uIiwic2NhblBvc2l0aW9ucyIsImNyZWF0ZVJlbmRlcmVyIiwiUmVuZGVyZXIiLCJDZWxsV2lkdGgiLCJDaGFyUG9vbCIsImNlbGxBdCIsImNyZWF0ZVNjcmVlbiIsIkh5cGVybGlua1Bvb2wiLCJpc0VtcHR5Q2VsbEF0IiwibWlncmF0ZVNjcmVlblBvb2xzIiwiU3R5bGVQb29sIiwiYXBwbHlTZWFyY2hIaWdobGlnaHQiLCJhcHBseVNlbGVjdGlvbk92ZXJsYXkiLCJjYXB0dXJlU2Nyb2xsZWRSb3dzIiwiY2xlYXJTZWxlY3Rpb24iLCJjcmVhdGVTZWxlY3Rpb25TdGF0ZSIsImV4dGVuZFNlbGVjdGlvbiIsIkZvY3VzTW92ZSIsImZpbmRQbGFpblRleHRVcmxBdCIsImdldFNlbGVjdGVkVGV4dCIsImhhc1NlbGVjdGlvbiIsIm1vdmVGb2N1cyIsIlNlbGVjdGlvblN0YXRlIiwic2VsZWN0TGluZUF0Iiwic2VsZWN0V29yZEF0Iiwic2hpZnRBbmNob3IiLCJzaGlmdFNlbGVjdGlvbiIsInNoaWZ0U2VsZWN0aW9uRm9yRm9sbG93Iiwic3RhcnRTZWxlY3Rpb24iLCJ1cGRhdGVTZWxlY3Rpb24iLCJTWU5DX09VVFBVVF9TVVBQT1JURUQiLCJzdXBwb3J0c0V4dGVuZGVkS2V5cyIsIlRlcm1pbmFsIiwid3JpdGVEaWZmVG9UZXJtaW5hbCIsIkNVUlNPUl9IT01FIiwiY3Vyc29yTW92ZSIsImN1cnNvclBvc2l0aW9uIiwiRElTQUJMRV9LSVRUWV9LRVlCT0FSRCIsIkRJU0FCTEVfTU9ESUZZX09USEVSX0tFWVMiLCJFTkFCTEVfS0lUVFlfS0VZQk9BUkQiLCJFTkFCTEVfTU9ESUZZX09USEVSX0tFWVMiLCJFUkFTRV9TQ1JFRU4iLCJEQlAiLCJERkUiLCJESVNBQkxFX01PVVNFX1RSQUNLSU5HIiwiRU5BQkxFX01PVVNFX1RSQUNLSU5HIiwiRU5URVJfQUxUX1NDUkVFTiIsIkVYSVRfQUxUX1NDUkVFTiIsIlNIT1dfQ1VSU09SIiwiQ0xFQVJfSVRFUk0yX1BST0dSRVNTIiwiQ0xFQVJfVEFCX1NUQVRVUyIsInNldENsaXBib2FyZCIsInN1cHBvcnRzVGFiU3RhdHVzIiwid3JhcEZvck11bHRpcGxleGVyIiwiVGVybWluYWxXcml0ZVByb3ZpZGVyIiwiQUxUX1NDUkVFTl9BTkNIT1JfQ1VSU09SIiwiT2JqZWN0IiwiZnJlZXplIiwieCIsInkiLCJ2aXNpYmxlIiwiQ1VSU09SX0hPTUVfUEFUQ0giLCJ0eXBlIiwiY29uc3QiLCJjb250ZW50IiwiRVJBU0VfVEhFTl9IT01FX1BBVENIIiwibWFrZUFsdFNjcmVlblBhcmtQYXRjaCIsInRlcm1pbmFsUm93cyIsIk9wdGlvbnMiLCJzdGRvdXQiLCJOb2RlSlMiLCJXcml0ZVN0cmVhbSIsInN0ZGluIiwiUmVhZFN0cmVhbSIsInN0ZGVyciIsImV4aXRPbkN0cmxDIiwicGF0Y2hDb25zb2xlIiwid2FpdFVudGlsRXhpdCIsIlByb21pc2UiLCJvbkZyYW1lIiwiZXZlbnQiLCJJbmsiLCJsb2ciLCJ0ZXJtaW5hbCIsInNjaGVkdWxlUmVuZGVyIiwiY2FuY2VsIiwiaXNVbm1vdW50ZWQiLCJpc1BhdXNlZCIsImNvbnRhaW5lciIsInJvb3ROb2RlIiwiRE9NRWxlbWVudCIsImZvY3VzTWFuYWdlciIsInJlbmRlcmVyIiwic3R5bGVQb29sIiwiY2hhclBvb2wiLCJoeXBlcmxpbmtQb29sIiwiZXhpdFByb21pc2UiLCJyZXN0b3JlQ29uc29sZSIsInJlc3RvcmVTdGRlcnIiLCJ1bnN1YnNjcmliZVRUWUhhbmRsZXJzIiwidGVybWluYWxDb2x1bW5zIiwiY3VycmVudE5vZGUiLCJmcm9udEZyYW1lIiwiYmFja0ZyYW1lIiwibGFzdFBvb2xSZXNldFRpbWUiLCJwZXJmb3JtYW5jZSIsIm5vdyIsImRyYWluVGltZXIiLCJSZXR1cm5UeXBlIiwic2V0VGltZW91dCIsImxhc3RZb2dhQ291bnRlcnMiLCJtcyIsInZpc2l0ZWQiLCJtZWFzdXJlZCIsImNhY2hlSGl0cyIsImxpdmUiLCJhbHRTY3JlZW5QYXJrUGF0Y2giLCJSZWFkb25seSIsInNlbGVjdGlvbiIsInNlYXJjaEhpZ2hsaWdodFF1ZXJ5Iiwic2VhcmNoUG9zaXRpb25zIiwicG9zaXRpb25zIiwicm93T2Zmc2V0IiwiY3VycmVudElkeCIsInNlbGVjdGlvbkxpc3RlbmVycyIsIlNldCIsImhvdmVyZWROb2RlcyIsImFsdFNjcmVlbkFjdGl2ZSIsImFsdFNjcmVlbk1vdXNlVHJhY2tpbmciLCJwcmV2RnJhbWVDb250YW1pbmF0ZWQiLCJuZWVkc0VyYXNlQmVmb3JlUGFpbnQiLCJjdXJzb3JEZWNsYXJhdGlvbiIsImRpc3BsYXlDdXJzb3IiLCJjb25zdHJ1Y3RvciIsIm9wdGlvbnMiLCJwYXRjaFN0ZGVyciIsImNvbHVtbnMiLCJyb3dzIiwiaXNUVFkiLCJkZWZlcnJlZFJlbmRlciIsInF1ZXVlTWljcm90YXNrIiwib25SZW5kZXIiLCJsZWFkaW5nIiwidHJhaWxpbmciLCJ1bnN1YnNjcmliZUV4aXQiLCJ1bm1vdW50IiwiYWx3YXlzTGFzdCIsIm9uIiwiaGFuZGxlUmVzaXplIiwicHJvY2VzcyIsImhhbmRsZVJlc3VtZSIsIm9mZiIsImNyZWF0ZU5vZGUiLCJ0YXJnZXQiLCJkaXNwYXRjaERpc2NyZXRlIiwib25JbW1lZGlhdGVSZW5kZXIiLCJvbkNvbXB1dGVMYXlvdXQiLCJ5b2dhTm9kZSIsInQwIiwic2V0V2lkdGgiLCJjYWxjdWxhdGVMYXlvdXQiLCJjIiwiY3JlYXRlQ29udGFpbmVyIiwiaW5qZWN0SW50b0RldlRvb2xzIiwiYnVuZGxlVHlwZSIsInZlcnNpb24iLCJyZW5kZXJlclBhY2thZ2VOYW1lIiwicmVlbnRlckFsdFNjcmVlbiIsInZpZXdwb3J0IiwiaGVpZ2h0Iiwid2lkdGgiLCJyZXNldCIsImNvbHMiLCJ3cml0ZSIsInJlc2V0RnJhbWVzRm9yQWx0U2NyZWVuIiwicmVuZGVyIiwicmVzb2x2ZUV4aXRQcm9taXNlIiwicmVqZWN0RXhpdFByb21pc2UiLCJyZWFzb24iLCJFcnJvciIsImVudGVyQWx0ZXJuYXRlU2NyZWVuIiwicGF1c2UiLCJzdXNwZW5kU3RkaW4iLCJleGl0QWx0ZXJuYXRlU2NyZWVuIiwicmVzdW1lU3RkaW4iLCJyZXBhaW50IiwicmVzdW1lIiwiY2xlYXJUaW1lb3V0IiwicmVuZGVyU3RhcnQiLCJ0ZXJtaW5hbFdpZHRoIiwiZnJhbWUiLCJhbHRTY3JlZW4iLCJyZW5kZXJlck1zIiwiZm9sbG93IiwiYW5jaG9yIiwicm93Iiwidmlld3BvcnRUb3AiLCJ2aWV3cG9ydEJvdHRvbSIsImRlbHRhIiwiaXNEcmFnZ2luZyIsInNjcmVlbiIsImZvY3VzIiwiY2xlYXJlZCIsImNiIiwic2VsQWN0aXZlIiwiaGxBY3RpdmUiLCJzcCIsInBvc0FwcGxpZWQiLCJkYW1hZ2UiLCJwcmV2RnJhbWUiLCJjdXJzb3IiLCJ0RGlmZiIsImRpZmYiLCJkaWZmTXMiLCJyZXNldFBvb2xzIiwiZmxpY2tlcnMiLCJwYXRjaCIsInB1c2giLCJkZXNpcmVkSGVpZ2h0IiwiYXZhaWxhYmxlSGVpZ2h0IiwiZGVidWciLCJjaGFpbiIsImZpbmRPd25lckNoYWluQXRSb3ciLCJ0cmlnZ2VyWSIsInByZXZMaW5lIiwibmV4dExpbmUiLCJsZW5ndGgiLCJqb2luIiwibGV2ZWwiLCJ0T3B0aW1pemUiLCJvcHRpbWl6ZWQiLCJvcHRpbWl6ZU1zIiwiaGFzRGlmZiIsInVuc2hpZnQiLCJkZWNsIiwicmVjdCIsImdldCIsIm5vZGUiLCJ1bmRlZmluZWQiLCJyZWxhdGl2ZVgiLCJyZWxhdGl2ZVkiLCJwYXJrZWQiLCJ0YXJnZXRNb3ZlZCIsInBkeCIsInBkeSIsIk1hdGgiLCJtaW4iLCJtYXgiLCJjb2wiLCJmcm9tIiwiZHgiLCJkeSIsInJkeCIsInJkeSIsInRXcml0ZSIsIndyaXRlTXMiLCJzY3JvbGxEcmFpblBlbmRpbmciLCJ5b2dhTXMiLCJjb21taXRNcyIsInljIiwiZHVyYXRpb25NcyIsInBoYXNlcyIsInBhdGNoZXMiLCJ5b2dhIiwiY29tbWl0IiwieW9nYVZpc2l0ZWQiLCJ5b2dhTWVhc3VyZWQiLCJ5b2dhQ2FjaGVIaXRzIiwieW9nYUxpdmUiLCJmbHVzaFN5bmNGcm9tUmVjb25jaWxlciIsImZvcmNlUmVkcmF3IiwiaW52YWxpZGF0ZVByZXZGcmFtZSIsInNldEFsdFNjcmVlbkFjdGl2ZSIsImFjdGl2ZSIsIm1vdXNlVHJhY2tpbmciLCJpc0FsdFNjcmVlbkFjdGl2ZSIsInJlYXNzZXJ0VGVybWluYWxNb2RlcyIsImluY2x1ZGVBbHRTY3JlZW4iLCJkZXRhY2hGb3JTaHV0ZG93biIsImlzUmF3Iiwic2V0UmF3TW9kZSIsIm0iLCJkcmFpblN0ZGluIiwiYmxhbmsiLCJjb3B5U2VsZWN0aW9uTm9DbGVhciIsInRleHQiLCJ0aGVuIiwicmF3IiwiY29weVNlbGVjdGlvbiIsIm5vdGlmeVNlbGVjdGlvbkNoYW5nZSIsImNsZWFyVGV4dFNlbGVjdGlvbiIsInNldFNlYXJjaEhpZ2hsaWdodCIsInF1ZXJ5Iiwic2NhbkVsZW1lbnRTdWJ0cmVlIiwiZWwiLCJjZWlsIiwiZ2V0Q29tcHV0ZWRXaWR0aCIsImdldENvbXB1dGVkSGVpZ2h0IiwiZWxMZWZ0IiwiZ2V0Q29tcHV0ZWRMZWZ0IiwiZWxUb3AiLCJnZXRDb21wdXRlZFRvcCIsIm91dHB1dCIsIm9mZnNldFgiLCJvZmZzZXRZIiwicHJldlNjcmVlbiIsInJlbmRlcmVkIiwibWFya0RpcnR5Iiwic2xpY2UiLCJtYXAiLCJwIiwic2V0U2VhcmNoUG9zaXRpb25zIiwic3RhdGUiLCJzZXRTZWxlY3Rpb25CZ0NvbG9yIiwiY29sb3IiLCJ3cmFwcGVkIiwibnVsIiwiaW5kZXhPZiIsInNldFNlbGVjdGlvbkJnIiwiY29kZSIsImVuZENvZGUiLCJmaXJzdFJvdyIsImxhc3RSb3ciLCJzaWRlIiwic2hpZnRTZWxlY3Rpb25Gb3JTY3JvbGwiLCJkUm93IiwibWluUm93IiwibWF4Um93IiwiaGFkU2VsIiwibW92ZVNlbGVjdGlvbkZvY3VzIiwibW92ZSIsIm1heENvbCIsImhhc1RleHRTZWxlY3Rpb24iLCJzdWJzY3JpYmVUb1NlbGVjdGlvbkNoYW5nZSIsImFkZCIsImRlbGV0ZSIsImRpc3BhdGNoS2V5Ym9hcmRFdmVudCIsInBhcnNlZEtleSIsImFjdGl2ZUVsZW1lbnQiLCJkZWZhdWx0UHJldmVudGVkIiwibmFtZSIsImN0cmwiLCJtZXRhIiwic2hpZnQiLCJmb2N1c1ByZXZpb3VzIiwiZm9jdXNOZXh0IiwiZ2V0SHlwZXJsaW5rQXQiLCJjZWxsIiwidXJsIiwiaHlwZXJsaW5rIiwiU3BhY2VyVGFpbCIsIm9uSHlwZXJsaW5rQ2xpY2siLCJvcGVuSHlwZXJsaW5rIiwiaGFuZGxlTXVsdGlDbGljayIsImNvdW50IiwiaGFuZGxlU2VsZWN0aW9uRHJhZyIsInNlbCIsImFuY2hvclNwYW4iLCJzdGRpbkxpc3RlbmVycyIsIkFycmF5IiwibGlzdGVuZXIiLCJhcmdzIiwid2FzUmF3TW9kZSIsInJlYWRhYmxlTGlzdGVuZXJzIiwibGlzdGVuZXJzIiwiZm9yRWFjaCIsInJlbW92ZUxpc3RlbmVyIiwic3RkaW5XaXRoUmF3IiwibW9kZSIsImFkZExpc3RlbmVyIiwid3JpdGVSYXciLCJkYXRhIiwic2V0Q3Vyc29yRGVjbGFyYXRpb24iLCJjbGVhcklmTm9kZSIsInRyZWUiLCJ1cGRhdGVDb250YWluZXJTeW5jIiwiZmx1c2hTeW5jV29yayIsImVycm9yIiwicmVuZGVyUHJldmlvdXNPdXRwdXRfREVQUkVDQVRFRCIsImZyZWUiLCJyZXNvbHZlIiwicmVqZWN0IiwicmVzZXRMaW5lQ291bnQiLCJjb24iLCJjb25zb2xlIiwib3JpZ2luYWxzIiwiUGFydGlhbCIsIlJlY29yZCIsIkNvbnNvbGUiLCJ0b0RlYnVnIiwidG9FcnJvciIsIkNPTlNPTEVfU1RET1VUX01FVEhPRFMiLCJDT05TT0xFX1NUREVSUl9NRVRIT0RTIiwiYXNzZXJ0IiwiY29uZGl0aW9uIiwiYXNzaWduIiwib3JpZ2luYWxXcml0ZSIsInJlZW50ZXJlZCIsImludGVyY2VwdCIsImNodW5rIiwiVWludDhBcnJheSIsImVuY29kaW5nT3JDYiIsIkJ1ZmZlckVuY29kaW5nIiwiZXJyIiwiY2FsbGJhY2siLCJlbmNvZGluZyIsImNhbGwiLCJCdWZmZXIiLCJ0b1N0cmluZyIsInJlYWQiLCJwbGF0Zm9ybSIsInR0eSIsIndhc1JhdyIsImZkIiwiT19SRE9OTFkiLCJPX05PTkJMT0NLIiwiYnVmIiwiYWxsb2MiLCJpIl0sInNvdXJjZXMiOlsiaW5rLnRzeCJdLCJzb3VyY2VzQ29udGVudCI6WyJpbXBvcnQgYXV0b0JpbmQgZnJvbSAnYXV0by1iaW5kJ1xuaW1wb3J0IHtcbiAgY2xvc2VTeW5jLFxuICBjb25zdGFudHMgYXMgZnNDb25zdGFudHMsXG4gIG9wZW5TeW5jLFxuICByZWFkU3luYyxcbiAgd3JpdGVTeW5jLFxufSBmcm9tICdmcydcbmltcG9ydCBub29wIGZyb20gJ2xvZGFzaC1lcy9ub29wLmpzJ1xuaW1wb3J0IHRocm90dGxlIGZyb20gJ2xvZGFzaC1lcy90aHJvdHRsZS5qcydcbmltcG9ydCBSZWFjdCwgeyB0eXBlIFJlYWN0Tm9kZSB9IGZyb20gJ3JlYWN0J1xuaW1wb3J0IHR5cGUgeyBGaWJlclJvb3QgfSBmcm9tICdyZWFjdC1yZWNvbmNpbGVyJ1xuaW1wb3J0IHsgQ29uY3VycmVudFJvb3QgfSBmcm9tICdyZWFjdC1yZWNvbmNpbGVyL2NvbnN0YW50cy5qcydcbmltcG9ydCB7IG9uRXhpdCB9IGZyb20gJ3NpZ25hbC1leGl0J1xuaW1wb3J0IHsgZmx1c2hJbnRlcmFjdGlvblRpbWUgfSBmcm9tICdzcmMvYm9vdHN0cmFwL3N0YXRlLmpzJ1xuaW1wb3J0IHsgZ2V0WW9nYUNvdW50ZXJzIH0gZnJvbSAnc3JjL25hdGl2ZS10cy95b2dhLWxheW91dC9pbmRleC5qcydcbmltcG9ydCB7IGxvZ0ZvckRlYnVnZ2luZyB9IGZyb20gJ3NyYy91dGlscy9kZWJ1Zy5qcydcbmltcG9ydCB7IGxvZ0Vycm9yIH0gZnJvbSAnc3JjL3V0aWxzL2xvZy5qcydcbmltcG9ydCB7IGZvcm1hdCB9IGZyb20gJ3V0aWwnXG5pbXBvcnQgeyBjb2xvcml6ZSB9IGZyb20gJy4vY29sb3JpemUuanMnXG5pbXBvcnQgQXBwIGZyb20gJy4vY29tcG9uZW50cy9BcHAuanMnXG5pbXBvcnQgdHlwZSB7XG4gIEN1cnNvckRlY2xhcmF0aW9uLFxuICBDdXJzb3JEZWNsYXJhdGlvblNldHRlcixcbn0gZnJvbSAnLi9jb21wb25lbnRzL0N1cnNvckRlY2xhcmF0aW9uQ29udGV4dC5qcydcbmltcG9ydCB7IEZSQU1FX0lOVEVSVkFMX01TIH0gZnJvbSAnLi9jb25zdGFudHMuanMnXG5pbXBvcnQgKiBhcyBkb20gZnJvbSAnLi9kb20uanMnXG5pbXBvcnQgeyBLZXlib2FyZEV2ZW50IH0gZnJvbSAnLi9ldmVudHMva2V5Ym9hcmQtZXZlbnQuanMnXG5pbXBvcnQgeyBGb2N1c01hbmFnZXIgfSBmcm9tICcuL2ZvY3VzLmpzJ1xuaW1wb3J0IHsgZW1wdHlGcmFtZSwgdHlwZSBGcmFtZSwgdHlwZSBGcmFtZUV2ZW50IH0gZnJvbSAnLi9mcmFtZS5qcydcbmltcG9ydCB7IGRpc3BhdGNoQ2xpY2ssIGRpc3BhdGNoSG92ZXIgfSBmcm9tICcuL2hpdC10ZXN0LmpzJ1xuaW1wb3J0IGluc3RhbmNlcyBmcm9tICcuL2luc3RhbmNlcy5qcydcbmltcG9ydCB7IExvZ1VwZGF0ZSB9IGZyb20gJy4vbG9nLXVwZGF0ZS5qcydcbmltcG9ydCB7IG5vZGVDYWNoZSB9IGZyb20gJy4vbm9kZS1jYWNoZS5qcydcbmltcG9ydCB7IG9wdGltaXplIH0gZnJvbSAnLi9vcHRpbWl6ZXIuanMnXG5pbXBvcnQgT3V0cHV0IGZyb20gJy4vb3V0cHV0LmpzJ1xuaW1wb3J0IHR5cGUgeyBQYXJzZWRLZXkgfSBmcm9tICcuL3BhcnNlLWtleXByZXNzLmpzJ1xuaW1wb3J0IHJlY29uY2lsZXIsIHtcbiAgZGlzcGF0Y2hlcixcbiAgZ2V0TGFzdENvbW1pdE1zLFxuICBnZXRMYXN0WW9nYU1zLFxuICBpc0RlYnVnUmVwYWludHNFbmFibGVkLFxuICByZWNvcmRZb2dhTXMsXG4gIHJlc2V0UHJvZmlsZUNvdW50ZXJzLFxufSBmcm9tICcuL3JlY29uY2lsZXIuanMnXG5pbXBvcnQgcmVuZGVyTm9kZVRvT3V0cHV0LCB7XG4gIGNvbnN1bWVGb2xsb3dTY3JvbGwsXG4gIGRpZExheW91dFNoaWZ0LFxufSBmcm9tICcuL3JlbmRlci1ub2RlLXRvLW91dHB1dC5qcydcbmltcG9ydCB7XG4gIGFwcGx5UG9zaXRpb25lZEhpZ2hsaWdodCxcbiAgdHlwZSBNYXRjaFBvc2l0aW9uLFxuICBzY2FuUG9zaXRpb25zLFxufSBmcm9tICcuL3JlbmRlci10by1zY3JlZW4uanMnXG5pbXBvcnQgY3JlYXRlUmVuZGVyZXIsIHsgdHlwZSBSZW5kZXJlciB9IGZyb20gJy4vcmVuZGVyZXIuanMnXG5pbXBvcnQge1xuICBDZWxsV2lkdGgsXG4gIENoYXJQb29sLFxuICBjZWxsQXQsXG4gIGNyZWF0ZVNjcmVlbixcbiAgSHlwZXJsaW5rUG9vbCxcbiAgaXNFbXB0eUNlbGxBdCxcbiAgbWlncmF0ZVNjcmVlblBvb2xzLFxuICBTdHlsZVBvb2wsXG59IGZyb20gJy4vc2NyZWVuLmpzJ1xuaW1wb3J0IHsgYXBwbHlTZWFyY2hIaWdobGlnaHQgfSBmcm9tICcuL3NlYXJjaEhpZ2hsaWdodC5qcydcbmltcG9ydCB7XG4gIGFwcGx5U2VsZWN0aW9uT3ZlcmxheSxcbiAgY2FwdHVyZVNjcm9sbGVkUm93cyxcbiAgY2xlYXJTZWxlY3Rpb24sXG4gIGNyZWF0ZVNlbGVjdGlvblN0YXRlLFxuICBleHRlbmRTZWxlY3Rpb24sXG4gIHR5cGUgRm9jdXNNb3ZlLFxuICBmaW5kUGxhaW5UZXh0VXJsQXQsXG4gIGdldFNlbGVjdGVkVGV4dCxcbiAgaGFzU2VsZWN0aW9uLFxuICBtb3ZlRm9jdXMsXG4gIHR5cGUgU2VsZWN0aW9uU3RhdGUsXG4gIHNlbGVjdExpbmVBdCxcbiAgc2VsZWN0V29yZEF0LFxuICBzaGlmdEFuY2hvcixcbiAgc2hpZnRTZWxlY3Rpb24sXG4gIHNoaWZ0U2VsZWN0aW9uRm9yRm9sbG93LFxuICBzdGFydFNlbGVjdGlvbixcbiAgdXBkYXRlU2VsZWN0aW9uLFxufSBmcm9tICcuL3NlbGVjdGlvbi5qcydcbmltcG9ydCB7XG4gIFNZTkNfT1VUUFVUX1NVUFBPUlRFRCxcbiAgc3VwcG9ydHNFeHRlbmRlZEtleXMsXG4gIHR5cGUgVGVybWluYWwsXG4gIHdyaXRlRGlmZlRvVGVybWluYWwsXG59IGZyb20gJy4vdGVybWluYWwuanMnXG5pbXBvcnQge1xuICBDVVJTT1JfSE9NRSxcbiAgY3Vyc29yTW92ZSxcbiAgY3Vyc29yUG9zaXRpb24sXG4gIERJU0FCTEVfS0lUVFlfS0VZQk9BUkQsXG4gIERJU0FCTEVfTU9ESUZZX09USEVSX0tFWVMsXG4gIEVOQUJMRV9LSVRUWV9LRVlCT0FSRCxcbiAgRU5BQkxFX01PRElGWV9PVEhFUl9LRVlTLFxuICBFUkFTRV9TQ1JFRU4sXG59IGZyb20gJy4vdGVybWlvL2NzaS5qcydcbmltcG9ydCB7XG4gIERCUCxcbiAgREZFLFxuICBESVNBQkxFX01PVVNFX1RSQUNLSU5HLFxuICBFTkFCTEVfTU9VU0VfVFJBQ0tJTkcsXG4gIEVOVEVSX0FMVF9TQ1JFRU4sXG4gIEVYSVRfQUxUX1NDUkVFTixcbiAgU0hPV19DVVJTT1IsXG59IGZyb20gJy4vdGVybWlvL2RlYy5qcydcbmltcG9ydCB7XG4gIENMRUFSX0lURVJNMl9QUk9HUkVTUyxcbiAgQ0xFQVJfVEFCX1NUQVRVUyxcbiAgc2V0Q2xpcGJvYXJkLFxuICBzdXBwb3J0c1RhYlN0YXR1cyxcbiAgd3JhcEZvck11bHRpcGxleGVyLFxufSBmcm9tICcuL3Rlcm1pby9vc2MuanMnXG5pbXBvcnQgeyBUZXJtaW5hbFdyaXRlUHJvdmlkZXIgfSBmcm9tICcuL3VzZVRlcm1pbmFsTm90aWZpY2F0aW9uLmpzJ1xuXG4vLyBBbHQtc2NyZWVuOiByZW5kZXJlci50cyBzZXRzIGN1cnNvci52aXNpYmxlID0gIWlzVFRZIHx8IHNjcmVlbi5oZWlnaHQ9PT0wLFxuLy8gd2hpY2ggaXMgYWx3YXlzIGZhbHNlIGluIGFsdC1zY3JlZW4gKFRUWSArIGNvbnRlbnQgZmlsbHMgc2NyZWVuKS5cbi8vIFJldXNpbmcgYSBmcm96ZW4gb2JqZWN0IHNhdmVzIDEgYWxsb2NhdGlvbiBwZXIgZnJhbWUuXG5jb25zdCBBTFRfU0NSRUVOX0FOQ0hPUl9DVVJTT1IgPSBPYmplY3QuZnJlZXplKHsgeDogMCwgeTogMCwgdmlzaWJsZTogZmFsc2UgfSlcbmNvbnN0IENVUlNPUl9IT01FX1BBVENIID0gT2JqZWN0LmZyZWV6ZSh7XG4gIHR5cGU6ICdzdGRvdXQnIGFzIGNvbnN0LFxuICBjb250ZW50OiBDVVJTT1JfSE9NRSxcbn0pXG5jb25zdCBFUkFTRV9USEVOX0hPTUVfUEFUQ0ggPSBPYmplY3QuZnJlZXplKHtcbiAgdHlwZTogJ3N0ZG91dCcgYXMgY29uc3QsXG4gIGNvbnRlbnQ6IEVSQVNFX1NDUkVFTiArIENVUlNPUl9IT01FLFxufSlcblxuLy8gQ2FjaGVkIHBlci1JbmstaW5zdGFuY2UsIGludmFsaWRhdGVkIG9uIHJlc2l6ZS4gZnJhbWUuY3Vyc29yLnkgZm9yXG4vLyBhbHQtc2NyZWVuIGlzIGFsd2F5cyB0ZXJtaW5hbFJvd3MgLSAxIChyZW5kZXJlci50cykuXG5mdW5jdGlvbiBtYWtlQWx0U2NyZWVuUGFya1BhdGNoKHRlcm1pbmFsUm93czogbnVtYmVyKSB7XG4gIHJldHVybiBPYmplY3QuZnJlZXplKHtcbiAgICB0eXBlOiAnc3Rkb3V0JyBhcyBjb25zdCxcbiAgICBjb250ZW50OiBjdXJzb3JQb3NpdGlvbih0ZXJtaW5hbFJvd3MsIDEpLFxuICB9KVxufVxuXG5leHBvcnQgdHlwZSBPcHRpb25zID0ge1xuICBzdGRvdXQ6IE5vZGVKUy5Xcml0ZVN0cmVhbVxuICBzdGRpbjogTm9kZUpTLlJlYWRTdHJlYW1cbiAgc3RkZXJyOiBOb2RlSlMuV3JpdGVTdHJlYW1cbiAgZXhpdE9uQ3RybEM6IGJvb2xlYW5cbiAgcGF0Y2hDb25zb2xlOiBib29sZWFuXG4gIHdhaXRVbnRpbEV4aXQ/OiAoKSA9PiBQcm9taXNlPHZvaWQ+XG4gIG9uRnJhbWU/OiAoZXZlbnQ6IEZyYW1lRXZlbnQpID0+IHZvaWRcbn1cblxuZXhwb3J0IGRlZmF1bHQgY2xhc3MgSW5rIHtcbiAgcHJpdmF0ZSByZWFkb25seSBsb2c6IExvZ1VwZGF0ZVxuICBwcml2YXRlIHJlYWRvbmx5IHRlcm1pbmFsOiBUZXJtaW5hbFxuICBwcml2YXRlIHNjaGVkdWxlUmVuZGVyOiAoKCkgPT4gdm9pZCkgJiB7IGNhbmNlbD86ICgpID0+IHZvaWQgfVxuICAvLyBJZ25vcmUgbGFzdCByZW5kZXIgYWZ0ZXIgdW5tb3VudGluZyBhIHRyZWUgdG8gcHJldmVudCBlbXB0eSBvdXRwdXQgYmVmb3JlIGV4aXRcbiAgcHJpdmF0ZSBpc1VubW91bnRlZCA9IGZhbHNlXG4gIHByaXZhdGUgaXNQYXVzZWQgPSBmYWxzZVxuICBwcml2YXRlIHJlYWRvbmx5IGNvbnRhaW5lcjogRmliZXJSb290XG4gIHByaXZhdGUgcm9vdE5vZGU6IGRvbS5ET01FbGVtZW50XG4gIHJlYWRvbmx5IGZvY3VzTWFuYWdlcjogRm9jdXNNYW5hZ2VyXG4gIHByaXZhdGUgcmVuZGVyZXI6IFJlbmRlcmVyXG4gIHByaXZhdGUgcmVhZG9ubHkgc3R5bGVQb29sOiBTdHlsZVBvb2xcbiAgcHJpdmF0ZSBjaGFyUG9vbDogQ2hhclBvb2xcbiAgcHJpdmF0ZSBoeXBlcmxpbmtQb29sOiBIeXBlcmxpbmtQb29sXG4gIHByaXZhdGUgZXhpdFByb21pc2U/OiBQcm9taXNlPHZvaWQ+XG4gIHByaXZhdGUgcmVzdG9yZUNvbnNvbGU/OiAoKSA9PiB2b2lkXG4gIHByaXZhdGUgcmVzdG9yZVN0ZGVycj86ICgpID0+IHZvaWRcbiAgcHJpdmF0ZSByZWFkb25seSB1bnN1YnNjcmliZVRUWUhhbmRsZXJzPzogKCkgPT4gdm9pZFxuICBwcml2YXRlIHRlcm1pbmFsQ29sdW1uczogbnVtYmVyXG4gIHByaXZhdGUgdGVybWluYWxSb3dzOiBudW1iZXJcbiAgcHJpdmF0ZSBjdXJyZW50Tm9kZTogUmVhY3ROb2RlID0gbnVsbFxuICBwcml2YXRlIGZyb250RnJhbWU6IEZyYW1lXG4gIHByaXZhdGUgYmFja0ZyYW1lOiBGcmFtZVxuICBwcml2YXRlIGxhc3RQb29sUmVzZXRUaW1lID0gcGVyZm9ybWFuY2Uubm93KClcbiAgcHJpdmF0ZSBkcmFpblRpbWVyOiBSZXR1cm5UeXBlPHR5cGVvZiBzZXRUaW1lb3V0PiB8IG51bGwgPSBudWxsXG4gIHByaXZhdGUgbGFzdFlvZ2FDb3VudGVyczoge1xuICAgIG1zOiBudW1iZXJcbiAgICB2aXNpdGVkOiBudW1iZXJcbiAgICBtZWFzdXJlZDogbnVtYmVyXG4gICAgY2FjaGVIaXRzOiBudW1iZXJcbiAgICBsaXZlOiBudW1iZXJcbiAgfSA9IHsgbXM6IDAsIHZpc2l0ZWQ6IDAsIG1lYXN1cmVkOiAwLCBjYWNoZUhpdHM6IDAsIGxpdmU6IDAgfVxuICBwcml2YXRlIGFsdFNjcmVlblBhcmtQYXRjaDogUmVhZG9ubHk8eyB0eXBlOiAnc3Rkb3V0JzsgY29udGVudDogc3RyaW5nIH0+XG4gIC8vIFRleHQgc2VsZWN0aW9uIHN0YXRlIChhbHQtc2NyZWVuIG9ubHkpLiBPd25lZCBoZXJlIHNvIHRoZSBvdmVybGF5XG4gIC8vIHBhc3MgaW4gb25SZW5kZXIgY2FuIHJlYWQgaXQgYW5kIEFwcC50c3ggY2FuIHVwZGF0ZSBpdCBmcm9tIG1vdXNlXG4gIC8vIGV2ZW50cy4gUHVibGljIHNvIGluc3RhbmNlcy5nZXQoKSBjYWxsZXJzIGNhbiBhY2Nlc3MuXG4gIHJlYWRvbmx5IHNlbGVjdGlvbjogU2VsZWN0aW9uU3RhdGUgPSBjcmVhdGVTZWxlY3Rpb25TdGF0ZSgpXG4gIC8vIFNlYXJjaCBoaWdobGlnaHQgcXVlcnkgKGFsdC1zY3JlZW4gb25seSkuIFNldHRlciBiZWxvdyB0cmlnZ2Vyc1xuICAvLyBzY2hlZHVsZVJlbmRlcjsgYXBwbHlTZWFyY2hIaWdobGlnaHQgaW4gb25SZW5kZXIgaW52ZXJ0cyBtYXRjaGluZyBjZWxscy5cbiAgcHJpdmF0ZSBzZWFyY2hIaWdobGlnaHRRdWVyeSA9ICcnXG4gIC8vIFBvc2l0aW9uLWJhc2VkIGhpZ2hsaWdodC4gVk1MIHNjYW5zIHBvc2l0aW9ucyBPTkNFICh2aWFcbiAgLy8gc2NhbkVsZW1lbnRTdWJ0cmVlLCB3aGVuIHRoZSB0YXJnZXQgbWVzc2FnZSBpcyBtb3VudGVkKSwgc3RvcmVzIHRoZW1cbiAgLy8gbWVzc2FnZS1yZWxhdGl2ZSwgc2V0cyB0aGlzIGZvciBldmVyeS1mcmFtZSBhcHBseS4gcm93T2Zmc2V0ID1cbiAgLy8gbWVzc2FnZSdzIGN1cnJlbnQgc2NyZWVuLXRvcC4gY3VycmVudElkeCA9IHdoaWNoIHBvc2l0aW9uIGlzXG4gIC8vIFwiY3VycmVudFwiICh5ZWxsb3cpLiBudWxsIGNsZWFycy4gUG9zaXRpb25zIGFyZSBrbm93biB1cGZyb250IOKAlFxuICAvLyBuYXZpZ2F0aW9uIGlzIGluZGV4IGFyaXRobWV0aWMsIG5vIHNjYW4tZmVlZGJhY2sgbG9vcC5cbiAgcHJpdmF0ZSBzZWFyY2hQb3NpdGlvbnM6IHtcbiAgICBwb3NpdGlvbnM6IE1hdGNoUG9zaXRpb25bXVxuICAgIHJvd09mZnNldDogbnVtYmVyXG4gICAgY3VycmVudElkeDogbnVtYmVyXG4gIH0gfCBudWxsID0gbnVsbFxuICAvLyBSZWFjdC1sYW5kIHN1YnNjcmliZXJzIGZvciBzZWxlY3Rpb24gc3RhdGUgY2hhbmdlcyAodXNlSGFzU2VsZWN0aW9uKS5cbiAgLy8gRmlyZWQgYWxvbmdzaWRlIHRoZSB0ZXJtaW5hbCByZXBhaW50IHdoZW5ldmVyIHRoZSBzZWxlY3Rpb24gbXV0YXRlc1xuICAvLyBzbyBVSSAoZS5nLiBmb290ZXIgaGludHMpIGNhbiByZWFjdCB0byBzZWxlY3Rpb24gYXBwZWFyaW5nL2NsZWFyaW5nLlxuICBwcml2YXRlIHJlYWRvbmx5IHNlbGVjdGlvbkxpc3RlbmVycyA9IG5ldyBTZXQ8KCkgPT4gdm9pZD4oKVxuICAvLyBET00gbm9kZXMgY3VycmVudGx5IHVuZGVyIHRoZSBwb2ludGVyIChtb2RlLTEwMDMgbW90aW9uKS4gSGVsZCBoZXJlXG4gIC8vIHNvIEFwcC50c3gncyBoYW5kbGVNb3VzZUV2ZW50IGlzIHN0YXRlbGVzcyDigJQgZGlzcGF0Y2hIb3ZlciBkaWZmc1xuICAvLyBhZ2FpbnN0IHRoaXMgc2V0IGFuZCBtdXRhdGVzIGl0IGluIHBsYWNlLlxuICBwcml2YXRlIHJlYWRvbmx5IGhvdmVyZWROb2RlcyA9IG5ldyBTZXQ8ZG9tLkRPTUVsZW1lbnQ+KClcbiAgLy8gU2V0IGJ5IDxBbHRlcm5hdGVTY3JlZW4+IHZpYSBzZXRBbHRTY3JlZW5BY3RpdmUoKS4gQ29udHJvbHMgdGhlXG4gIC8vIHJlbmRlcmVyJ3MgY3Vyc29yLnkgY2xhbXBpbmcgKGtlZXBzIGN1cnNvciBpbi12aWV3cG9ydCB0byBhdm9pZFxuICAvLyBMRi1pbmR1Y2VkIHNjcm9sbCB3aGVuIHNjcmVlbi5oZWlnaHQgPT09IHRlcm1pbmFsUm93cykgYW5kIGdhdGVzXG4gIC8vIGFsdC1zY3JlZW4tYXdhcmUgU0lHQ09OVC9yZXNpemUvdW5tb3VudCBoYW5kbGluZy5cbiAgcHJpdmF0ZSBhbHRTY3JlZW5BY3RpdmUgPSBmYWxzZVxuICAvLyBTZXQgYWxvbmdzaWRlIGFsdFNjcmVlbkFjdGl2ZSBzbyBTSUdDT05UIHJlc3VtZSBrbm93cyB3aGV0aGVyIHRvXG4gIC8vIHJlLWVuYWJsZSBtb3VzZSB0cmFja2luZyAobm90IGFsbCA8QWx0ZXJuYXRlU2NyZWVuPiB1c2VzIHdhbnQgaXQpLlxuICBwcml2YXRlIGFsdFNjcmVlbk1vdXNlVHJhY2tpbmcgPSBmYWxzZVxuICAvLyBUcnVlIHdoZW4gdGhlIHByZXZpb3VzIGZyYW1lJ3Mgc2NyZWVuIGJ1ZmZlciBjYW5ub3QgYmUgdHJ1c3RlZCBmb3JcbiAgLy8gYmxpdCDigJQgc2VsZWN0aW9uIG92ZXJsYXkgbXV0YXRlZCBpdCwgcmVzZXRGcmFtZXNGb3JBbHRTY3JlZW4oKVxuICAvLyByZXBsYWNlZCBpdCB3aXRoIGJsYW5rcywgb3IgZm9yY2VSZWRyYXcoKSByZXNldCBpdCB0byAww5cwLiBGb3JjZXNcbiAgLy8gb25lIGZ1bGwtcmVuZGVyIGZyYW1lOyBzdGVhZHktc3RhdGUgZnJhbWVzIGFmdGVyIGNsZWFyIGl0IGFuZCByZWdhaW5cbiAgLy8gdGhlIGJsaXQgKyBuYXJyb3ctZGFtYWdlIGZhc3QgcGF0aC5cbiAgcHJpdmF0ZSBwcmV2RnJhbWVDb250YW1pbmF0ZWQgPSBmYWxzZVxuICAvLyBTZXQgYnkgaGFuZGxlUmVzaXplOiBwcmVwZW5kIEVSQVNFX1NDUkVFTiB0byB0aGUgbmV4dCBvblJlbmRlcidzIHBhdGNoZXNcbiAgLy8gSU5TSURFIHRoZSBCU1UvRVNVIGJsb2NrIHNvIGNsZWFyK3BhaW50IGlzIGF0b21pYy4gV3JpdGluZyBFUkFTRV9TQ1JFRU5cbiAgLy8gc3luY2hyb25vdXNseSBpbiBoYW5kbGVSZXNpemUgd291bGQgbGVhdmUgdGhlIHNjcmVlbiBibGFuayBmb3IgdGhlIH44MG1zXG4gIC8vIHJlbmRlcigpIHRha2VzOyBkZWZlcnJpbmcgaW50byB0aGUgYXRvbWljIGJsb2NrIG1lYW5zIG9sZCBjb250ZW50IHN0YXlzXG4gIC8vIHZpc2libGUgdW50aWwgdGhlIG5ldyBmcmFtZSBpcyBmdWxseSByZWFkeS5cbiAgcHJpdmF0ZSBuZWVkc0VyYXNlQmVmb3JlUGFpbnQgPSBmYWxzZVxuICAvLyBOYXRpdmUgY3Vyc29yIHBvc2l0aW9uaW5nOiBhIGNvbXBvbmVudCAodmlhIHVzZURlY2xhcmVkQ3Vyc29yKSBkZWNsYXJlc1xuICAvLyB3aGVyZSB0aGUgdGVybWluYWwgY3Vyc29yIHNob3VsZCBiZSBwYXJrZWQgYWZ0ZXIgZWFjaCBmcmFtZS4gVGVybWluYWxcbiAgLy8gZW11bGF0b3JzIHJlbmRlciBJTUUgcHJlZWRpdCB0ZXh0IGF0IHRoZSBwaHlzaWNhbCBjdXJzb3IgcG9zaXRpb24sIGFuZFxuICAvLyBzY3JlZW4gcmVhZGVycyAvIHNjcmVlbiBtYWduaWZpZXJzIHRyYWNrIGl0IOKAlCBzbyBwYXJraW5nIGF0IHRoZSB0ZXh0XG4gIC8vIGlucHV0J3MgY2FyZXQgbWFrZXMgQ0pLIGlucHV0IGFwcGVhciBpbmxpbmUgYW5kIGxldHMgYTExeSB0b29scyBmb2xsb3cuXG4gIHByaXZhdGUgY3Vyc29yRGVjbGFyYXRpb246IEN1cnNvckRlY2xhcmF0aW9uIHwgbnVsbCA9IG51bGxcbiAgLy8gTWFpbi1zY3JlZW46IHBoeXNpY2FsIGN1cnNvciBwb3NpdGlvbiBhZnRlciB0aGUgZGVjbGFyZWQtY3Vyc29yIG1vdmUsXG4gIC8vIHRyYWNrZWQgc2VwYXJhdGVseSBmcm9tIGZyYW1lLmN1cnNvciAod2hpY2ggbXVzdCBzdGF5IGF0IGNvbnRlbnQtYm90dG9tXG4gIC8vIGZvciBsb2ctdXBkYXRlJ3MgcmVsYXRpdmUtbW92ZSBpbnZhcmlhbnRzKS4gQWx0LXNjcmVlbiBkb2Vzbid0IG5lZWRcbiAgLy8gdGhpcyDigJQgZXZlcnkgZnJhbWUgYmVnaW5zIHdpdGggQ1NJIEguIG51bGwgPSBubyBtb3ZlIGVtaXR0ZWQgbGFzdCBmcmFtZS5cbiAgcHJpdmF0ZSBkaXNwbGF5Q3Vyc29yOiB7IHg6IG51bWJlcjsgeTogbnVtYmVyIH0gfCBudWxsID0gbnVsbFxuXG4gIGNvbnN0cnVjdG9yKHByaXZhdGUgcmVhZG9ubHkgb3B0aW9uczogT3B0aW9ucykge1xuICAgIGF1dG9CaW5kKHRoaXMpXG5cbiAgICBpZiAodGhpcy5vcHRpb25zLnBhdGNoQ29uc29sZSkge1xuICAgICAgdGhpcy5yZXN0b3JlQ29uc29sZSA9IHRoaXMucGF0Y2hDb25zb2xlKClcbiAgICAgIHRoaXMucmVzdG9yZVN0ZGVyciA9IHRoaXMucGF0Y2hTdGRlcnIoKVxuICAgIH1cblxuICAgIHRoaXMudGVybWluYWwgPSB7XG4gICAgICBzdGRvdXQ6IG9wdGlvbnMuc3Rkb3V0LFxuICAgICAgc3RkZXJyOiBvcHRpb25zLnN0ZGVycixcbiAgICB9XG5cbiAgICB0aGlzLnRlcm1pbmFsQ29sdW1ucyA9IG9wdGlvbnMuc3Rkb3V0LmNvbHVtbnMgfHwgODBcbiAgICB0aGlzLnRlcm1pbmFsUm93cyA9IG9wdGlvbnMuc3Rkb3V0LnJvd3MgfHwgMjRcbiAgICB0aGlzLmFsdFNjcmVlblBhcmtQYXRjaCA9IG1ha2VBbHRTY3JlZW5QYXJrUGF0Y2godGhpcy50ZXJtaW5hbFJvd3MpXG4gICAgdGhpcy5zdHlsZVBvb2wgPSBuZXcgU3R5bGVQb29sKClcbiAgICB0aGlzLmNoYXJQb29sID0gbmV3IENoYXJQb29sKClcbiAgICB0aGlzLmh5cGVybGlua1Bvb2wgPSBuZXcgSHlwZXJsaW5rUG9vbCgpXG4gICAgdGhpcy5mcm9udEZyYW1lID0gZW1wdHlGcmFtZShcbiAgICAgIHRoaXMudGVybWluYWxSb3dzLFxuICAgICAgdGhpcy50ZXJtaW5hbENvbHVtbnMsXG4gICAgICB0aGlzLnN0eWxlUG9vbCxcbiAgICAgIHRoaXMuY2hhclBvb2wsXG4gICAgICB0aGlzLmh5cGVybGlua1Bvb2wsXG4gICAgKVxuICAgIHRoaXMuYmFja0ZyYW1lID0gZW1wdHlGcmFtZShcbiAgICAgIHRoaXMudGVybWluYWxSb3dzLFxuICAgICAgdGhpcy50ZXJtaW5hbENvbHVtbnMsXG4gICAgICB0aGlzLnN0eWxlUG9vbCxcbiAgICAgIHRoaXMuY2hhclBvb2wsXG4gICAgICB0aGlzLmh5cGVybGlua1Bvb2wsXG4gICAgKVxuXG4gICAgdGhpcy5sb2cgPSBuZXcgTG9nVXBkYXRlKHtcbiAgICAgIGlzVFRZOiAob3B0aW9ucy5zdGRvdXQuaXNUVFkgYXMgYm9vbGVhbiB8IHVuZGVmaW5lZCkgfHwgZmFsc2UsXG4gICAgICBzdHlsZVBvb2w6IHRoaXMuc3R5bGVQb29sLFxuICAgIH0pXG5cbiAgICAvLyBzY2hlZHVsZVJlbmRlciBpcyBjYWxsZWQgZnJvbSB0aGUgcmVjb25jaWxlcidzIHJlc2V0QWZ0ZXJDb21taXQsIHdoaWNoXG4gICAgLy8gcnVucyBCRUZPUkUgUmVhY3QncyBsYXlvdXQgcGhhc2UgKHJlZiBhdHRhY2ggKyB1c2VMYXlvdXRFZmZlY3QpLiBBbnlcbiAgICAvLyBzdGF0ZSBzZXQgaW4gbGF5b3V0IGVmZmVjdHMg4oCUIG5vdGFibHkgdGhlIGN1cnNvckRlY2xhcmF0aW9uIGZyb21cbiAgICAvLyB1c2VEZWNsYXJlZEN1cnNvciDigJQgd291bGQgbGFnIG9uZSBjb21taXQgYmVoaW5kIGlmIHdlIHJlbmRlcmVkXG4gICAgLy8gc3luY2hyb25vdXNseS4gRGVmZXJyaW5nIHRvIGEgbWljcm90YXNrIHJ1bnMgb25SZW5kZXIgYWZ0ZXIgbGF5b3V0XG4gICAgLy8gZWZmZWN0cyBoYXZlIGNvbW1pdHRlZCwgc28gdGhlIG5hdGl2ZSBjdXJzb3IgdHJhY2tzIHRoZSBjYXJldCB3aXRob3V0XG4gICAgLy8gYSBvbmUta2V5c3Ryb2tlIGxhZy4gU2FtZSBldmVudC1sb29wIHRpY2ssIHNvIHRocm91Z2hwdXQgaXMgdW5jaGFuZ2VkLlxuICAgIC8vIFRlc3QgZW52IHVzZXMgb25JbW1lZGlhdGVSZW5kZXIgKGRpcmVjdCBvblJlbmRlciwgbm8gdGhyb3R0bGUpIHNvXG4gICAgLy8gZXhpc3Rpbmcgc3luY2hyb25vdXMgbGFzdEZyYW1lKCkgdGVzdHMgYXJlIHVuYWZmZWN0ZWQuXG4gICAgY29uc3QgZGVmZXJyZWRSZW5kZXIgPSAoKTogdm9pZCA9PiBxdWV1ZU1pY3JvdGFzayh0aGlzLm9uUmVuZGVyKVxuICAgIHRoaXMuc2NoZWR1bGVSZW5kZXIgPSB0aHJvdHRsZShkZWZlcnJlZFJlbmRlciwgRlJBTUVfSU5URVJWQUxfTVMsIHtcbiAgICAgIGxlYWRpbmc6IHRydWUsXG4gICAgICB0cmFpbGluZzogdHJ1ZSxcbiAgICB9KVxuXG4gICAgLy8gSWdub3JlIGxhc3QgcmVuZGVyIGFmdGVyIHVubW91bnRpbmcgYSB0cmVlIHRvIHByZXZlbnQgZW1wdHkgb3V0cHV0IGJlZm9yZSBleGl0XG4gICAgdGhpcy5pc1VubW91bnRlZCA9IGZhbHNlXG5cbiAgICAvLyBVbm1vdW50IHdoZW4gcHJvY2VzcyBleGl0c1xuICAgIHRoaXMudW5zdWJzY3JpYmVFeGl0ID0gb25FeGl0KHRoaXMudW5tb3VudCwgeyBhbHdheXNMYXN0OiBmYWxzZSB9KVxuXG4gICAgaWYgKG9wdGlvbnMuc3Rkb3V0LmlzVFRZKSB7XG4gICAgICBvcHRpb25zLnN0ZG91dC5vbigncmVzaXplJywgdGhpcy5oYW5kbGVSZXNpemUpXG4gICAgICBwcm9jZXNzLm9uKCdTSUdDT05UJywgdGhpcy5oYW5kbGVSZXN1bWUpXG5cbiAgICAgIHRoaXMudW5zdWJzY3JpYmVUVFlIYW5kbGVycyA9ICgpID0+IHtcbiAgICAgICAgb3B0aW9ucy5zdGRvdXQub2ZmKCdyZXNpemUnLCB0aGlzLmhhbmRsZVJlc2l6ZSlcbiAgICAgICAgcHJvY2Vzcy5vZmYoJ1NJR0NPTlQnLCB0aGlzLmhhbmRsZVJlc3VtZSlcbiAgICAgIH1cbiAgICB9XG5cbiAgICB0aGlzLnJvb3ROb2RlID0gZG9tLmNyZWF0ZU5vZGUoJ2luay1yb290JylcbiAgICB0aGlzLmZvY3VzTWFuYWdlciA9IG5ldyBGb2N1c01hbmFnZXIoKHRhcmdldCwgZXZlbnQpID0+XG4gICAgICBkaXNwYXRjaGVyLmRpc3BhdGNoRGlzY3JldGUodGFyZ2V0LCBldmVudCksXG4gICAgKVxuICAgIHRoaXMucm9vdE5vZGUuZm9jdXNNYW5hZ2VyID0gdGhpcy5mb2N1c01hbmFnZXJcbiAgICB0aGlzLnJlbmRlcmVyID0gY3JlYXRlUmVuZGVyZXIodGhpcy5yb290Tm9kZSwgdGhpcy5zdHlsZVBvb2wpXG4gICAgdGhpcy5yb290Tm9kZS5vblJlbmRlciA9IHRoaXMuc2NoZWR1bGVSZW5kZXJcbiAgICB0aGlzLnJvb3ROb2RlLm9uSW1tZWRpYXRlUmVuZGVyID0gdGhpcy5vblJlbmRlclxuICAgIHRoaXMucm9vdE5vZGUub25Db21wdXRlTGF5b3V0ID0gKCkgPT4ge1xuICAgICAgLy8gQ2FsY3VsYXRlIGxheW91dCBkdXJpbmcgUmVhY3QncyBjb21taXQgcGhhc2Ugc28gdXNlTGF5b3V0RWZmZWN0IGhvb2tzXG4gICAgICAvLyBoYXZlIGFjY2VzcyB0byBmcmVzaCBsYXlvdXQgZGF0YVxuICAgICAgLy8gR3VhcmQgYWdhaW5zdCBhY2Nlc3NpbmcgZnJlZWQgWW9nYSBub2RlcyBhZnRlciB1bm1vdW50XG4gICAgICBpZiAodGhpcy5pc1VubW91bnRlZCkge1xuICAgICAgICByZXR1cm5cbiAgICAgIH1cblxuICAgICAgaWYgKHRoaXMucm9vdE5vZGUueW9nYU5vZGUpIHtcbiAgICAgICAgY29uc3QgdDAgPSBwZXJmb3JtYW5jZS5ub3coKVxuICAgICAgICB0aGlzLnJvb3ROb2RlLnlvZ2FOb2RlLnNldFdpZHRoKHRoaXMudGVybWluYWxDb2x1bW5zKVxuICAgICAgICB0aGlzLnJvb3ROb2RlLnlvZ2FOb2RlLmNhbGN1bGF0ZUxheW91dCh0aGlzLnRlcm1pbmFsQ29sdW1ucylcbiAgICAgICAgY29uc3QgbXMgPSBwZXJmb3JtYW5jZS5ub3coKSAtIHQwXG4gICAgICAgIHJlY29yZFlvZ2FNcyhtcylcbiAgICAgICAgY29uc3QgYyA9IGdldFlvZ2FDb3VudGVycygpXG4gICAgICAgIHRoaXMubGFzdFlvZ2FDb3VudGVycyA9IHsgbXMsIC4uLmMgfVxuICAgICAgfVxuICAgIH1cblxuICAgIC8vIEB0cy1leHBlY3QtZXJyb3IgQHR5cGVzL3JlYWN0LXJlY29uY2lsZXJAMC4zMi4zIGRlY2xhcmVzIDExIGFyZ3Mgd2l0aCB0cmFuc2l0aW9uQ2FsbGJhY2tzLFxuICAgIC8vIGJ1dCByZWFjdC1yZWNvbmNpbGVyIDAuMzMuMCBzb3VyY2Ugb25seSBhY2NlcHRzIDEwIGFyZ3MgKG5vIHRyYW5zaXRpb25DYWxsYmFja3MpXG4gICAgdGhpcy5jb250YWluZXIgPSByZWNvbmNpbGVyLmNyZWF0ZUNvbnRhaW5lcihcbiAgICAgIHRoaXMucm9vdE5vZGUsXG4gICAgICBDb25jdXJyZW50Um9vdCxcbiAgICAgIG51bGwsXG4gICAgICBmYWxzZSxcbiAgICAgIG51bGwsXG4gICAgICAnaWQnLFxuICAgICAgbm9vcCwgLy8gb25VbmNhdWdodEVycm9yXG4gICAgICBub29wLCAvLyBvbkNhdWdodEVycm9yXG4gICAgICBub29wLCAvLyBvblJlY292ZXJhYmxlRXJyb3JcbiAgICAgIG5vb3AsIC8vIG9uRGVmYXVsdFRyYW5zaXRpb25JbmRpY2F0b3JcbiAgICApXG5cbiAgICBpZiAoXCJwcm9kdWN0aW9uXCIgPT09ICdkZXZlbG9wbWVudCcpIHtcbiAgICAgIHJlY29uY2lsZXIuaW5qZWN0SW50b0RldlRvb2xzKHtcbiAgICAgICAgYnVuZGxlVHlwZTogMCxcbiAgICAgICAgLy8gUmVwb3J0aW5nIFJlYWN0IERPTSdzIHZlcnNpb24sIG5vdCBJbmsnc1xuICAgICAgICAvLyBTZWUgaHR0cHM6Ly9naXRodWIuY29tL2ZhY2Vib29rL3JlYWN0L2lzc3Vlcy8xNjY2NiNpc3N1ZWNvbW1lbnQtNTMyNjM5OTA1XG4gICAgICAgIHZlcnNpb246ICcxNi4xMy4xJyxcbiAgICAgICAgcmVuZGVyZXJQYWNrYWdlTmFtZTogJ2luaycsXG4gICAgICB9KVxuICAgIH1cbiAgfVxuXG4gIHByaXZhdGUgaGFuZGxlUmVzdW1lID0gKCkgPT4ge1xuICAgIGlmICghdGhpcy5vcHRpb25zLnN0ZG91dC5pc1RUWSkge1xuICAgICAgcmV0dXJuXG4gICAgfVxuXG4gICAgLy8gQWx0IHNjcmVlbjogYWZ0ZXIgU0lHQ09OVCwgY29udGVudCBpcyBzdGFsZSAoc2hlbGwgbWF5IGhhdmUgd3JpdHRlblxuICAgIC8vIHRvIG1haW4gc2NyZWVuLCBzd2l0Y2hpbmcgZm9jdXMgYXdheSkgYW5kIG1vdXNlIHRyYWNraW5nIHdhc1xuICAgIC8vIGRpc2FibGVkIGJ5IGhhbmRsZVN1c3BlbmQuXG4gICAgaWYgKHRoaXMuYWx0U2NyZWVuQWN0aXZlKSB7XG4gICAgICB0aGlzLnJlZW50ZXJBbHRTY3JlZW4oKVxuICAgICAgcmV0dXJuXG4gICAgfVxuXG4gICAgLy8gTWFpbiBzY3JlZW46IHN0YXJ0IGZyZXNoIHRvIHByZXZlbnQgY2xvYmJlcmluZyB0ZXJtaW5hbCBjb250ZW50XG4gICAgdGhpcy5mcm9udEZyYW1lID0gZW1wdHlGcmFtZShcbiAgICAgIHRoaXMuZnJvbnRGcmFtZS52aWV3cG9ydC5oZWlnaHQsXG4gICAgICB0aGlzLmZyb250RnJhbWUudmlld3BvcnQud2lkdGgsXG4gICAgICB0aGlzLnN0eWxlUG9vbCxcbiAgICAgIHRoaXMuY2hhclBvb2wsXG4gICAgICB0aGlzLmh5cGVybGlua1Bvb2wsXG4gICAgKVxuICAgIHRoaXMuYmFja0ZyYW1lID0gZW1wdHlGcmFtZShcbiAgICAgIHRoaXMuYmFja0ZyYW1lLnZpZXdwb3J0LmhlaWdodCxcbiAgICAgIHRoaXMuYmFja0ZyYW1lLnZpZXdwb3J0LndpZHRoLFxuICAgICAgdGhpcy5zdHlsZVBvb2wsXG4gICAgICB0aGlzLmNoYXJQb29sLFxuICAgICAgdGhpcy5oeXBlcmxpbmtQb29sLFxuICAgIClcbiAgICB0aGlzLmxvZy5yZXNldCgpXG4gICAgLy8gUGh5c2ljYWwgY3Vyc29yIHBvc2l0aW9uIGlzIHVua25vd24gYWZ0ZXIgdGhlIHNoZWxsIHRvb2sgb3ZlciBkdXJpbmdcbiAgICAvLyBzdXNwZW5kLiBDbGVhciBkaXNwbGF5Q3Vyc29yIHNvIHRoZSBuZXh0IGZyYW1lJ3MgY3Vyc29yIHByZWFtYmxlXG4gICAgLy8gZG9lc24ndCBlbWl0IGEgcmVsYXRpdmUgbW92ZSBmcm9tIGEgc3RhbGUgcGFyayBwb3NpdGlvbi5cbiAgICB0aGlzLmRpc3BsYXlDdXJzb3IgPSBudWxsXG4gIH1cblxuICAvLyBOT1QgZGVib3VuY2VkLiBBIGRlYm91bmNlIG9wZW5zIGEgd2luZG93IHdoZXJlIHN0ZG91dC5jb2x1bW5zIGlzIE5FV1xuICAvLyBidXQgdGhpcy50ZXJtaW5hbENvbHVtbnMvWW9nYSBhcmUgT0xEIOKAlCBhbnkgc2NoZWR1bGVSZW5kZXIgZHVyaW5nIHRoYXRcbiAgLy8gd2luZG93IChzcGlubmVyLCBjbG9jaykgbWFrZXMgbG9nLXVwZGF0ZSBkZXRlY3QgYSB3aWR0aCBjaGFuZ2UgYW5kXG4gIC8vIGNsZWFyIHRoZSBzY3JlZW4sIHRoZW4gdGhlIGRlYm91bmNlIGZpcmVzIGFuZCBjbGVhcnMgYWdhaW4gKGRvdWJsZVxuICAvLyBibGFua+KGknBhaW50IGZsaWNrZXIpLiB1c2VWaXJ0dWFsU2Nyb2xsJ3MgaGVpZ2h0IHNjYWxpbmcgYWxyZWFkeSBib3VuZHNcbiAgLy8gdGhlIHBlci1yZXNpemUgY29zdDsgc3luY2hyb25vdXMgaGFuZGxpbmcga2VlcHMgZGltZW5zaW9ucyBjb25zaXN0ZW50LlxuICBwcml2YXRlIGhhbmRsZVJlc2l6ZSA9ICgpID0+IHtcbiAgICBjb25zdCBjb2xzID0gdGhpcy5vcHRpb25zLnN0ZG91dC5jb2x1bW5zIHx8IDgwXG4gICAgY29uc3Qgcm93cyA9IHRoaXMub3B0aW9ucy5zdGRvdXQucm93cyB8fCAyNFxuICAgIC8vIFRlcm1pbmFscyBvZnRlbiBlbWl0IDIrIHJlc2l6ZSBldmVudHMgZm9yIG9uZSB1c2VyIGFjdGlvbiAod2luZG93XG4gICAgLy8gc2V0dGxpbmcpLiBTYW1lLWRpbWVuc2lvbiBldmVudHMgYXJlIG5vLW9wczsgc2tpcCB0byBhdm9pZCByZWR1bmRhbnRcbiAgICAvLyBmcmFtZSByZXNldHMgYW5kIHJlbmRlcnMuXG4gICAgaWYgKGNvbHMgPT09IHRoaXMudGVybWluYWxDb2x1bW5zICYmIHJvd3MgPT09IHRoaXMudGVybWluYWxSb3dzKSByZXR1cm5cbiAgICB0aGlzLnRlcm1pbmFsQ29sdW1ucyA9IGNvbHNcbiAgICB0aGlzLnRlcm1pbmFsUm93cyA9IHJvd3NcbiAgICB0aGlzLmFsdFNjcmVlblBhcmtQYXRjaCA9IG1ha2VBbHRTY3JlZW5QYXJrUGF0Y2godGhpcy50ZXJtaW5hbFJvd3MpXG5cbiAgICAvLyBBbHQgc2NyZWVuOiByZXNldCBmcmFtZSBidWZmZXJzIHNvIHRoZSBuZXh0IHJlbmRlciByZXBhaW50cyBmcm9tXG4gICAgLy8gc2NyYXRjaCAocHJldkZyYW1lQ29udGFtaW5hdGVkIOKGkiBldmVyeSBjZWxsIHdyaXR0ZW4sIHdyYXBwZWQgaW5cbiAgICAvLyBCU1UvRVNVIOKAlCBvbGQgY29udGVudCBzdGF5cyB2aXNpYmxlIHVudGlsIHRoZSBuZXcgZnJhbWUgc3dhcHNcbiAgICAvLyBhdG9taWNhbGx5KS4gUmUtYXNzZXJ0IG1vdXNlIHRyYWNraW5nIChzb21lIGVtdWxhdG9ycyByZXNldCBpdCBvblxuICAgIC8vIHJlc2l6ZSkuIERvIE5PVCB3cml0ZSBFTlRFUl9BTFRfU0NSRUVOOiBpVGVybTIgdHJlYXRzID8xMDQ5aCBhcyBhXG4gICAgLy8gYnVmZmVyIGNsZWFyIGV2ZW4gd2hlbiBhbHJlYWR5IGluIGFsdCDigJQgdGhhdCdzIHRoZSBibGFuayBmbGlja2VyLlxuICAgIC8vIFNlbGYtaGVhbGluZyByZS1lbnRyeSAoaWYgc29tZXRoaW5nIGtpY2tlZCB1cyBvdXQgb2YgYWx0KSBpcyBoYW5kbGVkXG4gICAgLy8gYnkgaGFuZGxlUmVzdW1lIChTSUdDT05UKSBhbmQgdGhlIHNsZWVwLXdha2UgZGV0ZWN0b3I7IHJlc2l6ZSBpdHNlbGZcbiAgICAvLyBkb2Vzbid0IGV4aXQgYWx0LXNjcmVlbi4gRG8gTk9UIHdyaXRlIEVSQVNFX1NDUkVFTjogcmVuZGVyKCkgYmVsb3dcbiAgICAvLyBjYW4gdGFrZSB+ODBtczsgZXJhc2luZyBmaXJzdCBsZWF2ZXMgdGhlIHNjcmVlbiBibGFuayB0aGF0IHdob2xlIHRpbWUuXG4gICAgaWYgKHRoaXMuYWx0U2NyZWVuQWN0aXZlICYmICF0aGlzLmlzUGF1c2VkICYmIHRoaXMub3B0aW9ucy5zdGRvdXQuaXNUVFkpIHtcbiAgICAgIGlmICh0aGlzLmFsdFNjcmVlbk1vdXNlVHJhY2tpbmcpIHtcbiAgICAgICAgdGhpcy5vcHRpb25zLnN0ZG91dC53cml0ZShFTkFCTEVfTU9VU0VfVFJBQ0tJTkcpXG4gICAgICB9XG4gICAgICB0aGlzLnJlc2V0RnJhbWVzRm9yQWx0U2NyZWVuKClcbiAgICAgIHRoaXMubmVlZHNFcmFzZUJlZm9yZVBhaW50ID0gdHJ1ZVxuICAgIH1cblxuICAgIC8vIFJlLXJlbmRlciB0aGUgUmVhY3QgdHJlZSB3aXRoIHVwZGF0ZWQgcHJvcHMgc28gdGhlIGNvbnRleHQgdmFsdWUgY2hhbmdlcy5cbiAgICAvLyBSZWFjdCdzIGNvbW1pdCBwaGFzZSB3aWxsIGNhbGwgb25Db21wdXRlTGF5b3V0KCkgdG8gcmVjYWxjdWxhdGUgeW9nYSBsYXlvdXRcbiAgICAvLyB3aXRoIHRoZSBuZXcgZGltZW5zaW9ucywgdGhlbiBjYWxsIG9uUmVuZGVyKCkgdG8gcmVuZGVyIHRoZSB1cGRhdGVkIGZyYW1lLlxuICAgIC8vIFdlIGRvbid0IGNhbGwgc2NoZWR1bGVSZW5kZXIoKSBoZXJlIGJlY2F1c2UgdGhhdCB3b3VsZCByZW5kZXIgYmVmb3JlIHRoZVxuICAgIC8vIGxheW91dCBpcyB1cGRhdGVkLCBjYXVzaW5nIGEgbWlzbWF0Y2ggYmV0d2VlbiB2aWV3cG9ydCBhbmQgY29udGVudCBkaW1lbnNpb25zLlxuICAgIGlmICh0aGlzLmN1cnJlbnROb2RlICE9PSBudWxsKSB7XG4gICAgICB0aGlzLnJlbmRlcih0aGlzLmN1cnJlbnROb2RlKVxuICAgIH1cbiAgfVxuXG4gIHJlc29sdmVFeGl0UHJvbWlzZTogKCkgPT4gdm9pZCA9ICgpID0+IHt9XG4gIHJlamVjdEV4aXRQcm9taXNlOiAocmVhc29uPzogRXJyb3IpID0+IHZvaWQgPSAoKSA9PiB7fVxuICB1bnN1YnNjcmliZUV4aXQ6ICgpID0+IHZvaWQgPSAoKSA9PiB7fVxuXG4gIC8qKlxuICAgKiBQYXVzZSBJbmsgYW5kIGhhbmQgdGhlIHRlcm1pbmFsIG92ZXIgdG8gYW4gZXh0ZXJuYWwgVFVJIChlLmcuIGdpdFxuICAgKiBjb21taXQgZWRpdG9yKS4gSW4gbm9uLWZ1bGxzY3JlZW4gbW9kZSB0aGlzIGVudGVycyB0aGUgYWx0IHNjcmVlbjtcbiAgICogaW4gZnVsbHNjcmVlbiBtb2RlIHdlJ3JlIGFscmVhZHkgaW4gYWx0IHNvIHdlIGp1c3QgY2xlYXIgaXQuXG4gICAqIENhbGwgYGV4aXRBbHRlcm5hdGVTY3JlZW4oKWAgd2hlbiBkb25lIHRvIHJlc3RvcmUgSW5rLlxuICAgKi9cbiAgZW50ZXJBbHRlcm5hdGVTY3JlZW4oKTogdm9pZCB7XG4gICAgdGhpcy5wYXVzZSgpXG4gICAgdGhpcy5zdXNwZW5kU3RkaW4oKVxuICAgIHRoaXMub3B0aW9ucy5zdGRvdXQud3JpdGUoXG4gICAgICAvLyBEaXNhYmxlIGV4dGVuZGVkIGtleSByZXBvcnRpbmcgZmlyc3Qg4oCUIGVkaXRvcnMgdGhhdCBkb24ndCBzcGVha1xuICAgICAgLy8gQ1NJLXUgKGUuZy4gbmFubykgc2hvdyBcIlVua25vd24gc2VxdWVuY2VcIiBmb3IgZXZlcnkgQ3RybC08a2V5PiBpZlxuICAgICAgLy8ga2l0dHkvbW9kaWZ5T3RoZXJLZXlzIHN0YXlzIGFjdGl2ZS4gZXhpdEFsdGVybmF0ZVNjcmVlbiByZS1lbmFibGVzLlxuICAgICAgRElTQUJMRV9LSVRUWV9LRVlCT0FSRCArXG4gICAgICAgIERJU0FCTEVfTU9ESUZZX09USEVSX0tFWVMgK1xuICAgICAgICAodGhpcy5hbHRTY3JlZW5Nb3VzZVRyYWNraW5nID8gRElTQUJMRV9NT1VTRV9UUkFDS0lORyA6ICcnKSArIC8vIGRpc2FibGUgbW91c2UgKG5vLW9wIGlmIG9mZilcbiAgICAgICAgKHRoaXMuYWx0U2NyZWVuQWN0aXZlID8gJycgOiAnXFx4MWJbPzEwNDloJykgKyAvLyBlbnRlciBhbHQgKGFscmVhZHkgaW4gYWx0IGlmIGZ1bGxzY3JlZW4pXG4gICAgICAgICdcXHgxYls/MTAwNGwnICsgLy8gZGlzYWJsZSBmb2N1cyByZXBvcnRpbmdcbiAgICAgICAgJ1xceDFiWzBtJyArIC8vIHJlc2V0IGF0dHJpYnV0ZXNcbiAgICAgICAgJ1xceDFiWz8yNWgnICsgLy8gc2hvdyBjdXJzb3JcbiAgICAgICAgJ1xceDFiWzJKJyArIC8vIGNsZWFyIHNjcmVlblxuICAgICAgICAnXFx4MWJbSCcsIC8vIGN1cnNvciBob21lXG4gICAgKVxuICB9XG5cbiAgLyoqXG4gICAqIFJlc3VtZSBJbmsgYWZ0ZXIgYW4gZXh0ZXJuYWwgVFVJIGhhbmRvZmYgd2l0aCBhIGZ1bGwgcmVwYWludC5cbiAgICogSW4gbm9uLWZ1bGxzY3JlZW4gbW9kZSB0aGlzIGV4aXRzIHRoZSBhbHQgc2NyZWVuIGJhY2sgdG8gbWFpbjtcbiAgICogaW4gZnVsbHNjcmVlbiBtb2RlIHdlIHJlLWVudGVyIGFsdCBhbmQgY2xlYXIgKyByZXBhaW50LlxuICAgKlxuICAgKiBUaGUgcmUtZW50ZXIgbWF0dGVyczogdGVybWluYWwgZWRpdG9ycyAodmltLCBuYW5vLCBsZXNzKSB3cml0ZVxuICAgKiBzbWN1cC9ybWN1cCAoPzEwNDloLz8xMDQ5bCksIHNvIGV2ZW4gdGhvdWdoIHdlIHN0YXJ0ZWQgaW4gYWx0LFxuICAgKiB0aGUgZWRpdG9yJ3Mgcm1jdXAgb24gZXhpdCBkcm9wcyB1cyB0byBtYWluIHNjcmVlbi4gV2l0aG91dFxuICAgKiByZS1lbnRlcmluZywgdGhlIDJKIGJlbG93IHdpcGVzIHRoZSB1c2VyJ3MgbWFpbi1zY3JlZW4gc2Nyb2xsYmFja1xuICAgKiBhbmQgc3Vic2VxdWVudCByZW5kZXJzIGxhbmQgaW4gbWFpbiDigJQgbmF0aXZlIHRlcm1pbmFsIHNjcm9sbFxuICAgKiByZXR1cm5zLCBmdWxsc2NyZWVuIHNjcm9sbCBpcyBkZWFkLlxuICAgKi9cbiAgZXhpdEFsdGVybmF0ZVNjcmVlbigpOiB2b2lkIHtcbiAgICB0aGlzLm9wdGlvbnMuc3Rkb3V0LndyaXRlKFxuICAgICAgKHRoaXMuYWx0U2NyZWVuQWN0aXZlID8gRU5URVJfQUxUX1NDUkVFTiA6ICcnKSArIC8vIHJlLWVudGVyIGFsdCDigJQgdmltJ3Mgcm1jdXAgZHJvcHBlZCB1cyB0byBtYWluXG4gICAgICAgICdcXHgxYlsySicgKyAvLyBjbGVhciBzY3JlZW4gKG5vdyBhbHQgaWYgZnVsbHNjcmVlbilcbiAgICAgICAgJ1xceDFiW0gnICsgLy8gY3Vyc29yIGhvbWVcbiAgICAgICAgKHRoaXMuYWx0U2NyZWVuTW91c2VUcmFja2luZyA/IEVOQUJMRV9NT1VTRV9UUkFDS0lORyA6ICcnKSArIC8vIHJlLWVuYWJsZSBtb3VzZSAoc2tpcCBpZiBDTEFVREVfQ09ERV9ESVNBQkxFX01PVVNFKVxuICAgICAgICAodGhpcy5hbHRTY3JlZW5BY3RpdmUgPyAnJyA6ICdcXHgxYls/MTA0OWwnKSArIC8vIGV4aXQgYWx0IChub24tZnVsbHNjcmVlbiBvbmx5KVxuICAgICAgICAnXFx4MWJbPzI1bCcsIC8vIGhpZGUgY3Vyc29yIChJbmsgbWFuYWdlcylcbiAgICApXG4gICAgdGhpcy5yZXN1bWVTdGRpbigpXG4gICAgaWYgKHRoaXMuYWx0U2NyZWVuQWN0aXZlKSB7XG4gICAgICB0aGlzLnJlc2V0RnJhbWVzRm9yQWx0U2NyZWVuKClcbiAgICB9IGVsc2Uge1xuICAgICAgdGhpcy5yZXBhaW50KClcbiAgICB9XG4gICAgdGhpcy5yZXN1bWUoKVxuICAgIC8vIFJlLWVuYWJsZSBmb2N1cyByZXBvcnRpbmcgYW5kIGV4dGVuZGVkIGtleSByZXBvcnRpbmcg4oCUIHRlcm1pbmFsXG4gICAgLy8gZWRpdG9ycyAodmltLCBuYW5vLCBldGMuKSB3cml0ZSB0aGVpciBvd24gbW9kaWZ5T3RoZXJLZXlzIGxldmVsIG9uXG4gICAgLy8gZW50cnkgYW5kIHJlc2V0IGl0IG9uIGV4aXQsIGxlYXZpbmcgdXMgdW5hYmxlIHRvIGRpc3Rpbmd1aXNoXG4gICAgLy8gY3RybCtzaGlmdCs8bGV0dGVyPiBmcm9tIGN0cmwrPGxldHRlcj4uIFBvcC1iZWZvcmUtcHVzaCBrZWVwcyB0aGVcbiAgICAvLyBLaXR0eSBzdGFjayBiYWxhbmNlZCAoYSB3ZWxsLWJlaGF2ZWQgZWRpdG9yIHJlc3RvcmVzIG91ciBlbnRyeSwgc29cbiAgICAvLyB3aXRob3V0IHRoZSBwb3Agd2UnZCBhY2N1bXVsYXRlIGRlcHRoIG9uIGVhY2ggZWRpdG9yIHJvdW5kLXRyaXApLlxuICAgIHRoaXMub3B0aW9ucy5zdGRvdXQud3JpdGUoXG4gICAgICAnXFx4MWJbPzEwMDRoJyArXG4gICAgICAgIChzdXBwb3J0c0V4dGVuZGVkS2V5cygpXG4gICAgICAgICAgPyBESVNBQkxFX0tJVFRZX0tFWUJPQVJEICtcbiAgICAgICAgICAgIEVOQUJMRV9LSVRUWV9LRVlCT0FSRCArXG4gICAgICAgICAgICBFTkFCTEVfTU9ESUZZX09USEVSX0tFWVNcbiAgICAgICAgICA6ICcnKSxcbiAgICApXG4gIH1cblxuICBvblJlbmRlcigpIHtcbiAgICBpZiAodGhpcy5pc1VubW91bnRlZCB8fCB0aGlzLmlzUGF1c2VkKSB7XG4gICAgICByZXR1cm5cbiAgICB9XG4gICAgLy8gRW50ZXJpbmcgYSByZW5kZXIgY2FuY2VscyBhbnkgcGVuZGluZyBkcmFpbiB0aWNrIOKAlCB0aGlzIHJlbmRlciB3aWxsXG4gICAgLy8gaGFuZGxlIHRoZSBkcmFpbiAoYW5kIHJlLXNjaGVkdWxlIGJlbG93IGlmIG5lZWRlZCkuIFByZXZlbnRzIGFcbiAgICAvLyB3aGVlbC1ldmVudC10cmlnZ2VyZWQgcmVuZGVyIEFORCBhIGRyYWluLXRpbWVyIHJlbmRlciBib3RoIGZpcmluZy5cbiAgICBpZiAodGhpcy5kcmFpblRpbWVyICE9PSBudWxsKSB7XG4gICAgICBjbGVhclRpbWVvdXQodGhpcy5kcmFpblRpbWVyKVxuICAgICAgdGhpcy5kcmFpblRpbWVyID0gbnVsbFxuICAgIH1cblxuICAgIC8vIEZsdXNoIGRlZmVycmVkIGludGVyYWN0aW9uLXRpbWUgdXBkYXRlIGJlZm9yZSByZW5kZXJpbmcgc28gd2UgY2FsbFxuICAgIC8vIERhdGUubm93KCkgYXQgbW9zdCBvbmNlIHBlciBmcmFtZSBpbnN0ZWFkIG9mIG9uY2UgcGVyIGtleXByZXNzLlxuICAgIC8vIERvbmUgYmVmb3JlIHRoZSByZW5kZXIgdG8gYXZvaWQgZGlydHlpbmcgc3RhdGUgdGhhdCB3b3VsZCB0cmlnZ2VyXG4gICAgLy8gYW4gZXh0cmEgUmVhY3QgcmUtcmVuZGVyIGN5Y2xlLlxuICAgIGZsdXNoSW50ZXJhY3Rpb25UaW1lKClcblxuICAgIGNvbnN0IHJlbmRlclN0YXJ0ID0gcGVyZm9ybWFuY2Uubm93KClcbiAgICBjb25zdCB0ZXJtaW5hbFdpZHRoID0gdGhpcy5vcHRpb25zLnN0ZG91dC5jb2x1bW5zIHx8IDgwXG4gICAgY29uc3QgdGVybWluYWxSb3dzID0gdGhpcy5vcHRpb25zLnN0ZG91dC5yb3dzIHx8IDI0XG5cbiAgICBjb25zdCBmcmFtZSA9IHRoaXMucmVuZGVyZXIoe1xuICAgICAgZnJvbnRGcmFtZTogdGhpcy5mcm9udEZyYW1lLFxuICAgICAgYmFja0ZyYW1lOiB0aGlzLmJhY2tGcmFtZSxcbiAgICAgIGlzVFRZOiB0aGlzLm9wdGlvbnMuc3Rkb3V0LmlzVFRZLFxuICAgICAgdGVybWluYWxXaWR0aCxcbiAgICAgIHRlcm1pbmFsUm93cyxcbiAgICAgIGFsdFNjcmVlbjogdGhpcy5hbHRTY3JlZW5BY3RpdmUsXG4gICAgICBwcmV2RnJhbWVDb250YW1pbmF0ZWQ6IHRoaXMucHJldkZyYW1lQ29udGFtaW5hdGVkLFxuICAgIH0pXG4gICAgY29uc3QgcmVuZGVyZXJNcyA9IHBlcmZvcm1hbmNlLm5vdygpIC0gcmVuZGVyU3RhcnRcblxuICAgIC8vIFN0aWNreS9hdXRvLWZvbGxvdyBzY3JvbGxlZCB0aGUgU2Nyb2xsQm94IHRoaXMgZnJhbWUuIFRyYW5zbGF0ZSB0aGVcbiAgICAvLyBzZWxlY3Rpb24gYnkgdGhlIHNhbWUgZGVsdGEgc28gdGhlIGhpZ2hsaWdodCBzdGF5cyBhbmNob3JlZCB0byB0aGVcbiAgICAvLyBURVhUIChuYXRpdmUgdGVybWluYWwgYmVoYXZpb3Ig4oCUIHRoZSBzZWxlY3Rpb24gd2Fsa3MgdXAgdGhlIHNjcmVlblxuICAgIC8vIGFzIGNvbnRlbnQgc2Nyb2xscywgZXZlbnR1YWxseSBjbGlwcGluZyBhdCB0aGUgdG9wKS4gZnJvbnRGcmFtZVxuICAgIC8vIHN0aWxsIGhvbGRzIHRoZSBQUkVWSU9VUyBmcmFtZSdzIHNjcmVlbiAoc3dhcCBpcyBhdCB+NTAwIGJlbG93KSwgc29cbiAgICAvLyBjYXB0dXJlU2Nyb2xsZWRSb3dzIHJlYWRzIHRoZSByb3dzIHRoYXQgYXJlIGFib3V0IHRvIHNjcm9sbCBvdXRcbiAgICAvLyBiZWZvcmUgdGhleSdyZSBvdmVyd3JpdHRlbiDigJQgdGhlIHRleHQgc3RheXMgY29weWFibGUgdW50aWwgdGhlXG4gICAgLy8gc2VsZWN0aW9uIHNjcm9sbHMgZW50aXJlbHkgb2ZmLiBEdXJpbmcgZHJhZywgZm9jdXMgdHJhY2tzIHRoZSBtb3VzZVxuICAgIC8vIChzY3JlZW4tbG9jYWwpIHNvIG9ubHkgYW5jaG9yIHNoaWZ0cyDigJQgc2VsZWN0aW9uIGdyb3dzIHRvd2FyZCB0aGVcbiAgICAvLyBtb3VzZSBhcyB0aGUgYW5jaG9yIHdhbGtzIHVwLiBBZnRlciByZWxlYXNlLCBib3RoIGVuZHMgYXJlIHRleHQtXG4gICAgLy8gYW5jaG9yZWQgYW5kIG1vdmUgYXMgYSBibG9jay5cbiAgICBjb25zdCBmb2xsb3cgPSBjb25zdW1lRm9sbG93U2Nyb2xsKClcbiAgICBpZiAoXG4gICAgICBmb2xsb3cgJiZcbiAgICAgIHRoaXMuc2VsZWN0aW9uLmFuY2hvciAmJlxuICAgICAgLy8gT25seSB0cmFuc2xhdGUgaWYgdGhlIHNlbGVjdGlvbiBpcyBPTiBzY3JvbGxib3ggY29udGVudC4gU2VsZWN0aW9uc1xuICAgICAgLy8gaW4gdGhlIGZvb3Rlci9wcm9tcHQvU3RpY2t5UHJvbXB0SGVhZGVyIGFyZSBvbiBzdGF0aWMgdGV4dCDigJQgdGhlXG4gICAgICAvLyBzY3JvbGwgZG9lc24ndCBtb3ZlIHdoYXQncyB1bmRlciB0aGVtLiBXaXRob3V0IHRoaXMgZ3VhcmQsIGFcbiAgICAgIC8vIGZvb3RlciBzZWxlY3Rpb24gd291bGQgYmUgc2hpZnRlZCBieSAtZGVsdGEgdGhlbiBjbGFtcGVkIHRvXG4gICAgICAvLyB2aWV3cG9ydEJvdHRvbSwgdGVsZXBvcnRpbmcgaXQgaW50byB0aGUgc2Nyb2xsYm94LiBNaXJyb3IgdGhlXG4gICAgICAvLyBib3VuZHMgY2hlY2sgdGhlIGRlbGV0ZWQgY2hlY2soKSBpbiBTY3JvbGxLZXliaW5kaW5nSGFuZGxlciBoYWQuXG4gICAgICB0aGlzLnNlbGVjdGlvbi5hbmNob3Iucm93ID49IGZvbGxvdy52aWV3cG9ydFRvcCAmJlxuICAgICAgdGhpcy5zZWxlY3Rpb24uYW5jaG9yLnJvdyA8PSBmb2xsb3cudmlld3BvcnRCb3R0b21cbiAgICApIHtcbiAgICAgIGNvbnN0IHsgZGVsdGEsIHZpZXdwb3J0VG9wLCB2aWV3cG9ydEJvdHRvbSB9ID0gZm9sbG93XG4gICAgICAvLyBjYXB0dXJlU2Nyb2xsZWRSb3dzIGFuZCBzaGlmdCogYXJlIGEgcGFpcjogY2FwdHVyZSBncmFicyByb3dzIGFib3V0XG4gICAgICAvLyB0byBzY3JvbGwgb2ZmLCBzaGlmdCBtb3ZlcyB0aGUgc2VsZWN0aW9uIGVuZHBvaW50IHNvIHRoZSBzYW1lIHJvd3NcbiAgICAgIC8vIHdvbid0IGludGVyc2VjdCBhZ2FpbiBuZXh0IGZyYW1lLiBDYXB0dXJpbmcgd2l0aG91dCBzaGlmdGluZyBsZWF2ZXNcbiAgICAgIC8vIHRoZSBlbmRwb2ludCBpbiBwbGFjZSwgc28gdGhlIFNBTUUgdmlld3BvcnQgcm93cyByZS1pbnRlcnNlY3QgZXZlcnlcbiAgICAgIC8vIGZyYW1lIGFuZCBzY3JvbGxlZE9mZkFib3ZlIGdyb3dzIHdpdGhvdXQgYm91bmQg4oCUIGdldFNlbGVjdGVkVGV4dFxuICAgICAgLy8gdGhlbiByZXR1cm5zIGV2ZXItZ3Jvd2luZyB0ZXh0IG9uIGVhY2ggcmUtY29weS4gS2VlcCBjYXB0dXJlIGluc2lkZVxuICAgICAgLy8gZWFjaCBzaGlmdCBicmFuY2ggc28gdGhlIHBhaXJpbmcgY2FuJ3QgYmUgYnJva2VuIGJ5IGEgbmV3IGd1YXJkLlxuICAgICAgaWYgKHRoaXMuc2VsZWN0aW9uLmlzRHJhZ2dpbmcpIHtcbiAgICAgICAgaWYgKGhhc1NlbGVjdGlvbih0aGlzLnNlbGVjdGlvbikpIHtcbiAgICAgICAgICBjYXB0dXJlU2Nyb2xsZWRSb3dzKFxuICAgICAgICAgICAgdGhpcy5zZWxlY3Rpb24sXG4gICAgICAgICAgICB0aGlzLmZyb250RnJhbWUuc2NyZWVuLFxuICAgICAgICAgICAgdmlld3BvcnRUb3AsXG4gICAgICAgICAgICB2aWV3cG9ydFRvcCArIGRlbHRhIC0gMSxcbiAgICAgICAgICAgICdhYm92ZScsXG4gICAgICAgICAgKVxuICAgICAgICB9XG4gICAgICAgIHNoaWZ0QW5jaG9yKHRoaXMuc2VsZWN0aW9uLCAtZGVsdGEsIHZpZXdwb3J0VG9wLCB2aWV3cG9ydEJvdHRvbSlcbiAgICAgIH0gZWxzZSBpZiAoXG4gICAgICAgIC8vIEZsYWctMyBndWFyZDogdGhlIGFuY2hvciBjaGVjayBhYm92ZSBvbmx5IHByb3ZlcyBPTkUgZW5kcG9pbnQgaXNcbiAgICAgICAgLy8gb24gc2Nyb2xsYm94IGNvbnRlbnQuIEEgZHJhZyBmcm9tIHJvdyAzIChzY3JvbGxib3gpIGludG8gdGhlXG4gICAgICAgIC8vIGZvb3RlciBhdCByb3cgNiwgdGhlbiByZWxlYXNlLCBsZWF2ZXMgZm9jdXMgb3V0c2lkZSB0aGUgdmlld3BvcnRcbiAgICAgICAgLy8g4oCUIHNoaWZ0U2VsZWN0aW9uRm9yRm9sbG93IHdvdWxkIGNsYW1wIGl0IHRvIHZpZXdwb3J0Qm90dG9tLFxuICAgICAgICAvLyB0ZWxlcG9ydGluZyB0aGUgaGlnaGxpZ2h0IGZyb20gc3RhdGljIGZvb3RlciBpbnRvIHRoZSBzY3JvbGxib3guXG4gICAgICAgIC8vIFN5bW1ldHJpYyBjaGVjazogcmVxdWlyZSBCT1RIIGVuZHMgaW5zaWRlIHRvIHRyYW5zbGF0ZS4gQVxuICAgICAgICAvLyBzdHJhZGRsaW5nIHNlbGVjdGlvbiBmYWxscyB0aHJvdWdoIHRvIE5FSVRIRVIgc2hpZnQgTk9SIGNhcHR1cmU6XG4gICAgICAgIC8vIHRoZSBmb290ZXIgZW5kcG9pbnQgcGlucyB0aGUgc2VsZWN0aW9uLCB0ZXh0IHNjcm9sbHMgYXdheSB1bmRlclxuICAgICAgICAvLyB0aGUgaGlnaGxpZ2h0LCBhbmQgZ2V0U2VsZWN0ZWRUZXh0IHJlYWRzIHRoZSBDVVJSRU5UIHNjcmVlblxuICAgICAgICAvLyBjb250ZW50cyDigJQgbm8gYWNjdW11bGF0aW9uLiBEcmFnZ2luZyBicmFuY2ggZG9lc24ndCBuZWVkIHRoaXM6XG4gICAgICAgIC8vIHNoaWZ0QW5jaG9yIGlnbm9yZXMgZm9jdXMsIGFuZCB0aGUgYW5jaG9yIERPRVMgc2hpZnQgKHNvIGNhcHR1cmVcbiAgICAgICAgLy8gaXMgY29ycmVjdCB0aGVyZSBldmVuIHdoZW4gZm9jdXMgaXMgaW4gdGhlIGZvb3RlcikuXG4gICAgICAgICF0aGlzLnNlbGVjdGlvbi5mb2N1cyB8fFxuICAgICAgICAodGhpcy5zZWxlY3Rpb24uZm9jdXMucm93ID49IHZpZXdwb3J0VG9wICYmXG4gICAgICAgICAgdGhpcy5zZWxlY3Rpb24uZm9jdXMucm93IDw9IHZpZXdwb3J0Qm90dG9tKVxuICAgICAgKSB7XG4gICAgICAgIGlmIChoYXNTZWxlY3Rpb24odGhpcy5zZWxlY3Rpb24pKSB7XG4gICAgICAgICAgY2FwdHVyZVNjcm9sbGVkUm93cyhcbiAgICAgICAgICAgIHRoaXMuc2VsZWN0aW9uLFxuICAgICAgICAgICAgdGhpcy5mcm9udEZyYW1lLnNjcmVlbixcbiAgICAgICAgICAgIHZpZXdwb3J0VG9wLFxuICAgICAgICAgICAgdmlld3BvcnRUb3AgKyBkZWx0YSAtIDEsXG4gICAgICAgICAgICAnYWJvdmUnLFxuICAgICAgICAgIClcbiAgICAgICAgfVxuICAgICAgICBjb25zdCBjbGVhcmVkID0gc2hpZnRTZWxlY3Rpb25Gb3JGb2xsb3coXG4gICAgICAgICAgdGhpcy5zZWxlY3Rpb24sXG4gICAgICAgICAgLWRlbHRhLFxuICAgICAgICAgIHZpZXdwb3J0VG9wLFxuICAgICAgICAgIHZpZXdwb3J0Qm90dG9tLFxuICAgICAgICApXG4gICAgICAgIC8vIEF1dG8tY2xlYXIgKGJvdGggZW5kcyBvdmVyc2hvdCBtaW5Sb3cpIG11c3Qgbm90aWZ5IFJlYWN0LWxhbmRcbiAgICAgICAgLy8gc28gdXNlSGFzU2VsZWN0aW9uIHJlLXJlbmRlcnMgYW5kIHRoZSBmb290ZXIgY29weS9lc2NhcGUgaGludFxuICAgICAgICAvLyBkaXNhcHBlYXJzLiBub3RpZnlTZWxlY3Rpb25DaGFuZ2UoKSB3b3VsZCByZWN1cnNlIGludG8gb25SZW5kZXI7XG4gICAgICAgIC8vIGZpcmUgdGhlIGxpc3RlbmVycyBkaXJlY3RseSDigJQgdGhleSBzY2hlZHVsZSBhIFJlYWN0IHVwZGF0ZSBmb3JcbiAgICAgICAgLy8gTEFURVIsIHRoZXkgZG9uJ3QgcmUtZW50ZXIgdGhpcyBmcmFtZS5cbiAgICAgICAgaWYgKGNsZWFyZWQpIGZvciAoY29uc3QgY2Igb2YgdGhpcy5zZWxlY3Rpb25MaXN0ZW5lcnMpIGNiKClcbiAgICAgIH1cbiAgICB9XG5cbiAgICAvLyBTZWxlY3Rpb24gb3ZlcmxheTogaW52ZXJ0IGNlbGwgc3R5bGVzIGluIHRoZSBzY3JlZW4gYnVmZmVyIGl0c2VsZixcbiAgICAvLyBzbyB0aGUgZGlmZiBwaWNrcyB1cCBzZWxlY3Rpb24gYXMgb3JkaW5hcnkgY2VsbCBjaGFuZ2VzIGFuZFxuICAgIC8vIExvZ1VwZGF0ZSByZW1haW5zIGEgcHVyZSBkaWZmIGVuZ2luZS5cbiAgICAvL1xuICAgIC8vIEZ1bGwtc2NyZWVuIGRhbWFnZSAoUFIgIzIwMTIwKSBpcyBhIGNvcnJlY3RuZXNzIGJhY2tzdG9wIGZvciB0aGVcbiAgICAvLyBzaWJsaW5nLXJlc2l6ZSBibGVlZDogd2hlbiBmbGV4Ym94IHNpYmxpbmdzIHJlc2l6ZSBiZXR3ZWVuIGZyYW1lc1xuICAgIC8vIChzcGlubmVyIGFwcGVhcnMg4oaSIGJvdHRvbSBncm93cyDihpIgc2Nyb2xsYm94IHNocmlua3MpLCB0aGVcbiAgICAvLyBjYWNoZWQtY2xlYXIgKyBjbGlwLWFuZC1jdWxsICsgc2V0Q2VsbEF0IGRhbWFnZSB1bmlvbiBjYW4gbWlzc1xuICAgIC8vIHRyYW5zaXRpb24gY2VsbHMgYXQgdGhlIGJvdW5kYXJ5LiBCdXQgdGhhdCBvbmx5IGhhcHBlbnMgd2hlbiBsYXlvdXRcbiAgICAvLyBhY3R1YWxseSBTSElGVFMg4oCUIGRpZExheW91dFNoaWZ0KCkgdHJhY2tzIGV4YWN0bHkgdGhpcyAoYW55IG5vZGUnc1xuICAgIC8vIGNhY2hlZCB5b2dhIHBvc2l0aW9uL3NpemUgZGlmZmVycyBmcm9tIGN1cnJlbnQsIG9yIGEgY2hpbGQgd2FzXG4gICAgLy8gcmVtb3ZlZCkuIFN0ZWFkeS1zdGF0ZSBmcmFtZXMgKHNwaW5uZXIgcm90YXRlLCBjbG9jayB0aWNrLCB0ZXh0XG4gICAgLy8gc3RyZWFtIGludG8gZml4ZWQtaGVpZ2h0IGJveCkgZG9uJ3Qgc2hpZnQgbGF5b3V0LCBzbyBub3JtYWwgZGFtYWdlXG4gICAgLy8gYm91bmRzIGFyZSBjb3JyZWN0IGFuZCBkaWZmRWFjaCBvbmx5IGNvbXBhcmVzIHRoZSBkYW1hZ2VkIHJlZ2lvbi5cbiAgICAvL1xuICAgIC8vIFNlbGVjdGlvbiBhbHNvIHJlcXVpcmVzIGZ1bGwgZGFtYWdlOiBvdmVybGF5IHdyaXRlcyB2aWEgc2V0Q2VsbFN0eWxlSWRcbiAgICAvLyB3aGljaCBkb2Vzbid0IHRyYWNrIGRhbWFnZSwgYW5kIHByZXYtZnJhbWUgb3ZlcmxheSBjZWxscyBuZWVkIHRvIGJlXG4gICAgLy8gY29tcGFyZWQgd2hlbiBzZWxlY3Rpb24gbW92ZXMvY2xlYXJzLiBwcmV2RnJhbWVDb250YW1pbmF0ZWQgY292ZXJzXG4gICAgLy8gdGhlIGZyYW1lLWFmdGVyLXNlbGVjdGlvbi1jbGVhcnMgY2FzZS5cbiAgICBsZXQgc2VsQWN0aXZlID0gZmFsc2VcbiAgICBsZXQgaGxBY3RpdmUgPSBmYWxzZVxuICAgIGlmICh0aGlzLmFsdFNjcmVlbkFjdGl2ZSkge1xuICAgICAgc2VsQWN0aXZlID0gaGFzU2VsZWN0aW9uKHRoaXMuc2VsZWN0aW9uKVxuICAgICAgaWYgKHNlbEFjdGl2ZSkge1xuICAgICAgICBhcHBseVNlbGVjdGlvbk92ZXJsYXkoZnJhbWUuc2NyZWVuLCB0aGlzLnNlbGVjdGlvbiwgdGhpcy5zdHlsZVBvb2wpXG4gICAgICB9XG4gICAgICAvLyBTY2FuLWhpZ2hsaWdodDogaW52ZXJzZSBvbiBBTEwgdmlzaWJsZSBtYXRjaGVzIChsZXNzL3ZpbSBzdHlsZSkuXG4gICAgICAvLyBQb3NpdGlvbi1oaWdobGlnaHQgKGJlbG93KSBvdmVybGF5cyBDVVJSRU5UICh5ZWxsb3cpIG9uIHRvcC5cbiAgICAgIGhsQWN0aXZlID0gYXBwbHlTZWFyY2hIaWdobGlnaHQoXG4gICAgICAgIGZyYW1lLnNjcmVlbixcbiAgICAgICAgdGhpcy5zZWFyY2hIaWdobGlnaHRRdWVyeSxcbiAgICAgICAgdGhpcy5zdHlsZVBvb2wsXG4gICAgICApXG4gICAgICAvLyBQb3NpdGlvbi1iYXNlZCBDVVJSRU5UOiB3cml0ZSB5ZWxsb3cgYXQgcG9zaXRpb25zW2N1cnJlbnRJZHhdICtcbiAgICAgIC8vIHJvd09mZnNldC4gTm8gc2Nhbm5pbmcg4oCUIHBvc2l0aW9ucyBjYW1lIGZyb20gYSBwcmlvciBzY2FuIHdoZW5cbiAgICAgIC8vIHRoZSBtZXNzYWdlIGZpcnN0IG1vdW50ZWQuIE1lc3NhZ2UtcmVsYXRpdmUgKyByb3dPZmZzZXQgPSBzY3JlZW4uXG4gICAgICBpZiAodGhpcy5zZWFyY2hQb3NpdGlvbnMpIHtcbiAgICAgICAgY29uc3Qgc3AgPSB0aGlzLnNlYXJjaFBvc2l0aW9uc1xuICAgICAgICBjb25zdCBwb3NBcHBsaWVkID0gYXBwbHlQb3NpdGlvbmVkSGlnaGxpZ2h0KFxuICAgICAgICAgIGZyYW1lLnNjcmVlbixcbiAgICAgICAgICB0aGlzLnN0eWxlUG9vbCxcbiAgICAgICAgICBzcC5wb3NpdGlvbnMsXG4gICAgICAgICAgc3Aucm93T2Zmc2V0LFxuICAgICAgICAgIHNwLmN1cnJlbnRJZHgsXG4gICAgICAgIClcbiAgICAgICAgaGxBY3RpdmUgPSBobEFjdGl2ZSB8fCBwb3NBcHBsaWVkXG4gICAgICB9XG4gICAgfVxuXG4gICAgLy8gRnVsbC1kYW1hZ2UgYmFja3N0b3A6IGFwcGxpZXMgb24gQk9USCBhbHQtc2NyZWVuIGFuZCBtYWluLXNjcmVlbi5cbiAgICAvLyBMYXlvdXQgc2hpZnRzIChzcGlubmVyIGFwcGVhcnMsIHN0YXR1cyBsaW5lIHJlc2l6ZXMpIGNhbiBsZWF2ZSBzdGFsZVxuICAgIC8vIGNlbGxzIGF0IHNpYmxpbmcgYm91bmRhcmllcyB0aGF0IHBlci1ub2RlIGRhbWFnZSB0cmFja2luZyBtaXNzZXMuXG4gICAgLy8gU2VsZWN0aW9uL2hpZ2hsaWdodCBvdmVybGF5cyB3cml0ZSB2aWEgc2V0Q2VsbFN0eWxlSWQgd2hpY2ggZG9lc24ndFxuICAgIC8vIHRyYWNrIGRhbWFnZS4gcHJldkZyYW1lQ29udGFtaW5hdGVkIGNvdmVycyB0aGUgY2xlYW51cCBmcmFtZS5cbiAgICBpZiAoXG4gICAgICBkaWRMYXlvdXRTaGlmdCgpIHx8XG4gICAgICBzZWxBY3RpdmUgfHxcbiAgICAgIGhsQWN0aXZlIHx8XG4gICAgICB0aGlzLnByZXZGcmFtZUNvbnRhbWluYXRlZFxuICAgICkge1xuICAgICAgZnJhbWUuc2NyZWVuLmRhbWFnZSA9IHtcbiAgICAgICAgeDogMCxcbiAgICAgICAgeTogMCxcbiAgICAgICAgd2lkdGg6IGZyYW1lLnNjcmVlbi53aWR0aCxcbiAgICAgICAgaGVpZ2h0OiBmcmFtZS5zY3JlZW4uaGVpZ2h0LFxuICAgICAgfVxuICAgIH1cblxuICAgIC8vIEFsdC1zY3JlZW46IGFuY2hvciB0aGUgcGh5c2ljYWwgY3Vyc29yIHRvICgwLDApIGJlZm9yZSBldmVyeSBkaWZmLlxuICAgIC8vIEFsbCBjdXJzb3IgbW92ZXMgaW4gbG9nLXVwZGF0ZSBhcmUgUkVMQVRJVkUgdG8gcHJldi5jdXJzb3I7IGlmIHRtdXhcbiAgICAvLyAob3IgYW55IGVtdWxhdG9yKSBwZXJ0dXJicyB0aGUgcGh5c2ljYWwgY3Vyc29yIG91dC1vZi1iYW5kIChzdGF0dXNcbiAgICAvLyBiYXIgcmVmcmVzaCwgcGFuZSByZWRyYXcsIENtZCtLIHdpcGUpLCB0aGUgcmVsYXRpdmUgbW92ZXMgZHJpZnQgYW5kXG4gICAgLy8gY29udGVudCBjcmVlcHMgdXAgMSByb3cvZnJhbWUuIENTSSBIIHJlc2V0cyB0aGUgcGh5c2ljYWwgY3Vyc29yO1xuICAgIC8vIHBhc3NpbmcgcHJldi5jdXJzb3I9KDAsMCkgbWFrZXMgdGhlIGRpZmYgY29tcHV0ZSBmcm9tIHRoZSBzYW1lIHNwb3QuXG4gICAgLy8gU2VsZi1oZWFsaW5nIGFnYWluc3QgYW55IGV4dGVybmFsIGN1cnNvciBtYW5pcHVsYXRpb24uIE1haW4tc2NyZWVuXG4gICAgLy8gY2FuJ3QgZG8gdGhpcyDigJQgY3Vyc29yLnkgdHJhY2tzIHNjcm9sbGJhY2sgcm93cyBDU0kgSCBjYW4ndCByZWFjaC5cbiAgICAvLyBUaGUgQ1NJIEggd3JpdGUgaXMgZGVmZXJyZWQgdW50aWwgYWZ0ZXIgdGhlIGRpZmYgaXMgY29tcHV0ZWQgc28gd2VcbiAgICAvLyBjYW4gc2tpcCBpdCBmb3IgZW1wdHkgZGlmZnMgKG5vIHdyaXRlcyDihpIgcGh5c2ljYWwgY3Vyc29yIHVudXNlZCkuXG4gICAgbGV0IHByZXZGcmFtZSA9IHRoaXMuZnJvbnRGcmFtZVxuICAgIGlmICh0aGlzLmFsdFNjcmVlbkFjdGl2ZSkge1xuICAgICAgcHJldkZyYW1lID0geyAuLi50aGlzLmZyb250RnJhbWUsIGN1cnNvcjogQUxUX1NDUkVFTl9BTkNIT1JfQ1VSU09SIH1cbiAgICB9XG5cbiAgICBjb25zdCB0RGlmZiA9IHBlcmZvcm1hbmNlLm5vdygpXG4gICAgY29uc3QgZGlmZiA9IHRoaXMubG9nLnJlbmRlcihcbiAgICAgIHByZXZGcmFtZSxcbiAgICAgIGZyYW1lLFxuICAgICAgdGhpcy5hbHRTY3JlZW5BY3RpdmUsXG4gICAgICAvLyBERUNTVEJNIG5lZWRzIEJTVS9FU1UgYXRvbWljaXR5IOKAlCB3aXRob3V0IGl0IHRoZSBvdXRlciB0ZXJtaW5hbFxuICAgICAgLy8gcmVuZGVycyB0aGUgc2Nyb2xsZWQtYnV0LW5vdC15ZXQtcmVwYWludGVkIGludGVybWVkaWF0ZSBzdGF0ZS5cbiAgICAgIC8vIHRtdXggaXMgdGhlIG1haW4gY2FzZSAocmUtZW1pdHMgREVDU1RCTSB3aXRoIGl0cyBvd24gdGltaW5nIGFuZFxuICAgICAgLy8gZG9lc24ndCBpbXBsZW1lbnQgREVDIDIwMjYsIHNvIFNZTkNfT1VUUFVUX1NVUFBPUlRFRCBpcyBmYWxzZSkuXG4gICAgICBTWU5DX09VVFBVVF9TVVBQT1JURUQsXG4gICAgKVxuICAgIGNvbnN0IGRpZmZNcyA9IHBlcmZvcm1hbmNlLm5vdygpIC0gdERpZmZcbiAgICAvLyBTd2FwIGJ1ZmZlcnNcbiAgICB0aGlzLmJhY2tGcmFtZSA9IHRoaXMuZnJvbnRGcmFtZVxuICAgIHRoaXMuZnJvbnRGcmFtZSA9IGZyYW1lXG5cbiAgICAvLyBQZXJpb2RpY2FsbHkgcmVzZXQgY2hhci9oeXBlcmxpbmsgcG9vbHMgdG8gcHJldmVudCB1bmJvdW5kZWQgZ3Jvd3RoXG4gICAgLy8gZHVyaW5nIGxvbmcgc2Vzc2lvbnMuIDUgbWludXRlcyBpcyBpbmZyZXF1ZW50IGVub3VnaCB0aGF0IHRoZSBPKGNlbGxzKVxuICAgIC8vIG1pZ3JhdGlvbiBjb3N0IGlzIG5lZ2xpZ2libGUuIFJldXNlcyByZW5kZXJTdGFydCB0byBhdm9pZCBleHRyYSBjbG9jayBjYWxsLlxuICAgIGlmIChyZW5kZXJTdGFydCAtIHRoaXMubGFzdFBvb2xSZXNldFRpbWUgPiA1ICogNjAgKiAxMDAwKSB7XG4gICAgICB0aGlzLnJlc2V0UG9vbHMoKVxuICAgICAgdGhpcy5sYXN0UG9vbFJlc2V0VGltZSA9IHJlbmRlclN0YXJ0XG4gICAgfVxuXG4gICAgY29uc3QgZmxpY2tlcnM6IEZyYW1lRXZlbnRbJ2ZsaWNrZXJzJ10gPSBbXVxuICAgIGZvciAoY29uc3QgcGF0Y2ggb2YgZGlmZikge1xuICAgICAgaWYgKHBhdGNoLnR5cGUgPT09ICdjbGVhclRlcm1pbmFsJykge1xuICAgICAgICBmbGlja2Vycy5wdXNoKHtcbiAgICAgICAgICBkZXNpcmVkSGVpZ2h0OiBmcmFtZS5zY3JlZW4uaGVpZ2h0LFxuICAgICAgICAgIGF2YWlsYWJsZUhlaWdodDogZnJhbWUudmlld3BvcnQuaGVpZ2h0LFxuICAgICAgICAgIHJlYXNvbjogcGF0Y2gucmVhc29uLFxuICAgICAgICB9KVxuICAgICAgICBpZiAoaXNEZWJ1Z1JlcGFpbnRzRW5hYmxlZCgpICYmIHBhdGNoLmRlYnVnKSB7XG4gICAgICAgICAgY29uc3QgY2hhaW4gPSBkb20uZmluZE93bmVyQ2hhaW5BdFJvdyhcbiAgICAgICAgICAgIHRoaXMucm9vdE5vZGUsXG4gICAgICAgICAgICBwYXRjaC5kZWJ1Zy50cmlnZ2VyWSxcbiAgICAgICAgICApXG4gICAgICAgICAgbG9nRm9yRGVidWdnaW5nKFxuICAgICAgICAgICAgYFtSRVBBSU5UXSBmdWxsIHJlc2V0IMK3ICR7cGF0Y2gucmVhc29ufSDCtyByb3cgJHtwYXRjaC5kZWJ1Zy50cmlnZ2VyWX1cXG5gICtcbiAgICAgICAgICAgICAgYCAgcHJldjogXCIke3BhdGNoLmRlYnVnLnByZXZMaW5lfVwiXFxuYCArXG4gICAgICAgICAgICAgIGAgIG5leHQ6IFwiJHtwYXRjaC5kZWJ1Zy5uZXh0TGluZX1cIlxcbmAgK1xuICAgICAgICAgICAgICBgICBjdWxwcml0OiAke2NoYWluLmxlbmd0aCA/IGNoYWluLmpvaW4oJyA8ICcpIDogJyhubyBvd25lciBjaGFpbiBjYXB0dXJlZCknfWAsXG4gICAgICAgICAgICB7IGxldmVsOiAnd2FybicgfSxcbiAgICAgICAgICApXG4gICAgICAgIH1cbiAgICAgIH1cbiAgICB9XG5cbiAgICBjb25zdCB0T3B0aW1pemUgPSBwZXJmb3JtYW5jZS5ub3coKVxuICAgIGNvbnN0IG9wdGltaXplZCA9IG9wdGltaXplKGRpZmYpXG4gICAgY29uc3Qgb3B0aW1pemVNcyA9IHBlcmZvcm1hbmNlLm5vdygpIC0gdE9wdGltaXplXG4gICAgY29uc3QgaGFzRGlmZiA9IG9wdGltaXplZC5sZW5ndGggPiAwXG4gICAgaWYgKHRoaXMuYWx0U2NyZWVuQWN0aXZlICYmIGhhc0RpZmYpIHtcbiAgICAgIC8vIFByZXBlbmQgQ1NJIEggdG8gYW5jaG9yIHRoZSBwaHlzaWNhbCBjdXJzb3IgdG8gKDAsMCkgc29cbiAgICAgIC8vIGxvZy11cGRhdGUncyByZWxhdGl2ZSBtb3ZlcyBjb21wdXRlIGZyb20gYSBrbm93biBzcG90IChzZWxmLWhlYWxpbmdcbiAgICAgIC8vIGFnYWluc3Qgb3V0LW9mLWJhbmQgY3Vyc29yIGRyaWZ0LCBzZWUgdGhlIEFMVF9TQ1JFRU5fQU5DSE9SX0NVUlNPUlxuICAgICAgLy8gY29tbWVudCBhYm92ZSkuIEFwcGVuZCBDU0kgcm93OzEgSCB0byBwYXJrIHRoZSBjdXJzb3IgYXQgdGhlIGJvdHRvbVxuICAgICAgLy8gcm93ICh3aGVyZSB0aGUgcHJvbXB0IGlucHV0IGlzKSDigJQgd2l0aG91dCB0aGlzLCB0aGUgY3Vyc29yIGVuZHNcbiAgICAgIC8vIHdoZXJldmVyIHRoZSBsYXN0IGRpZmYgd3JpdGUgbGFuZGVkIChhIGRpZmZlcmVudCByb3cgZXZlcnkgZnJhbWUpLFxuICAgICAgLy8gbWFraW5nIGlUZXJtMidzIGN1cnNvciBndWlkZSBmbGlja2VyIGFzIGl0IGNoYXNlcyB0aGUgY3Vyc29yLlxuICAgICAgLy8gQlNVL0VTVSBwcm90ZWN0cyBjb250ZW50IGF0b21pY2l0eSBidXQgaVRlcm0yJ3MgZ3VpZGUgdHJhY2tzIGN1cnNvclxuICAgICAgLy8gcG9zaXRpb24gaW5kZXBlbmRlbnRseS4gUGFya2luZyBhdCBib3R0b20gKG5vdCAwLDApIGtlZXBzIHRoZSBndWlkZVxuICAgICAgLy8gd2hlcmUgdGhlIHVzZXIncyBhdHRlbnRpb24gaXMuXG4gICAgICAvL1xuICAgICAgLy8gQWZ0ZXIgcmVzaXplLCBwcmVwZW5kIEVSQVNFX1NDUkVFTiB0b28uIFRoZSBkaWZmIG9ubHkgd3JpdGVzIGNlbGxzXG4gICAgICAvLyB0aGF0IGNoYW5nZWQ7IGNlbGxzIHdoZXJlIG5ldz1ibGFuayBhbmQgcHJldi1idWZmZXI9YmxhbmsgZ2V0IHNraXBwZWRcbiAgICAgIC8vIOKAlCBidXQgdGhlIHBoeXNpY2FsIHRlcm1pbmFsIHN0aWxsIGhhcyBzdGFsZSBjb250ZW50IHRoZXJlIChzaG9ydGVyXG4gICAgICAvLyBsaW5lcyBhdCBuZXcgd2lkdGggbGVhdmUgb2xkLXdpZHRoIHRleHQgdGFpbHMgdmlzaWJsZSkuIEVSQVNFIGluc2lkZVxuICAgICAgLy8gQlNVL0VTVSBpcyBhdG9taWM6IG9sZCBjb250ZW50IHN0YXlzIHZpc2libGUgdW50aWwgdGhlIHdob2xlXG4gICAgICAvLyBlcmFzZStwYWludCBsYW5kcywgdGhlbiBzd2FwcyBpbiBvbmUgZ28uIFdyaXRpbmcgRVJBU0VfU0NSRUVOXG4gICAgICAvLyBzeW5jaHJvbm91c2x5IGluIGhhbmRsZVJlc2l6ZSB3b3VsZCBibGFuayB0aGUgc2NyZWVuIGZvciB0aGUgfjgwbXNcbiAgICAgIC8vIHJlbmRlcigpIHRha2VzLlxuICAgICAgaWYgKHRoaXMubmVlZHNFcmFzZUJlZm9yZVBhaW50KSB7XG4gICAgICAgIHRoaXMubmVlZHNFcmFzZUJlZm9yZVBhaW50ID0gZmFsc2VcbiAgICAgICAgb3B0aW1pemVkLnVuc2hpZnQoRVJBU0VfVEhFTl9IT01FX1BBVENIKVxuICAgICAgfSBlbHNlIHtcbiAgICAgICAgb3B0aW1pemVkLnVuc2hpZnQoQ1VSU09SX0hPTUVfUEFUQ0gpXG4gICAgICB9XG4gICAgICBvcHRpbWl6ZWQucHVzaCh0aGlzLmFsdFNjcmVlblBhcmtQYXRjaClcbiAgICB9XG5cbiAgICAvLyBOYXRpdmUgY3Vyc29yIHBvc2l0aW9uaW5nOiBwYXJrIHRoZSB0ZXJtaW5hbCBjdXJzb3IgYXQgdGhlIGRlY2xhcmVkXG4gICAgLy8gcG9zaXRpb24gc28gSU1FIHByZWVkaXQgdGV4dCByZW5kZXJzIGlubGluZSBhbmQgc2NyZWVuIHJlYWRlcnMgL1xuICAgIC8vIG1hZ25pZmllcnMgY2FuIGZvbGxvdyB0aGUgaW5wdXQuIG5vZGVDYWNoZSBob2xkcyB0aGUgYWJzb2x1dGUgc2NyZWVuXG4gICAgLy8gcmVjdCBwb3B1bGF0ZWQgYnkgcmVuZGVyTm9kZVRvT3V0cHV0IHRoaXMgZnJhbWUgKGluY2x1ZGluZyBzY3JvbGxUb3BcbiAgICAvLyB0cmFuc2xhdGlvbikg4oCUIGlmIHRoZSBkZWNsYXJlZCBub2RlIGRpZG4ndCByZW5kZXIgKHN0YWxlIGRlY2xhcmF0aW9uXG4gICAgLy8gYWZ0ZXIgcmVtb3VudCwgb3Igc2Nyb2xsZWQgb3V0IG9mIHZpZXcpLCBpdCB3b24ndCBiZSBpbiB0aGUgY2FjaGVcbiAgICAvLyBhbmQgbm8gbW92ZSBpcyBlbWl0dGVkLlxuICAgIGNvbnN0IGRlY2wgPSB0aGlzLmN1cnNvckRlY2xhcmF0aW9uXG4gICAgY29uc3QgcmVjdCA9IGRlY2wgIT09IG51bGwgPyBub2RlQ2FjaGUuZ2V0KGRlY2wubm9kZSkgOiB1bmRlZmluZWRcbiAgICBjb25zdCB0YXJnZXQgPVxuICAgICAgZGVjbCAhPT0gbnVsbCAmJiByZWN0ICE9PSB1bmRlZmluZWRcbiAgICAgICAgPyB7IHg6IHJlY3QueCArIGRlY2wucmVsYXRpdmVYLCB5OiByZWN0LnkgKyBkZWNsLnJlbGF0aXZlWSB9XG4gICAgICAgIDogbnVsbFxuICAgIGNvbnN0IHBhcmtlZCA9IHRoaXMuZGlzcGxheUN1cnNvclxuXG4gICAgLy8gUHJlc2VydmUgdGhlIGVtcHR5LWRpZmYgemVyby13cml0ZSBmYXN0IHBhdGg6IHNraXAgYWxsIGN1cnNvciB3cml0ZXNcbiAgICAvLyB3aGVuIG5vdGhpbmcgcmVuZGVyZWQgQU5EIHRoZSBwYXJrIHRhcmdldCBpcyB1bmNoYW5nZWQuXG4gICAgY29uc3QgdGFyZ2V0TW92ZWQgPVxuICAgICAgdGFyZ2V0ICE9PSBudWxsICYmXG4gICAgICAocGFya2VkID09PSBudWxsIHx8IHBhcmtlZC54ICE9PSB0YXJnZXQueCB8fCBwYXJrZWQueSAhPT0gdGFyZ2V0LnkpXG4gICAgaWYgKGhhc0RpZmYgfHwgdGFyZ2V0TW92ZWQgfHwgKHRhcmdldCA9PT0gbnVsbCAmJiBwYXJrZWQgIT09IG51bGwpKSB7XG4gICAgICAvLyBNYWluLXNjcmVlbiBwcmVhbWJsZTogbG9nLXVwZGF0ZSdzIHJlbGF0aXZlIG1vdmVzIGFzc3VtZSB0aGVcbiAgICAgIC8vIHBoeXNpY2FsIGN1cnNvciBpcyBhdCBwcmV2RnJhbWUuY3Vyc29yLiBJZiBsYXN0IGZyYW1lIHBhcmtlZCBpdFxuICAgICAgLy8gZWxzZXdoZXJlLCBtb3ZlIGJhY2sgYmVmb3JlIHRoZSBkaWZmIHJ1bnMuIEFsdC1zY3JlZW4ncyBDU0kgSFxuICAgICAgLy8gYWxyZWFkeSByZXNldHMgdG8gKDAsMCkgc28gbm8gcHJlYW1ibGUgbmVlZGVkLlxuICAgICAgaWYgKHBhcmtlZCAhPT0gbnVsbCAmJiAhdGhpcy5hbHRTY3JlZW5BY3RpdmUgJiYgaGFzRGlmZikge1xuICAgICAgICBjb25zdCBwZHggPSBwcmV2RnJhbWUuY3Vyc29yLnggLSBwYXJrZWQueFxuICAgICAgICBjb25zdCBwZHkgPSBwcmV2RnJhbWUuY3Vyc29yLnkgLSBwYXJrZWQueVxuICAgICAgICBpZiAocGR4ICE9PSAwIHx8IHBkeSAhPT0gMCkge1xuICAgICAgICAgIG9wdGltaXplZC51bnNoaWZ0KHsgdHlwZTogJ3N0ZG91dCcsIGNvbnRlbnQ6IGN1cnNvck1vdmUocGR4LCBwZHkpIH0pXG4gICAgICAgIH1cbiAgICAgIH1cblxuICAgICAgaWYgKHRhcmdldCAhPT0gbnVsbCkge1xuICAgICAgICBpZiAodGhpcy5hbHRTY3JlZW5BY3RpdmUpIHtcbiAgICAgICAgICAvLyBBYnNvbHV0ZSBDVVAgKDEtaW5kZXhlZCk7IG5leHQgZnJhbWUncyBDU0kgSCByZXNldHMgcmVnYXJkbGVzcy5cbiAgICAgICAgICAvLyBFbWl0dGVkIGFmdGVyIGFsdFNjcmVlblBhcmtQYXRjaCBzbyB0aGUgZGVjbGFyZWQgcG9zaXRpb24gd2lucy5cbiAgICAgICAgICBjb25zdCByb3cgPSBNYXRoLm1pbihNYXRoLm1heCh0YXJnZXQueSArIDEsIDEpLCB0ZXJtaW5hbFJvd3MpXG4gICAgICAgICAgY29uc3QgY29sID0gTWF0aC5taW4oTWF0aC5tYXgodGFyZ2V0LnggKyAxLCAxKSwgdGVybWluYWxXaWR0aClcbiAgICAgICAgICBvcHRpbWl6ZWQucHVzaCh7IHR5cGU6ICdzdGRvdXQnLCBjb250ZW50OiBjdXJzb3JQb3NpdGlvbihyb3csIGNvbCkgfSlcbiAgICAgICAgfSBlbHNlIHtcbiAgICAgICAgICAvLyBBZnRlciB0aGUgZGlmZiAob3IgcHJlYW1ibGUpLCBjdXJzb3IgaXMgYXQgZnJhbWUuY3Vyc29yLiBJZiBub1xuICAgICAgICAgIC8vIGRpZmYgQU5EIHByZXZpb3VzbHkgcGFya2VkLCBpdCdzIHN0aWxsIGF0IHRoZSBvbGQgcGFyayBwb3NpdGlvblxuICAgICAgICAgIC8vIChsb2ctdXBkYXRlIHdyb3RlIG5vdGhpbmcpLiBPdGhlcndpc2UgaXQncyBhdCBmcmFtZS5jdXJzb3IuXG4gICAgICAgICAgY29uc3QgZnJvbSA9XG4gICAgICAgICAgICAhaGFzRGlmZiAmJiBwYXJrZWQgIT09IG51bGxcbiAgICAgICAgICAgICAgPyBwYXJrZWRcbiAgICAgICAgICAgICAgOiB7IHg6IGZyYW1lLmN1cnNvci54LCB5OiBmcmFtZS5jdXJzb3IueSB9XG4gICAgICAgICAgY29uc3QgZHggPSB0YXJnZXQueCAtIGZyb20ueFxuICAgICAgICAgIGNvbnN0IGR5ID0gdGFyZ2V0LnkgLSBmcm9tLnlcbiAgICAgICAgICBpZiAoZHggIT09IDAgfHwgZHkgIT09IDApIHtcbiAgICAgICAgICAgIG9wdGltaXplZC5wdXNoKHsgdHlwZTogJ3N0ZG91dCcsIGNvbnRlbnQ6IGN1cnNvck1vdmUoZHgsIGR5KSB9KVxuICAgICAgICAgIH1cbiAgICAgICAgfVxuICAgICAgICB0aGlzLmRpc3BsYXlDdXJzb3IgPSB0YXJnZXRcbiAgICAgIH0gZWxzZSB7XG4gICAgICAgIC8vIERlY2xhcmF0aW9uIGNsZWFyZWQgKGlucHV0IGJsdXIsIHVubW91bnQpLiBSZXN0b3JlIHBoeXNpY2FsIGN1cnNvclxuICAgICAgICAvLyB0byBmcmFtZS5jdXJzb3IgYmVmb3JlIGZvcmdldHRpbmcgdGhlIHBhcmsgcG9zaXRpb24g4oCUIG90aGVyd2lzZVxuICAgICAgICAvLyBkaXNwbGF5Q3Vyc29yPW51bGwgbGllcyBhYm91dCB3aGVyZSB0aGUgY3Vyc29yIGlzLCBhbmQgdGhlIE5FWFRcbiAgICAgICAgLy8gZnJhbWUncyBwcmVhbWJsZSAob3IgbG9nLXVwZGF0ZSdzIHJlbGF0aXZlIG1vdmVzKSBjb21wdXRlcyBmcm9tIGFcbiAgICAgICAgLy8gd3Jvbmcgc3BvdC4gVGhlIHByZWFtYmxlIGFib3ZlIGhhbmRsZXMgaGFzRGlmZjsgdGhpcyBoYW5kbGVzXG4gICAgICAgIC8vICFoYXNEaWZmIChlLmcuIGFjY2Vzc2liaWxpdHkgbW9kZSB3aGVyZSBibHVyIGRvZXNuJ3QgY2hhbmdlXG4gICAgICAgIC8vIHJlbmRlcmVkVmFsdWUgc2luY2UgaW52ZXJ0IGlzIGlkZW50aXR5KS5cbiAgICAgICAgaWYgKHBhcmtlZCAhPT0gbnVsbCAmJiAhdGhpcy5hbHRTY3JlZW5BY3RpdmUgJiYgIWhhc0RpZmYpIHtcbiAgICAgICAgICBjb25zdCByZHggPSBmcmFtZS5jdXJzb3IueCAtIHBhcmtlZC54XG4gICAgICAgICAgY29uc3QgcmR5ID0gZnJhbWUuY3Vyc29yLnkgLSBwYXJrZWQueVxuICAgICAgICAgIGlmIChyZHggIT09IDAgfHwgcmR5ICE9PSAwKSB7XG4gICAgICAgICAgICBvcHRpbWl6ZWQucHVzaCh7IHR5cGU6ICdzdGRvdXQnLCBjb250ZW50OiBjdXJzb3JNb3ZlKHJkeCwgcmR5KSB9KVxuICAgICAgICAgIH1cbiAgICAgICAgfVxuICAgICAgICB0aGlzLmRpc3BsYXlDdXJzb3IgPSBudWxsXG4gICAgICB9XG4gICAgfVxuXG4gICAgY29uc3QgdFdyaXRlID0gcGVyZm9ybWFuY2Uubm93KClcbiAgICB3cml0ZURpZmZUb1Rlcm1pbmFsKFxuICAgICAgdGhpcy50ZXJtaW5hbCxcbiAgICAgIG9wdGltaXplZCxcbiAgICAgIHRoaXMuYWx0U2NyZWVuQWN0aXZlICYmICFTWU5DX09VVFBVVF9TVVBQT1JURUQsXG4gICAgKVxuICAgIGNvbnN0IHdyaXRlTXMgPSBwZXJmb3JtYW5jZS5ub3coKSAtIHRXcml0ZVxuXG4gICAgLy8gVXBkYXRlIGJsaXQgc2FmZXR5IGZvciB0aGUgTkVYVCBmcmFtZS4gVGhlIGZyYW1lIGp1c3QgcmVuZGVyZWRcbiAgICAvLyBiZWNvbWVzIGZyb250RnJhbWUgKD0gbmV4dCBmcmFtZSdzIHByZXZTY3JlZW4pLiBJZiB3ZSBhcHBsaWVkIHRoZVxuICAgIC8vIHNlbGVjdGlvbiBvdmVybGF5LCB0aGF0IGJ1ZmZlciBoYXMgaW52ZXJ0ZWQgY2VsbHMuIHNlbEFjdGl2ZS9obEFjdGl2ZVxuICAgIC8vIGFyZSBvbmx5IGV2ZXIgdHJ1ZSBpbiBhbHQtc2NyZWVuOyBpbiBtYWluLXNjcmVlbiB0aGlzIGlzIGZhbHNl4oaSZmFsc2UuXG4gICAgdGhpcy5wcmV2RnJhbWVDb250YW1pbmF0ZWQgPSBzZWxBY3RpdmUgfHwgaGxBY3RpdmVcblxuICAgIC8vIEEgU2Nyb2xsQm94IGhhcyBwZW5kaW5nU2Nyb2xsRGVsdGEgbGVmdCB0byBkcmFpbiDigJQgc2NoZWR1bGUgdGhlIG5leHRcbiAgICAvLyBmcmFtZS4gTVVTVCBOT1QgY2FsbCB0aGlzLnNjaGVkdWxlUmVuZGVyKCkgaGVyZTogd2UncmUgaW5zaWRlIGFcbiAgICAvLyB0cmFpbGluZy1lZGdlIHRocm90dGxlIGludm9jYXRpb24sIHRpbWVySWQgaXMgdW5kZWZpbmVkLCBhbmQgbG9kYXNoJ3NcbiAgICAvLyBkZWJvdW5jZSBzZWVzIHRpbWVTaW5jZUxhc3RDYWxsID49IHdhaXQgKGxhc3QgY2FsbCB3YXMgYXQgdGhlIHN0YXJ0XG4gICAgLy8gb2YgdGhpcyB3aW5kb3cpIOKGkiBsZWFkaW5nRWRnZSBmaXJlcyBJTU1FRElBVEVMWSDihpIgZG91YmxlIHJlbmRlciB+MC4xbXNcbiAgICAvLyBhcGFydCDihpIgamFuay4gVXNlIGEgcGxhaW4gdGltZW91dC4gSWYgYSB3aGVlbCBldmVudCBhcnJpdmVzIGZpcnN0LFxuICAgIC8vIGl0cyBzY2hlZHVsZVJlbmRlciBwYXRoIGZpcmVzIGEgcmVuZGVyIHdoaWNoIGNsZWFycyB0aGlzIHRpbWVyIGF0XG4gICAgLy8gdGhlIHRvcCBvZiBvblJlbmRlciDigJQgbm8gZG91YmxlLlxuICAgIC8vXG4gICAgLy8gRHJhaW4gZnJhbWVzIGFyZSBjaGVhcCAoREVDU1RCTSArIH4xMCBwYXRjaGVzLCB+MjAwIGJ5dGVzKSBzbyBydW4gYXRcbiAgICAvLyBxdWFydGVyIGludGVydmFsICh+MjUwZnBzLCBzZXRUaW1lb3V0IHByYWN0aWNhbCBmbG9vcikgZm9yIG1heCBzY3JvbGxcbiAgICAvLyBzcGVlZC4gUmVndWxhciByZW5kZXJzIHN0YXkgYXQgRlJBTUVfSU5URVJWQUxfTVMgdmlhIHRoZSB0aHJvdHRsZS5cbiAgICBpZiAoZnJhbWUuc2Nyb2xsRHJhaW5QZW5kaW5nKSB7XG4gICAgICB0aGlzLmRyYWluVGltZXIgPSBzZXRUaW1lb3V0KFxuICAgICAgICAoKSA9PiB0aGlzLm9uUmVuZGVyKCksXG4gICAgICAgIEZSQU1FX0lOVEVSVkFMX01TID4+IDIsXG4gICAgICApXG4gICAgfVxuXG4gICAgY29uc3QgeW9nYU1zID0gZ2V0TGFzdFlvZ2FNcygpXG4gICAgY29uc3QgY29tbWl0TXMgPSBnZXRMYXN0Q29tbWl0TXMoKVxuICAgIGNvbnN0IHljID0gdGhpcy5sYXN0WW9nYUNvdW50ZXJzXG4gICAgLy8gUmVzZXQgc28gZHJhaW4tb25seSBmcmFtZXMgKG5vIFJlYWN0IGNvbW1pdCkgZG9uJ3QgcmVwZWF0IHN0YWxlIHZhbHVlcy5cbiAgICByZXNldFByb2ZpbGVDb3VudGVycygpXG4gICAgdGhpcy5sYXN0WW9nYUNvdW50ZXJzID0ge1xuICAgICAgbXM6IDAsXG4gICAgICB2aXNpdGVkOiAwLFxuICAgICAgbWVhc3VyZWQ6IDAsXG4gICAgICBjYWNoZUhpdHM6IDAsXG4gICAgICBsaXZlOiAwLFxuICAgIH1cbiAgICB0aGlzLm9wdGlvbnMub25GcmFtZT8uKHtcbiAgICAgIGR1cmF0aW9uTXM6IHBlcmZvcm1hbmNlLm5vdygpIC0gcmVuZGVyU3RhcnQsXG4gICAgICBwaGFzZXM6IHtcbiAgICAgICAgcmVuZGVyZXI6IHJlbmRlcmVyTXMsXG4gICAgICAgIGRpZmY6IGRpZmZNcyxcbiAgICAgICAgb3B0aW1pemU6IG9wdGltaXplTXMsXG4gICAgICAgIHdyaXRlOiB3cml0ZU1zLFxuICAgICAgICBwYXRjaGVzOiBkaWZmLmxlbmd0aCxcbiAgICAgICAgeW9nYTogeW9nYU1zLFxuICAgICAgICBjb21taXQ6IGNvbW1pdE1zLFxuICAgICAgICB5b2dhVmlzaXRlZDogeWMudmlzaXRlZCxcbiAgICAgICAgeW9nYU1lYXN1cmVkOiB5Yy5tZWFzdXJlZCxcbiAgICAgICAgeW9nYUNhY2hlSGl0czogeWMuY2FjaGVIaXRzLFxuICAgICAgICB5b2dhTGl2ZTogeWMubGl2ZSxcbiAgICAgIH0sXG4gICAgICBmbGlja2VycyxcbiAgICB9KVxuICB9XG5cbiAgcGF1c2UoKTogdm9pZCB7XG4gICAgLy8gRmx1c2ggcGVuZGluZyBSZWFjdCB1cGRhdGVzIGFuZCByZW5kZXIgYmVmb3JlIHBhdXNpbmcuXG4gICAgLy8gQHRzLWV4cGVjdC1lcnJvciBmbHVzaFN5bmNGcm9tUmVjb25jaWxlciBleGlzdHMgaW4gcmVhY3QtcmVjb25jaWxlciAwLjMxIGJ1dCBub3QgaW4gQHR5cGVzL3JlYWN0LXJlY29uY2lsZXJcbiAgICByZWNvbmNpbGVyLmZsdXNoU3luY0Zyb21SZWNvbmNpbGVyKClcbiAgICB0aGlzLm9uUmVuZGVyKClcblxuICAgIHRoaXMuaXNQYXVzZWQgPSB0cnVlXG4gIH1cblxuICByZXN1bWUoKTogdm9pZCB7XG4gICAgdGhpcy5pc1BhdXNlZCA9IGZhbHNlXG4gICAgdGhpcy5vblJlbmRlcigpXG4gIH1cblxuICAvKipcbiAgICogUmVzZXQgZnJhbWUgYnVmZmVycyBzbyB0aGUgbmV4dCByZW5kZXIgd3JpdGVzIHRoZSBmdWxsIHNjcmVlbiBmcm9tIHNjcmF0Y2guXG4gICAqIENhbGwgdGhpcyBiZWZvcmUgcmVzdW1lKCkgd2hlbiB0aGUgdGVybWluYWwgY29udGVudCBoYXMgYmVlbiBjb3JydXB0ZWQgYnlcbiAgICogYW4gZXh0ZXJuYWwgcHJvY2VzcyAoZS5nLiB0bXV4LCBzaGVsbCwgZnVsbC1zY3JlZW4gVFVJKS5cbiAgICovXG4gIHJlcGFpbnQoKTogdm9pZCB7XG4gICAgdGhpcy5mcm9udEZyYW1lID0gZW1wdHlGcmFtZShcbiAgICAgIHRoaXMuZnJvbnRGcmFtZS52aWV3cG9ydC5oZWlnaHQsXG4gICAgICB0aGlzLmZyb250RnJhbWUudmlld3BvcnQud2lkdGgsXG4gICAgICB0aGlzLnN0eWxlUG9vbCxcbiAgICAgIHRoaXMuY2hhclBvb2wsXG4gICAgICB0aGlzLmh5cGVybGlua1Bvb2wsXG4gICAgKVxuICAgIHRoaXMuYmFja0ZyYW1lID0gZW1wdHlGcmFtZShcbiAgICAgIHRoaXMuYmFja0ZyYW1lLnZpZXdwb3J0LmhlaWdodCxcbiAgICAgIHRoaXMuYmFja0ZyYW1lLnZpZXdwb3J0LndpZHRoLFxuICAgICAgdGhpcy5zdHlsZVBvb2wsXG4gICAgICB0aGlzLmNoYXJQb29sLFxuICAgICAgdGhpcy5oeXBlcmxpbmtQb29sLFxuICAgIClcbiAgICB0aGlzLmxvZy5yZXNldCgpXG4gICAgLy8gUGh5c2ljYWwgY3Vyc29yIHBvc2l0aW9uIGlzIHVua25vd24gYWZ0ZXIgZXh0ZXJuYWwgdGVybWluYWwgY29ycnVwdGlvbi5cbiAgICAvLyBDbGVhciBkaXNwbGF5Q3Vyc29yIHNvIHRoZSBjdXJzb3IgcHJlYW1ibGUgZG9lc24ndCBlbWl0IGEgc3RhbGVcbiAgICAvLyByZWxhdGl2ZSBtb3ZlIGZyb20gd2hlcmUgd2UgbGFzdCBwYXJrZWQgaXQuXG4gICAgdGhpcy5kaXNwbGF5Q3Vyc29yID0gbnVsbFxuICB9XG5cbiAgLyoqXG4gICAqIENsZWFyIHRoZSBwaHlzaWNhbCB0ZXJtaW5hbCBhbmQgZm9yY2UgYSBmdWxsIHJlZHJhdy5cbiAgICpcbiAgICogVGhlIHRyYWRpdGlvbmFsIHJlYWRsaW5lIGN0cmwrbCDigJQgY2xlYXJzIHRoZSB2aXNpYmxlIHNjcmVlbiBhbmRcbiAgICogcmVkcmF3cyB0aGUgY3VycmVudCBjb250ZW50LiBBbHNvIHRoZSByZWNvdmVyeSBwYXRoIHdoZW4gdGhlIHRlcm1pbmFsXG4gICAqIHdhcyBjbGVhcmVkIGV4dGVybmFsbHkgKG1hY09TIENtZCtLKSBhbmQgSW5rJ3MgZGlmZiBlbmdpbmUgdGhpbmtzXG4gICAqIHVuY2hhbmdlZCBjZWxscyBkb24ndCBuZWVkIHJlcGFpbnRpbmcuIFNjcm9sbGJhY2sgaXMgcHJlc2VydmVkLlxuICAgKi9cbiAgZm9yY2VSZWRyYXcoKTogdm9pZCB7XG4gICAgaWYgKCF0aGlzLm9wdGlvbnMuc3Rkb3V0LmlzVFRZIHx8IHRoaXMuaXNVbm1vdW50ZWQgfHwgdGhpcy5pc1BhdXNlZCkgcmV0dXJuXG4gICAgdGhpcy5vcHRpb25zLnN0ZG91dC53cml0ZShFUkFTRV9TQ1JFRU4gKyBDVVJTT1JfSE9NRSlcbiAgICBpZiAodGhpcy5hbHRTY3JlZW5BY3RpdmUpIHtcbiAgICAgIHRoaXMucmVzZXRGcmFtZXNGb3JBbHRTY3JlZW4oKVxuICAgIH0gZWxzZSB7XG4gICAgICB0aGlzLnJlcGFpbnQoKVxuICAgICAgLy8gcmVwYWludCgpIHJlc2V0cyBmcm9udEZyYW1lIHRvIDDDlzAuIFdpdGhvdXQgdGhpcyBmbGFnIHRoZSBuZXh0XG4gICAgICAvLyBmcmFtZSdzIGJsaXQgb3B0aW1pemF0aW9uIGNvcGllcyBmcm9tIHRoYXQgZW1wdHkgc2NyZWVuIGFuZCB0aGVcbiAgICAgIC8vIGRpZmYgc2VlcyBubyBjb250ZW50LiBvblJlbmRlciByZXNldHMgdGhlIGZsYWcgYXQgZnJhbWUgZW5kLlxuICAgICAgdGhpcy5wcmV2RnJhbWVDb250YW1pbmF0ZWQgPSB0cnVlXG4gICAgfVxuICAgIHRoaXMub25SZW5kZXIoKVxuICB9XG5cbiAgLyoqXG4gICAqIE1hcmsgdGhlIHByZXZpb3VzIGZyYW1lIGFzIHVudHJ1c3R3b3J0aHkgZm9yIGJsaXQsIGZvcmNpbmcgdGhlIG5leHRcbiAgICogcmVuZGVyIHRvIGRvIGEgZnVsbC1kYW1hZ2UgZGlmZiBpbnN0ZWFkIG9mIHRoZSBwZXItbm9kZSBmYXN0IHBhdGguXG4gICAqXG4gICAqIExpZ2h0ZXIgdGhhbiBmb3JjZVJlZHJhdygpIOKAlCBubyBzY3JlZW4gY2xlYXIsIG5vIGV4dHJhIHdyaXRlLiBDYWxsXG4gICAqIGZyb20gYSB1c2VMYXlvdXRFZmZlY3QgY2xlYW51cCB3aGVuIHVubW91bnRpbmcgYSB0YWxsIG92ZXJsYXk6IHRoZVxuICAgKiBibGl0IGZhc3QgcGF0aCBjYW4gY29weSBzdGFsZSBjZWxscyBmcm9tIHRoZSBvdmVybGF5IGZyYW1lIGludG8gcm93c1xuICAgKiB0aGUgc2hydW5rZW4gbGF5b3V0IG5vIGxvbmdlciByZWFjaGVzLCBsZWF2aW5nIGEgZ2hvc3QgdGl0bGUvZGl2aWRlci5cbiAgICogb25SZW5kZXIgcmVzZXRzIHRoZSBmbGFnIGF0IGZyYW1lIGVuZCBzbyBpdCdzIG9uZS1zaG90LlxuICAgKi9cbiAgaW52YWxpZGF0ZVByZXZGcmFtZSgpOiB2b2lkIHtcbiAgICB0aGlzLnByZXZGcmFtZUNvbnRhbWluYXRlZCA9IHRydWVcbiAgfVxuXG4gIC8qKlxuICAgKiBDYWxsZWQgYnkgdGhlIDxBbHRlcm5hdGVTY3JlZW4+IGNvbXBvbmVudCBvbiBtb3VudC91bm1vdW50LlxuICAgKiBDb250cm9scyBjdXJzb3IueSBjbGFtcGluZyBpbiB0aGUgcmVuZGVyZXIgYW5kIGdhdGVzIGFsdC1zY3JlZW4tYXdhcmVcbiAgICogYmVoYXZpb3IgaW4gU0lHQ09OVC9yZXNpemUvdW5tb3VudCBoYW5kbGVycy4gUmVwYWludHMgb24gY2hhbmdlIHNvXG4gICAqIHRoZSBmaXJzdCBhbHQtc2NyZWVuIGZyYW1lIChhbmQgZmlyc3QgbWFpbi1zY3JlZW4gZnJhbWUgb24gZXhpdCkgaXNcbiAgICogYSBmdWxsIHJlZHJhdyB3aXRoIG5vIHN0YWxlIGRpZmYgc3RhdGUuXG4gICAqL1xuICBzZXRBbHRTY3JlZW5BY3RpdmUoYWN0aXZlOiBib29sZWFuLCBtb3VzZVRyYWNraW5nID0gZmFsc2UpOiB2b2lkIHtcbiAgICBpZiAodGhpcy5hbHRTY3JlZW5BY3RpdmUgPT09IGFjdGl2ZSkgcmV0dXJuXG4gICAgdGhpcy5hbHRTY3JlZW5BY3RpdmUgPSBhY3RpdmVcbiAgICB0aGlzLmFsdFNjcmVlbk1vdXNlVHJhY2tpbmcgPSBhY3RpdmUgJiYgbW91c2VUcmFja2luZ1xuICAgIGlmIChhY3RpdmUpIHtcbiAgICAgIHRoaXMucmVzZXRGcmFtZXNGb3JBbHRTY3JlZW4oKVxuICAgIH0gZWxzZSB7XG4gICAgICB0aGlzLnJlcGFpbnQoKVxuICAgIH1cbiAgfVxuXG4gIGdldCBpc0FsdFNjcmVlbkFjdGl2ZSgpOiBib29sZWFuIHtcbiAgICByZXR1cm4gdGhpcy5hbHRTY3JlZW5BY3RpdmVcbiAgfVxuXG4gIC8qKlxuICAgKiBSZS1hc3NlcnQgdGVybWluYWwgbW9kZXMgYWZ0ZXIgYSBnYXAgKD41cyBzdGRpbiBzaWxlbmNlIG9yIGV2ZW50LWxvb3BcbiAgICogc3RhbGwpLiBDYXRjaGVzIHRtdXggZGV0YWNo4oaSYXR0YWNoLCBzc2ggcmVjb25uZWN0LCBhbmQgbGFwdG9wXG4gICAqIHNsZWVwL3dha2Ug4oCUIG5vbmUgb2Ygd2hpY2ggc2VuZCBTSUdDT05ULiBUaGUgdGVybWluYWwgbWF5IHJlc2V0IERFQ1xuICAgKiBwcml2YXRlIG1vZGVzIG9uIHJlY29ubmVjdDsgdGhpcyBtZXRob2QgcmVzdG9yZXMgdGhlbS5cbiAgICpcbiAgICogQWx3YXlzIHJlLWFzc2VydHMgZXh0ZW5kZWQga2V5IHJlcG9ydGluZyBhbmQgbW91c2UgdHJhY2tpbmcuIE1vdXNlXG4gICAqIHRyYWNraW5nIGlzIGlkZW1wb3RlbnQgKERFQyBwcml2YXRlIG1vZGUgc2V0LXdoZW4tc2V0IGlzIGEgbm8tb3ApLiBUaGVcbiAgICogS2l0dHkga2V5Ym9hcmQgcHJvdG9jb2wgaXMgTk9UIOKAlCBDU0kgPjF1IGlzIGEgc3RhY2sgcHVzaCwgc28gd2UgcG9wXG4gICAqIGZpcnN0IHRvIGtlZXAgZGVwdGggYmFsYW5jZWQgKHBvcCBvbiBlbXB0eSBzdGFjayBpcyBhIG5vLW9wIHBlciBzcGVjLFxuICAgKiBzbyBhZnRlciBhIHRlcm1pbmFsIHJlc2V0IHRoaXMgc3RpbGwgcmVzdG9yZXMgZGVwdGggMOKGkjEpLiBXaXRob3V0IHRoZVxuICAgKiBwb3AsIGVhY2ggPjVzIGlkbGUgZ2FwIGFkZHMgYSBzdGFjayBlbnRyeSwgYW5kIHRoZSBzaW5nbGUgcG9wIG9uIGV4aXRcbiAgICogb3Igc3VzcGVuZCBjYW4ndCBkcmFpbiB0aGVtIOKAlCB0aGUgc2hlbGwgaXMgbGVmdCBpbiBDU0kgdSBtb2RlIHdoZXJlXG4gICAqIEN0cmwrQy9DdHJsK0QgbGVhayBhcyBlc2NhcGUgc2VxdWVuY2VzLiBUaGUgYWx0LXNjcmVlblxuICAgKiByZS1lbnRyeSAoRVJBU0VfU0NSRUVOICsgZnJhbWUgcmVzZXQpIGlzIE5PVCBpZGVtcG90ZW50IOKAlCBpdCBibGFua3MgdGhlXG4gICAqIHNjcmVlbiDigJQgc28gaXQncyBvcHQtaW4gdmlhIGluY2x1ZGVBbHRTY3JlZW4uIFRoZSBzdGRpbi1nYXAgY2FsbGVyIGZpcmVzXG4gICAqIG9uIG9yZGluYXJ5ID41cyBpZGxlICsga2V5cHJlc3MgYW5kIG11c3Qgbm90IGVyYXNlOyB0aGUgZXZlbnQtbG9vcCBzdGFsbFxuICAgKiBkZXRlY3RvciBmaXJlcyBvbiBnZW51aW5lIHNsZWVwL3dha2UgYW5kIG9wdHMgaW4uIHRtdXggYXR0YWNoIC8gc3NoXG4gICAqIHJlY29ubmVjdCB0eXBpY2FsbHkgc2VuZCBhIHJlc2l6ZSwgd2hpY2ggYWxyZWFkeSBjb3ZlcnMgYWx0LXNjcmVlbiB2aWFcbiAgICogaGFuZGxlUmVzaXplLlxuICAgKi9cbiAgcmVhc3NlcnRUZXJtaW5hbE1vZGVzID0gKGluY2x1ZGVBbHRTY3JlZW4gPSBmYWxzZSk6IHZvaWQgPT4ge1xuICAgIGlmICghdGhpcy5vcHRpb25zLnN0ZG91dC5pc1RUWSkgcmV0dXJuXG4gICAgLy8gRG9uJ3QgdG91Y2ggdGhlIHRlcm1pbmFsIGR1cmluZyBhbiBlZGl0b3IgaGFuZG9mZiDigJQgcmUtZW5hYmxpbmcga2l0dHlcbiAgICAvLyBrZXlib2FyZCBoZXJlIHdvdWxkIHVuZG8gZW50ZXJBbHRlcm5hdGVTY3JlZW4ncyBkaXNhYmxlIGFuZCBuYW5vIHdvdWxkXG4gICAgLy8gc3RhcnQgc2VlaW5nIENTSS11IHNlcXVlbmNlcyBhZ2Fpbi5cbiAgICBpZiAodGhpcy5pc1BhdXNlZCkgcmV0dXJuXG4gICAgLy8gRXh0ZW5kZWQga2V5cyDigJQgcmUtYXNzZXJ0IGlmIGVuYWJsZWQgKEFwcC50c3ggZW5hYmxlcyB0aGVzZSBvblxuICAgIC8vIGFsbG93bGlzdGVkIHRlcm1pbmFscyBhdCByYXctbW9kZSBlbnRyeTsgYSB0ZXJtaW5hbCByZXNldCBjbGVhcnMgdGhlbSkuXG4gICAgLy8gUG9wLWJlZm9yZS1wdXNoIGtlZXBzIEtpdHR5IHN0YWNrIGRlcHRoIGF0IDEgaW5zdGVhZCBvZiBhY2N1bXVsYXRpbmdcbiAgICAvLyBvbiBlYWNoIGNhbGwuXG4gICAgaWYgKHN1cHBvcnRzRXh0ZW5kZWRLZXlzKCkpIHtcbiAgICAgIHRoaXMub3B0aW9ucy5zdGRvdXQud3JpdGUoXG4gICAgICAgIERJU0FCTEVfS0lUVFlfS0VZQk9BUkQgK1xuICAgICAgICAgIEVOQUJMRV9LSVRUWV9LRVlCT0FSRCArXG4gICAgICAgICAgRU5BQkxFX01PRElGWV9PVEhFUl9LRVlTLFxuICAgICAgKVxuICAgIH1cbiAgICBpZiAoIXRoaXMuYWx0U2NyZWVuQWN0aXZlKSByZXR1cm5cbiAgICAvLyBNb3VzZSB0cmFja2luZyDigJQgaWRlbXBvdGVudCwgc2FmZSB0byByZS1hc3NlcnQgb24gZXZlcnkgc3RkaW4gZ2FwLlxuICAgIGlmICh0aGlzLmFsdFNjcmVlbk1vdXNlVHJhY2tpbmcpIHtcbiAgICAgIHRoaXMub3B0aW9ucy5zdGRvdXQud3JpdGUoRU5BQkxFX01PVVNFX1RSQUNLSU5HKVxuICAgIH1cbiAgICAvLyBBbHQtc2NyZWVuIHJlLWVudHJ5IOKAlCBkZXN0cnVjdGl2ZSAoRVJBU0VfU0NSRUVOKS4gT25seSBmb3IgY2FsbGVycyB0aGF0XG4gICAgLy8gaGF2ZSBhIHN0cm9uZyBzaWduYWwgdGhlIHRlcm1pbmFsIGFjdHVhbGx5IGRyb3BwZWQgbW9kZSAxMDQ5LlxuICAgIGlmIChpbmNsdWRlQWx0U2NyZWVuKSB7XG4gICAgICB0aGlzLnJlZW50ZXJBbHRTY3JlZW4oKVxuICAgIH1cbiAgfVxuXG4gIC8qKlxuICAgKiBNYXJrIHRoaXMgaW5zdGFuY2UgYXMgdW5tb3VudGVkIHNvIGZ1dHVyZSB1bm1vdW50KCkgY2FsbHMgZWFybHktcmV0dXJuLlxuICAgKiBDYWxsZWQgYnkgZ3JhY2VmdWxTaHV0ZG93bidzIGNsZWFudXBUZXJtaW5hbE1vZGVzKCkgYWZ0ZXIgaXQgaGFzIHNlbnRcbiAgICogRVhJVF9BTFRfU0NSRUVOIGJ1dCBiZWZvcmUgdGhlIHJlbWFpbmluZyB0ZXJtaW5hbC1yZXNldCBzZXF1ZW5jZXMuXG4gICAqIFdpdGhvdXQgdGhpcywgc2lnbmFsLWV4aXQncyBkZWZlcnJlZCBpbmsudW5tb3VudCgpICh0cmlnZ2VyZWQgYnlcbiAgICogcHJvY2Vzcy5leGl0KCkpIHJ1bnMgdGhlIGZ1bGwgdW5tb3VudCBwYXRoOiBvblJlbmRlcigpICsgd3JpdGVTeW5jXG4gICAqIGNsZWFudXAgYmxvY2sgKyB1cGRhdGVDb250YWluZXJTeW5jIOKGkiBBbHRlcm5hdGVTY3JlZW4gdW5tb3VudCBjbGVhbnVwLlxuICAgKiBUaGUgcmVzdWx0IGlzIDItMyByZWR1bmRhbnQgRVhJVF9BTFRfU0NSRUVOIHNlcXVlbmNlcyBsYW5kaW5nIG9uIHRoZVxuICAgKiBtYWluIHNjcmVlbiBBRlRFUiBwcmludFJlc3VtZUhpbnQoKSwgd2hpY2ggdG11eCAoYXQgbGVhc3QpIGludGVycHJldHNcbiAgICogYXMgcmVzdG9yaW5nIHRoZSBzYXZlZCBjdXJzb3IgcG9zaXRpb24g4oCUIGNsb2JiZXJpbmcgdGhlIHJlc3VtZSBoaW50LlxuICAgKi9cbiAgZGV0YWNoRm9yU2h1dGRvd24oKTogdm9pZCB7XG4gICAgdGhpcy5pc1VubW91bnRlZCA9IHRydWVcbiAgICAvLyBDYW5jZWwgYW55IHBlbmRpbmcgdGhyb3R0bGVkIHJlbmRlciBzbyBpdCBkb2Vzbid0IGZpcmUgYmV0d2VlblxuICAgIC8vIGNsZWFudXBUZXJtaW5hbE1vZGVzKCkgYW5kIHByb2Nlc3MuZXhpdCgpIGFuZCB3cml0ZSB0byBtYWluIHNjcmVlbi5cbiAgICB0aGlzLnNjaGVkdWxlUmVuZGVyLmNhbmNlbD8uKClcbiAgICAvLyBSZXN0b3JlIHN0ZGluIGZyb20gcmF3IG1vZGUuIHVubW91bnQoKSB1c2VkIHRvIGRvIHRoaXMgdmlhIFJlYWN0XG4gICAgLy8gdW5tb3VudCAoQXBwLmNvbXBvbmVudFdpbGxVbm1vdW50IOKGkiBoYW5kbGVTZXRSYXdNb2RlKGZhbHNlKSkgYnV0IHdlJ3JlXG4gICAgLy8gc2hvcnQtY2lyY3VpdGluZyB0aGF0IHBhdGguIE11c3QgdXNlIHRoaXMub3B0aW9ucy5zdGRpbiDigJQgTk9UXG4gICAgLy8gcHJvY2Vzcy5zdGRpbiDigJQgYmVjYXVzZSBnZXRTdGRpbk92ZXJyaWRlKCkgbWF5IGhhdmUgb3BlbmVkIC9kZXYvdHR5XG4gICAgLy8gd2hlbiBzdGRpbiBpcyBwaXBlZC5cbiAgICBjb25zdCBzdGRpbiA9IHRoaXMub3B0aW9ucy5zdGRpbiBhcyBOb2RlSlMuUmVhZFN0cmVhbSAmIHtcbiAgICAgIGlzUmF3PzogYm9vbGVhblxuICAgICAgc2V0UmF3TW9kZT86IChtOiBib29sZWFuKSA9PiB2b2lkXG4gICAgfVxuICAgIHRoaXMuZHJhaW5TdGRpbigpXG4gICAgaWYgKHN0ZGluLmlzVFRZICYmIHN0ZGluLmlzUmF3ICYmIHN0ZGluLnNldFJhd01vZGUpIHtcbiAgICAgIHN0ZGluLnNldFJhd01vZGUoZmFsc2UpXG4gICAgfVxuICB9XG5cbiAgLyoqIEBzZWUgZHJhaW5TdGRpbiAqL1xuICBkcmFpblN0ZGluKCk6IHZvaWQge1xuICAgIGRyYWluU3RkaW4odGhpcy5vcHRpb25zLnN0ZGluKVxuICB9XG5cbiAgLyoqXG4gICAqIFJlLWVudGVyIGFsdC1zY3JlZW4sIGNsZWFyLCBob21lLCByZS1lbmFibGUgbW91c2UgdHJhY2tpbmcsIGFuZCByZXNldFxuICAgKiBmcmFtZSBidWZmZXJzIHNvIHRoZSBuZXh0IHJlbmRlciByZXBhaW50cyBmcm9tIHNjcmF0Y2guIFNlbGYtaGVhbCBmb3JcbiAgICogU0lHQ09OVCwgcmVzaXplLCBhbmQgc3RkaW4tZ2FwL2V2ZW50LWxvb3Atc3RhbGwgKHNsZWVwL3dha2UpIOKAlCBhbnkgb2ZcbiAgICogd2hpY2ggY2FuIGxlYXZlIHRoZSB0ZXJtaW5hbCBpbiBtYWluLXNjcmVlbiBtb2RlIHdoaWxlIGFsdFNjcmVlbkFjdGl2ZVxuICAgKiBzdGF5cyB0cnVlLiBFTlRFUl9BTFRfU0NSRUVOIGlzIGEgdGVybWluYWwtc2lkZSBuby1vcCBpZiBhbHJlYWR5IGluIGFsdC5cbiAgICovXG4gIHByaXZhdGUgcmVlbnRlckFsdFNjcmVlbigpOiB2b2lkIHtcbiAgICB0aGlzLm9wdGlvbnMuc3Rkb3V0LndyaXRlKFxuICAgICAgRU5URVJfQUxUX1NDUkVFTiArXG4gICAgICAgIEVSQVNFX1NDUkVFTiArXG4gICAgICAgIENVUlNPUl9IT01FICtcbiAgICAgICAgKHRoaXMuYWx0U2NyZWVuTW91c2VUcmFja2luZyA/IEVOQUJMRV9NT1VTRV9UUkFDS0lORyA6ICcnKSxcbiAgICApXG4gICAgdGhpcy5yZXNldEZyYW1lc0ZvckFsdFNjcmVlbigpXG4gIH1cblxuICAvKipcbiAgICogU2VlZCBwcmV2L2JhY2sgZnJhbWVzIHdpdGggZnVsbC1zaXplIEJMQU5LIHNjcmVlbnMgKHJvd3PDl2NvbHMgb2YgZW1wdHlcbiAgICogY2VsbHMsIG5vdCAww5cwKS4gSW4gYWx0LXNjcmVlbiBtb2RlLCBuZXh0LnNjcmVlbi5oZWlnaHQgaXMgYWx3YXlzXG4gICAqIHRlcm1pbmFsUm93czsgaWYgcHJldi5zY3JlZW4uaGVpZ2h0IGlzIDAgKGVtcHR5RnJhbWUncyBkZWZhdWx0KSxcbiAgICogbG9nLXVwZGF0ZSBzZWVzIGhlaWdodERlbHRhID4gMCAoJ2dyb3dpbmcnKSBhbmQgY2FsbHMgcmVuZGVyRnJhbWVTbGljZSxcbiAgICogd2hvc2UgdHJhaWxpbmcgcGVyLXJvdyBDUitMRiBhdCB0aGUgbGFzdCByb3cgc2Nyb2xscyB0aGUgYWx0IHNjcmVlbixcbiAgICogcGVybWFuZW50bHkgZGVzeW5jaW5nIHRoZSB2aXJ0dWFsIGFuZCBwaHlzaWNhbCBjdXJzb3JzIGJ5IDEgcm93LlxuICAgKlxuICAgKiBXaXRoIGEgcm93c8OXY29scyBibGFuayBwcmV2LCBoZWlnaHREZWx0YSA9PT0gMCDihpIgc3RhbmRhcmQgZGlmZkVhY2hcbiAgICog4oaSIG1vdmVDdXJzb3JUbyAoQ1NJIGN1cnNvck1vdmUsIG5vIExGLCBubyBzY3JvbGwpLlxuICAgKlxuICAgKiB2aWV3cG9ydC5oZWlnaHQgPSByb3dzICsgMSBtYXRjaGVzIHRoZSByZW5kZXJlcidzIGFsdC1zY3JlZW4gb3V0cHV0LFxuICAgKiBwcmV2ZW50aW5nIGEgc3B1cmlvdXMgcmVzaXplIHRyaWdnZXIgb24gdGhlIGZpcnN0IGZyYW1lLiBjdXJzb3IueSA9IDBcbiAgICogbWF0Y2hlcyB0aGUgcGh5c2ljYWwgY3Vyc29yIGFmdGVyIEVOVEVSX0FMVF9TQ1JFRU4gKyBDU0kgSCAoaG9tZSkuXG4gICAqL1xuICBwcml2YXRlIHJlc2V0RnJhbWVzRm9yQWx0U2NyZWVuKCk6IHZvaWQge1xuICAgIGNvbnN0IHJvd3MgPSB0aGlzLnRlcm1pbmFsUm93c1xuICAgIGNvbnN0IGNvbHMgPSB0aGlzLnRlcm1pbmFsQ29sdW1uc1xuICAgIGNvbnN0IGJsYW5rID0gKCk6IEZyYW1lID0+ICh7XG4gICAgICBzY3JlZW46IGNyZWF0ZVNjcmVlbihcbiAgICAgICAgY29scyxcbiAgICAgICAgcm93cyxcbiAgICAgICAgdGhpcy5zdHlsZVBvb2wsXG4gICAgICAgIHRoaXMuY2hhclBvb2wsXG4gICAgICAgIHRoaXMuaHlwZXJsaW5rUG9vbCxcbiAgICAgICksXG4gICAgICB2aWV3cG9ydDogeyB3aWR0aDogY29scywgaGVpZ2h0OiByb3dzICsgMSB9LFxuICAgICAgY3Vyc29yOiB7IHg6IDAsIHk6IDAsIHZpc2libGU6IHRydWUgfSxcbiAgICB9KVxuICAgIHRoaXMuZnJvbnRGcmFtZSA9IGJsYW5rKClcbiAgICB0aGlzLmJhY2tGcmFtZSA9IGJsYW5rKClcbiAgICB0aGlzLmxvZy5yZXNldCgpXG4gICAgLy8gRGVmZW5zZS1pbi1kZXB0aDogYWx0LXNjcmVlbiBza2lwcyB0aGUgY3Vyc29yIHByZWFtYmxlIGFueXdheSAoQ1NJIEhcbiAgICAvLyByZXNldHMpLCBidXQgYSBzdGFsZSBkaXNwbGF5Q3Vyc29yIHdvdWxkIGJlIG1pc2xlYWRpbmcgaWYgd2UgbGF0ZXJcbiAgICAvLyBleGl0IHRvIG1haW4tc2NyZWVuIHdpdGhvdXQgYW4gaW50ZXJ2ZW5pbmcgcmVuZGVyLlxuICAgIHRoaXMuZGlzcGxheUN1cnNvciA9IG51bGxcbiAgICAvLyBGcmVzaCBmcm9udEZyYW1lIGlzIGJsYW5rIHJvd3PDl2NvbHMg4oCUIGJsaXR0aW5nIGZyb20gaXQgd291bGQgY29weVxuICAgIC8vIGJsYW5rcyBvdmVyIGNvbnRlbnQuIE5leHQgYWx0LXNjcmVlbiBmcmFtZSBtdXN0IGZ1bGwtcmVuZGVyLlxuICAgIHRoaXMucHJldkZyYW1lQ29udGFtaW5hdGVkID0gdHJ1ZVxuICB9XG5cbiAgLyoqXG4gICAqIENvcHkgdGhlIGN1cnJlbnQgc2VsZWN0aW9uIHRvIHRoZSBjbGlwYm9hcmQgd2l0aG91dCBjbGVhcmluZyB0aGVcbiAgICogaGlnaGxpZ2h0LiBNYXRjaGVzIGlUZXJtMidzIGNvcHktb24tc2VsZWN0IGJlaGF2aW9yIHdoZXJlIHRoZSBzZWxlY3RlZFxuICAgKiByZWdpb24gc3RheXMgdmlzaWJsZSBhZnRlciB0aGUgYXV0b21hdGljIGNvcHkuXG4gICAqL1xuICBjb3B5U2VsZWN0aW9uTm9DbGVhcigpOiBzdHJpbmcge1xuICAgIGlmICghaGFzU2VsZWN0aW9uKHRoaXMuc2VsZWN0aW9uKSkgcmV0dXJuICcnXG4gICAgY29uc3QgdGV4dCA9IGdldFNlbGVjdGVkVGV4dCh0aGlzLnNlbGVjdGlvbiwgdGhpcy5mcm9udEZyYW1lLnNjcmVlbilcbiAgICBpZiAodGV4dCkge1xuICAgICAgLy8gUmF3IE9TQyA1Miwgb3IgRENTLXBhc3N0aHJvdWdoLXdyYXBwZWQgT1NDIDUyIGluc2lkZSB0bXV4ICh0bXV4XG4gICAgICAvLyBkcm9wcyBpdCBzaWxlbnRseSB1bmxlc3MgYWxsb3ctcGFzc3Rocm91Z2ggaXMgb24g4oCUIG5vIHJlZ3Jlc3Npb24pLlxuICAgICAgdm9pZCBzZXRDbGlwYm9hcmQodGV4dCkudGhlbihyYXcgPT4ge1xuICAgICAgICBpZiAocmF3KSB0aGlzLm9wdGlvbnMuc3Rkb3V0LndyaXRlKHJhdylcbiAgICAgIH0pXG4gICAgfVxuICAgIHJldHVybiB0ZXh0XG4gIH1cblxuICAvKipcbiAgICogQ29weSB0aGUgY3VycmVudCB0ZXh0IHNlbGVjdGlvbiB0byB0aGUgc3lzdGVtIGNsaXBib2FyZCB2aWEgT1NDIDUyXG4gICAqIGFuZCBjbGVhciB0aGUgc2VsZWN0aW9uLiBSZXR1cm5zIHRoZSBjb3BpZWQgdGV4dCAoZW1wdHkgaWYgbm8gc2VsZWN0aW9uKS5cbiAgICovXG4gIGNvcHlTZWxlY3Rpb24oKTogc3RyaW5nIHtcbiAgICBpZiAoIWhhc1NlbGVjdGlvbih0aGlzLnNlbGVjdGlvbikpIHJldHVybiAnJ1xuICAgIGNvbnN0IHRleHQgPSB0aGlzLmNvcHlTZWxlY3Rpb25Ob0NsZWFyKClcbiAgICBjbGVhclNlbGVjdGlvbih0aGlzLnNlbGVjdGlvbilcbiAgICB0aGlzLm5vdGlmeVNlbGVjdGlvbkNoYW5nZSgpXG4gICAgcmV0dXJuIHRleHRcbiAgfVxuXG4gIC8qKiBDbGVhciB0aGUgY3VycmVudCB0ZXh0IHNlbGVjdGlvbiB3aXRob3V0IGNvcHlpbmcuICovXG4gIGNsZWFyVGV4dFNlbGVjdGlvbigpOiB2b2lkIHtcbiAgICBpZiAoIWhhc1NlbGVjdGlvbih0aGlzLnNlbGVjdGlvbikpIHJldHVyblxuICAgIGNsZWFyU2VsZWN0aW9uKHRoaXMuc2VsZWN0aW9uKVxuICAgIHRoaXMubm90aWZ5U2VsZWN0aW9uQ2hhbmdlKClcbiAgfVxuXG4gIC8qKlxuICAgKiBTZXQgdGhlIHNlYXJjaCBoaWdobGlnaHQgcXVlcnkuIE5vbi1lbXB0eSDihpIgYWxsIHZpc2libGUgb2NjdXJyZW5jZXNcbiAgICogYXJlIGludmVydGVkIChTR1IgNykgb24gdGhlIG5leHQgZnJhbWU7IGZpcnN0IG9uZSBhbHNvIHVuZGVybGluZWQuXG4gICAqIEVtcHR5IOKGkiBjbGVhcnMgKHByZXZGcmFtZUNvbnRhbWluYXRlZCBoYW5kbGVzIHRoZSBmcmFtZSBhZnRlcikuIFNhbWVcbiAgICogZGFtYWdlLXRyYWNraW5nIG1hY2hpbmVyeSBhcyBzZWxlY3Rpb24g4oCUIHNldENlbGxTdHlsZUlkIGRvZXNuJ3QgdHJhY2tcbiAgICogZGFtYWdlLCBzbyB0aGUgb3ZlcmxheSBmb3JjZXMgZnVsbC1mcmFtZSBkYW1hZ2Ugd2hpbGUgYWN0aXZlLlxuICAgKi9cbiAgc2V0U2VhcmNoSGlnaGxpZ2h0KHF1ZXJ5OiBzdHJpbmcpOiB2b2lkIHtcbiAgICBpZiAodGhpcy5zZWFyY2hIaWdobGlnaHRRdWVyeSA9PT0gcXVlcnkpIHJldHVyblxuICAgIHRoaXMuc2VhcmNoSGlnaGxpZ2h0UXVlcnkgPSBxdWVyeVxuICAgIHRoaXMuc2NoZWR1bGVSZW5kZXIoKVxuICB9XG5cbiAgLyoqIFBhaW50IGFuIEVYSVNUSU5HIERPTSBzdWJ0cmVlIHRvIGEgZnJlc2ggU2NyZWVuIGF0IGl0cyBuYXR1cmFsXG4gICAqICBoZWlnaHQsIHNjYW4gZm9yIHF1ZXJ5LiBSZXR1cm5zIHBvc2l0aW9ucyByZWxhdGl2ZSB0byB0aGUgZWxlbWVudCdzXG4gICAqICBib3VuZGluZyBib3ggKHJvdyAwID0gZWxlbWVudCB0b3ApLlxuICAgKlxuICAgKiAgVGhlIGVsZW1lbnQgY29tZXMgZnJvbSB0aGUgTUFJTiB0cmVlIOKAlCBidWlsdCB3aXRoIGFsbCByZWFsXG4gICAqICBwcm92aWRlcnMsIHlvZ2EgYWxyZWFkeSBjb21wdXRlZC4gV2UgcGFpbnQgaXQgdG8gYSBmcmVzaCBidWZmZXJcbiAgICogIHdpdGggb2Zmc2V0cyBzbyBpdCBsYW5kcyBhdCAoMCwwKS4gU2FtZSBwYWludCBwYXRoIGFzIHRoZSBtYWluXG4gICAqICByZW5kZXIuIFplcm8gZHJpZnQuIE5vIHNlY29uZCBSZWFjdCByb290LCBubyBjb250ZXh0IGJyaWRnZS5cbiAgICpcbiAgICogIH4xLTJtcyAocGFpbnQgb25seSwgbm8gcmVjb25jaWxlIOKAlCB0aGUgRE9NIGlzIGFscmVhZHkgYnVpbHQpLiAqL1xuICBzY2FuRWxlbWVudFN1YnRyZWUoZWw6IGRvbS5ET01FbGVtZW50KTogTWF0Y2hQb3NpdGlvbltdIHtcbiAgICBpZiAoIXRoaXMuc2VhcmNoSGlnaGxpZ2h0UXVlcnkgfHwgIWVsLnlvZ2FOb2RlKSByZXR1cm4gW11cbiAgICBjb25zdCB3aWR0aCA9IE1hdGguY2VpbChlbC55b2dhTm9kZS5nZXRDb21wdXRlZFdpZHRoKCkpXG4gICAgY29uc3QgaGVpZ2h0ID0gTWF0aC5jZWlsKGVsLnlvZ2FOb2RlLmdldENvbXB1dGVkSGVpZ2h0KCkpXG4gICAgaWYgKHdpZHRoIDw9IDAgfHwgaGVpZ2h0IDw9IDApIHJldHVybiBbXVxuICAgIC8vIHJlbmRlck5vZGVUb091dHB1dCBhZGRzIGVsJ3MgT1dOIGNvbXB1dGVkTGVmdC9Ub3AgdG8gb2Zmc2V0WC9ZLlxuICAgIC8vIFBhc3NpbmcgLWVsTGVmdC8tZWxUb3AgbmV0cyB0byAwIOKGkiBwYWludHMgYXQgKDAsMCkgaW4gb3VyIGJ1ZmZlci5cbiAgICBjb25zdCBlbExlZnQgPSBlbC55b2dhTm9kZS5nZXRDb21wdXRlZExlZnQoKVxuICAgIGNvbnN0IGVsVG9wID0gZWwueW9nYU5vZGUuZ2V0Q29tcHV0ZWRUb3AoKVxuICAgIGNvbnN0IHNjcmVlbiA9IGNyZWF0ZVNjcmVlbihcbiAgICAgIHdpZHRoLFxuICAgICAgaGVpZ2h0LFxuICAgICAgdGhpcy5zdHlsZVBvb2wsXG4gICAgICB0aGlzLmNoYXJQb29sLFxuICAgICAgdGhpcy5oeXBlcmxpbmtQb29sLFxuICAgIClcbiAgICBjb25zdCBvdXRwdXQgPSBuZXcgT3V0cHV0KHtcbiAgICAgIHdpZHRoLFxuICAgICAgaGVpZ2h0LFxuICAgICAgc3R5bGVQb29sOiB0aGlzLnN0eWxlUG9vbCxcbiAgICAgIHNjcmVlbixcbiAgICB9KVxuICAgIHJlbmRlck5vZGVUb091dHB1dChlbCwgb3V0cHV0LCB7XG4gICAgICBvZmZzZXRYOiAtZWxMZWZ0LFxuICAgICAgb2Zmc2V0WTogLWVsVG9wLFxuICAgICAgcHJldlNjcmVlbjogdW5kZWZpbmVkLFxuICAgIH0pXG4gICAgY29uc3QgcmVuZGVyZWQgPSBvdXRwdXQuZ2V0KClcbiAgICAvLyByZW5kZXJOb2RlVG9PdXRwdXQgd3JvdGUgb3VyIG9mZnNldCBwb3NpdGlvbnMgdG8gbm9kZUNhY2hlIOKAlFxuICAgIC8vIGNvcnJ1cHRzIHRoZSBtYWluIHJlbmRlciAoaXQnZCBibGl0IGZyb20gd3JvbmcgY29vcmRzKS4gTWFyayB0aGVcbiAgICAvLyBzdWJ0cmVlIGRpcnR5IHNvIHRoZSBuZXh0IG1haW4gcmVuZGVyIHJlcGFpbnRzICsgcmUtY2FjaGVzXG4gICAgLy8gY29ycmVjdGx5LiBPbmUgZXh0cmEgcGFpbnQgb2YgdGhpcyBtZXNzYWdlLCBidXQgY29ycmVjdCA+IGZhc3QuXG4gICAgZG9tLm1hcmtEaXJ0eShlbClcbiAgICBjb25zdCBwb3NpdGlvbnMgPSBzY2FuUG9zaXRpb25zKHJlbmRlcmVkLCB0aGlzLnNlYXJjaEhpZ2hsaWdodFF1ZXJ5KVxuICAgIGxvZ0ZvckRlYnVnZ2luZyhcbiAgICAgIGBzY2FuRWxlbWVudFN1YnRyZWU6IHE9JyR7dGhpcy5zZWFyY2hIaWdobGlnaHRRdWVyeX0nIGAgK1xuICAgICAgICBgZWw9JHt3aWR0aH14JHtoZWlnaHR9QCgke2VsTGVmdH0sJHtlbFRvcH0pIG49JHtwb3NpdGlvbnMubGVuZ3RofSBgICtcbiAgICAgICAgYFske3Bvc2l0aW9uc1xuICAgICAgICAgIC5zbGljZSgwLCAxMClcbiAgICAgICAgICAubWFwKHAgPT4gYCR7cC5yb3d9OiR7cC5jb2x9YClcbiAgICAgICAgICAuam9pbignLCcpfWAgK1xuICAgICAgICBgJHtwb3NpdGlvbnMubGVuZ3RoID4gMTAgPyAnLOKApicgOiAnJ31dYCxcbiAgICApXG4gICAgcmV0dXJuIHBvc2l0aW9uc1xuICB9XG5cbiAgLyoqIFNldCB0aGUgcG9zaXRpb24tYmFzZWQgaGlnaGxpZ2h0IHN0YXRlLiBFdmVyeSBmcmFtZSwgd3JpdGVzIENVUlJFTlRcbiAgICogIHN0eWxlIGF0IHBvc2l0aW9uc1tjdXJyZW50SWR4XSArIHJvd09mZnNldC4gbnVsbCBjbGVhcnMuIFRoZSBzY2FuLVxuICAgKiAgaGlnaGxpZ2h0IChpbnZlcnNlIG9uIGFsbCBtYXRjaGVzKSBzdGlsbCBydW5zIOKAlCB0aGlzIG92ZXJsYXlzIHllbGxvd1xuICAgKiAgb24gdG9wLiByb3dPZmZzZXQgY2hhbmdlcyBhcyB0aGUgdXNlciBzY3JvbGxzICg9IG1lc3NhZ2UncyBjdXJyZW50XG4gICAqICBzY3JlZW4tdG9wKTsgcG9zaXRpb25zIHN0YXkgc3RhYmxlIChtZXNzYWdlLXJlbGF0aXZlKS4gKi9cbiAgc2V0U2VhcmNoUG9zaXRpb25zKFxuICAgIHN0YXRlOiB7XG4gICAgICBwb3NpdGlvbnM6IE1hdGNoUG9zaXRpb25bXVxuICAgICAgcm93T2Zmc2V0OiBudW1iZXJcbiAgICAgIGN1cnJlbnRJZHg6IG51bWJlclxuICAgIH0gfCBudWxsLFxuICApOiB2b2lkIHtcbiAgICB0aGlzLnNlYXJjaFBvc2l0aW9ucyA9IHN0YXRlXG4gICAgdGhpcy5zY2hlZHVsZVJlbmRlcigpXG4gIH1cblxuICAvKipcbiAgICogU2V0IHRoZSBzZWxlY3Rpb24gaGlnaGxpZ2h0IGJhY2tncm91bmQgY29sb3IuIFJlcGxhY2VzIHRoZSBwZXItY2VsbFxuICAgKiBTR1ItNyBpbnZlcnNlIHdpdGggYSBzb2xpZCB0aGVtZS1hd2FyZSBiZyAobWF0Y2hlcyBuYXRpdmUgdGVybWluYWxcbiAgICogc2VsZWN0aW9uKS4gQWNjZXB0cyB0aGUgc2FtZSBjb2xvciBmb3JtYXRzIGFzIFRleHQgYmFja2dyb3VuZENvbG9yXG4gICAqIChyZ2IoKSwgYW5zaTpuYW1lLCAjaGV4LCBhbnNpMjU2KCkpIOKAlCBjb2xvcml6ZSgpIHJvdXRlcyB0aHJvdWdoXG4gICAqIGNoYWxrIHNvIHRoZSB0bXV4L3h0ZXJtLmpzIGxldmVsIGNsYW1wcyBpbiBjb2xvcml6ZS50cyBhcHBseSBhbmRcbiAgICogdGhlIGVtaXR0ZWQgU0dSIGlzIGNvcnJlY3QgZm9yIHRoZSBjdXJyZW50IHRlcm1pbmFsLlxuICAgKlxuICAgKiBDYWxsZWQgYnkgUmVhY3QtbGFuZCBvbmNlIHRoZW1lIGlzIGtub3duIChTY3JvbGxLZXliaW5kaW5nSGFuZGxlcidzXG4gICAqIHVzZUVmZmVjdCB3YXRjaGluZyB1c2VUaGVtZSkuIEJlZm9yZSB0aGF0IGNhbGwsIHdpdGhTZWxlY3Rpb25CZ1xuICAgKiBmYWxscyBiYWNrIHRvIHdpdGhJbnZlcnNlIHNvIHNlbGVjdGlvbiBzdGlsbCByZW5kZXJzIG9uIHRoZSBmaXJzdFxuICAgKiBmcmFtZTsgdGhlIGVmZmVjdCBmaXJlcyBiZWZvcmUgYW55IG1vdXNlIGlucHV0IHNvIHRoZSBmYWxsYmFjayBpc1xuICAgKiB1bm9ic2VydmFibGUgaW4gcHJhY3RpY2UuXG4gICAqL1xuICBzZXRTZWxlY3Rpb25CZ0NvbG9yKGNvbG9yOiBzdHJpbmcpOiB2b2lkIHtcbiAgICAvLyBXcmFwIGEgTlVMIG1hcmtlciwgdGhlbiBzcGxpdCBvbiBpdCB0byBleHRyYWN0IHRoZSBvcGVuL2Nsb3NlIFNHUi5cbiAgICAvLyBjb2xvcml6ZSByZXR1cm5zIHRoZSBpbnB1dCB1bmNoYW5nZWQgaWYgdGhlIGNvbG9yIHN0cmluZyBpcyBiYWQg4oCUXG4gICAgLy8gbm8gTlVMLXNwbGl0IHRoZW4sIHNvIGZhbGwgdGhyb3VnaCB0byBudWxsIChpbnZlcnNlIGZhbGxiYWNrKS5cbiAgICBjb25zdCB3cmFwcGVkID0gY29sb3JpemUoJ1xcMCcsIGNvbG9yLCAnYmFja2dyb3VuZCcpXG4gICAgY29uc3QgbnVsID0gd3JhcHBlZC5pbmRleE9mKCdcXDAnKVxuICAgIGlmIChudWwgPD0gMCB8fCBudWwgPT09IHdyYXBwZWQubGVuZ3RoIC0gMSkge1xuICAgICAgdGhpcy5zdHlsZVBvb2wuc2V0U2VsZWN0aW9uQmcobnVsbClcbiAgICAgIHJldHVyblxuICAgIH1cbiAgICB0aGlzLnN0eWxlUG9vbC5zZXRTZWxlY3Rpb25CZyh7XG4gICAgICB0eXBlOiAnYW5zaScsXG4gICAgICBjb2RlOiB3cmFwcGVkLnNsaWNlKDAsIG51bCksXG4gICAgICBlbmRDb2RlOiB3cmFwcGVkLnNsaWNlKG51bCArIDEpLCAvLyBhbHdheXMgXFx4MWJbNDltIGZvciBiZ1xuICAgIH0pXG4gICAgLy8gTm8gc2NoZWR1bGVSZW5kZXI6IHRoaXMgaXMgY2FsbGVkIGZyb20gYSBSZWFjdCBlZmZlY3QgdGhhdCBhbHJlYWR5XG4gICAgLy8gcnVucyBpbnNpZGUgdGhlIHJlbmRlciBjeWNsZSwgYW5kIHRoZSBiZyBvbmx5IG1hdHRlcnMgb25jZSBhXG4gICAgLy8gc2VsZWN0aW9uIGV4aXN0cyAod2hpY2ggaXRzZWxmIHRyaWdnZXJzIGEgZnVsbC1kYW1hZ2UgZnJhbWUpLlxuICB9XG5cbiAgLyoqXG4gICAqIENhcHR1cmUgdGV4dCBmcm9tIHJvd3MgYWJvdXQgdG8gc2Nyb2xsIG91dCBvZiB0aGUgdmlld3BvcnQgZHVyaW5nXG4gICAqIGRyYWctdG8tc2Nyb2xsLiBNdXN0IGJlIGNhbGxlZCBCRUZPUkUgdGhlIFNjcm9sbEJveCBzY3JvbGxzIHNvIHRoZVxuICAgKiBzY3JlZW4gYnVmZmVyIHN0aWxsIGhvbGRzIHRoZSBvdXRnb2luZyBjb250ZW50LiBBY2N1bXVsYXRlZCBpbnRvXG4gICAqIHRoZSBzZWxlY3Rpb24gc3RhdGUgYW5kIGpvaW5lZCBiYWNrIGluIGJ5IGdldFNlbGVjdGVkVGV4dC5cbiAgICovXG4gIGNhcHR1cmVTY3JvbGxlZFJvd3MoXG4gICAgZmlyc3RSb3c6IG51bWJlcixcbiAgICBsYXN0Um93OiBudW1iZXIsXG4gICAgc2lkZTogJ2Fib3ZlJyB8ICdiZWxvdycsXG4gICk6IHZvaWQge1xuICAgIGNhcHR1cmVTY3JvbGxlZFJvd3MoXG4gICAgICB0aGlzLnNlbGVjdGlvbixcbiAgICAgIHRoaXMuZnJvbnRGcmFtZS5zY3JlZW4sXG4gICAgICBmaXJzdFJvdyxcbiAgICAgIGxhc3RSb3csXG4gICAgICBzaWRlLFxuICAgIClcbiAgfVxuXG4gIC8qKlxuICAgKiBTaGlmdCBhbmNob3IgQU5EIGZvY3VzIGJ5IGRSb3csIGNsYW1wZWQgdG8gW21pblJvdywgbWF4Um93XS4gVXNlZCBieVxuICAgKiBrZXlib2FyZCBzY3JvbGwgaGFuZGxlcnMgKFBnVXAvUGdEbiBldGMuKSBzbyB0aGUgaGlnaGxpZ2h0IHRyYWNrcyB0aGVcbiAgICogY29udGVudCBpbnN0ZWFkIG9mIGRpc2FwcGVhcmluZy4gVW5saWtlIHNoaWZ0QW5jaG9yIChkcmFnLXRvLXNjcm9sbCksXG4gICAqIHRoaXMgbW92ZXMgQk9USCBlbmRwb2ludHMg4oCUIHRoZSB1c2VyIGlzbid0IGhvbGRpbmcgdGhlIG1vdXNlIGF0IG9uZVxuICAgKiBlZGdlLiBTdXBwbGllcyBzY3JlZW4ud2lkdGggZm9yIHRoZSBjb2wtcmVzZXQtb24tY2xhbXAgYm91bmRhcnkuXG4gICAqL1xuICBzaGlmdFNlbGVjdGlvbkZvclNjcm9sbChkUm93OiBudW1iZXIsIG1pblJvdzogbnVtYmVyLCBtYXhSb3c6IG51bWJlcik6IHZvaWQge1xuICAgIGNvbnN0IGhhZFNlbCA9IGhhc1NlbGVjdGlvbih0aGlzLnNlbGVjdGlvbilcbiAgICBzaGlmdFNlbGVjdGlvbihcbiAgICAgIHRoaXMuc2VsZWN0aW9uLFxuICAgICAgZFJvdyxcbiAgICAgIG1pblJvdyxcbiAgICAgIG1heFJvdyxcbiAgICAgIHRoaXMuZnJvbnRGcmFtZS5zY3JlZW4ud2lkdGgsXG4gICAgKVxuICAgIC8vIHNoaWZ0U2VsZWN0aW9uIGNsZWFycyB3aGVuIGJvdGggZW5kcG9pbnRzIG92ZXJzaG9vdCB0aGUgc2FtZSBlZGdlXG4gICAgLy8gKEhvbWUvZy9FbmQvRyBwYWdlLWp1bXAgcGFzdCB0aGUgc2VsZWN0aW9uKS4gTm90aWZ5IHN1YnNjcmliZXJzIHNvXG4gICAgLy8gdXNlSGFzU2VsZWN0aW9uIHVwZGF0ZXMuIFNhZmUgdG8gY2FsbCBub3RpZnlTZWxlY3Rpb25DaGFuZ2UgaGVyZSDigJRcbiAgICAvLyB0aGlzIHJ1bnMgZnJvbSBrZXlib2FyZCBoYW5kbGVycywgbm90IGluc2lkZSBvblJlbmRlcigpLlxuICAgIGlmIChoYWRTZWwgJiYgIWhhc1NlbGVjdGlvbih0aGlzLnNlbGVjdGlvbikpIHtcbiAgICAgIHRoaXMubm90aWZ5U2VsZWN0aW9uQ2hhbmdlKClcbiAgICB9XG4gIH1cblxuICAvKipcbiAgICogS2V5Ym9hcmQgc2VsZWN0aW9uIGV4dGVuc2lvbiAoc2hpZnQrYXJyb3cvaG9tZS9lbmQpLiBNb3ZlcyBmb2N1cztcbiAgICogYW5jaG9yIHN0YXlzIGZpeGVkIHNvIHRoZSBoaWdobGlnaHQgZ3Jvd3Mgb3Igc2hyaW5rcyByZWxhdGl2ZSB0byBpdC5cbiAgICogTGVmdC9yaWdodCB3cmFwIGFjcm9zcyByb3cgYm91bmRhcmllcyDigJQgbmF0aXZlIG1hY09TIHRleHQtZWRpdFxuICAgKiBiZWhhdmlvcjogc2hpZnQrbGVmdCBhdCBjb2wgMCB3cmFwcyB0byBlbmQgb2YgdGhlIHByZXZpb3VzIHJvdy5cbiAgICogVXAvZG93biBjbGFtcCBhdCB2aWV3cG9ydCBlZGdlcyAobm8gc2Nyb2xsLXRvLWV4dGVuZCB5ZXQpLiBEcm9wcyB0b1xuICAgKiBjaGFyIG1vZGUuIE5vLW9wIG91dHNpZGUgYWx0LXNjcmVlbiBvciB3aXRob3V0IGFuIGFjdGl2ZSBzZWxlY3Rpb24uXG4gICAqL1xuICBtb3ZlU2VsZWN0aW9uRm9jdXMobW92ZTogRm9jdXNNb3ZlKTogdm9pZCB7XG4gICAgaWYgKCF0aGlzLmFsdFNjcmVlbkFjdGl2ZSkgcmV0dXJuXG4gICAgY29uc3QgeyBmb2N1cyB9ID0gdGhpcy5zZWxlY3Rpb25cbiAgICBpZiAoIWZvY3VzKSByZXR1cm5cbiAgICBjb25zdCB7IHdpZHRoLCBoZWlnaHQgfSA9IHRoaXMuZnJvbnRGcmFtZS5zY3JlZW5cbiAgICBjb25zdCBtYXhDb2wgPSB3aWR0aCAtIDFcbiAgICBjb25zdCBtYXhSb3cgPSBoZWlnaHQgLSAxXG4gICAgbGV0IHsgY29sLCByb3cgfSA9IGZvY3VzXG4gICAgc3dpdGNoIChtb3ZlKSB7XG4gICAgICBjYXNlICdsZWZ0JzpcbiAgICAgICAgaWYgKGNvbCA+IDApIGNvbC0tXG4gICAgICAgIGVsc2UgaWYgKHJvdyA+IDApIHtcbiAgICAgICAgICBjb2wgPSBtYXhDb2xcbiAgICAgICAgICByb3ctLVxuICAgICAgICB9XG4gICAgICAgIGJyZWFrXG4gICAgICBjYXNlICdyaWdodCc6XG4gICAgICAgIGlmIChjb2wgPCBtYXhDb2wpIGNvbCsrXG4gICAgICAgIGVsc2UgaWYgKHJvdyA8IG1heFJvdykge1xuICAgICAgICAgIGNvbCA9IDBcbiAgICAgICAgICByb3crK1xuICAgICAgICB9XG4gICAgICAgIGJyZWFrXG4gICAgICBjYXNlICd1cCc6XG4gICAgICAgIGlmIChyb3cgPiAwKSByb3ctLVxuICAgICAgICBicmVha1xuICAgICAgY2FzZSAnZG93bic6XG4gICAgICAgIGlmIChyb3cgPCBtYXhSb3cpIHJvdysrXG4gICAgICAgIGJyZWFrXG4gICAgICBjYXNlICdsaW5lU3RhcnQnOlxuICAgICAgICBjb2wgPSAwXG4gICAgICAgIGJyZWFrXG4gICAgICBjYXNlICdsaW5lRW5kJzpcbiAgICAgICAgY29sID0gbWF4Q29sXG4gICAgICAgIGJyZWFrXG4gICAgfVxuICAgIGlmIChjb2wgPT09IGZvY3VzLmNvbCAmJiByb3cgPT09IGZvY3VzLnJvdykgcmV0dXJuXG4gICAgbW92ZUZvY3VzKHRoaXMuc2VsZWN0aW9uLCBjb2wsIHJvdylcbiAgICB0aGlzLm5vdGlmeVNlbGVjdGlvbkNoYW5nZSgpXG4gIH1cblxuICAvKiogV2hldGhlciB0aGVyZSBpcyBhbiBhY3RpdmUgdGV4dCBzZWxlY3Rpb24uICovXG4gIGhhc1RleHRTZWxlY3Rpb24oKTogYm9vbGVhbiB7XG4gICAgcmV0dXJuIGhhc1NlbGVjdGlvbih0aGlzLnNlbGVjdGlvbilcbiAgfVxuXG4gIC8qKlxuICAgKiBTdWJzY3JpYmUgdG8gc2VsZWN0aW9uIHN0YXRlIGNoYW5nZXMuIEZpcmVzIHdoZW5ldmVyIHRoZSBzZWxlY3Rpb25cbiAgICogaXMgc3RhcnRlZCwgdXBkYXRlZCwgY2xlYXJlZCwgb3IgY29waWVkLiBSZXR1cm5zIGFuIHVuc3Vic2NyaWJlIGZuLlxuICAgKi9cbiAgc3Vic2NyaWJlVG9TZWxlY3Rpb25DaGFuZ2UoY2I6ICgpID0+IHZvaWQpOiAoKSA9PiB2b2lkIHtcbiAgICB0aGlzLnNlbGVjdGlvbkxpc3RlbmVycy5hZGQoY2IpXG4gICAgcmV0dXJuICgpID0+IHRoaXMuc2VsZWN0aW9uTGlzdGVuZXJzLmRlbGV0ZShjYilcbiAgfVxuXG4gIHByaXZhdGUgbm90aWZ5U2VsZWN0aW9uQ2hhbmdlKCk6IHZvaWQge1xuICAgIHRoaXMub25SZW5kZXIoKVxuICAgIGZvciAoY29uc3QgY2Igb2YgdGhpcy5zZWxlY3Rpb25MaXN0ZW5lcnMpIGNiKClcbiAgfVxuXG4gIC8qKlxuICAgKiBIaXQtdGVzdCB0aGUgcmVuZGVyZWQgRE9NIHRyZWUgYXQgKGNvbCwgcm93KSBhbmQgYnViYmxlIGEgQ2xpY2tFdmVudFxuICAgKiBmcm9tIHRoZSBkZWVwZXN0IGhpdCBub2RlIHVwIHRocm91Z2ggYW5jZXN0b3JzIHdpdGggb25DbGljayBoYW5kbGVycy5cbiAgICogUmV0dXJucyB0cnVlIGlmIGEgRE9NIGhhbmRsZXIgY29uc3VtZWQgdGhlIGNsaWNrLiBHYXRlZCBvblxuICAgKiBhbHRTY3JlZW5BY3RpdmUg4oCUIGNsaWNrcyBvbmx5IG1ha2Ugc2Vuc2Ugd2l0aCBhIGZpeGVkIHZpZXdwb3J0IHdoZXJlXG4gICAqIG5vZGVDYWNoZSByZWN0cyBtYXAgMToxIHRvIHRlcm1pbmFsIGNlbGxzIChubyBzY3JvbGxiYWNrIG9mZnNldCkuXG4gICAqL1xuICBkaXNwYXRjaENsaWNrKGNvbDogbnVtYmVyLCByb3c6IG51bWJlcik6IGJvb2xlYW4ge1xuICAgIGlmICghdGhpcy5hbHRTY3JlZW5BY3RpdmUpIHJldHVybiBmYWxzZVxuICAgIGNvbnN0IGJsYW5rID0gaXNFbXB0eUNlbGxBdCh0aGlzLmZyb250RnJhbWUuc2NyZWVuLCBjb2wsIHJvdylcbiAgICByZXR1cm4gZGlzcGF0Y2hDbGljayh0aGlzLnJvb3ROb2RlLCBjb2wsIHJvdywgYmxhbmspXG4gIH1cblxuICBkaXNwYXRjaEhvdmVyKGNvbDogbnVtYmVyLCByb3c6IG51bWJlcik6IHZvaWQge1xuICAgIGlmICghdGhpcy5hbHRTY3JlZW5BY3RpdmUpIHJldHVyblxuICAgIGRpc3BhdGNoSG92ZXIodGhpcy5yb290Tm9kZSwgY29sLCByb3csIHRoaXMuaG92ZXJlZE5vZGVzKVxuICB9XG5cbiAgZGlzcGF0Y2hLZXlib2FyZEV2ZW50KHBhcnNlZEtleTogUGFyc2VkS2V5KTogdm9pZCB7XG4gICAgY29uc3QgdGFyZ2V0ID0gdGhpcy5mb2N1c01hbmFnZXIuYWN0aXZlRWxlbWVudCA/PyB0aGlzLnJvb3ROb2RlXG4gICAgY29uc3QgZXZlbnQgPSBuZXcgS2V5Ym9hcmRFdmVudChwYXJzZWRLZXkpXG4gICAgZGlzcGF0Y2hlci5kaXNwYXRjaERpc2NyZXRlKHRhcmdldCwgZXZlbnQpXG5cbiAgICAvLyBUYWIgY3ljbGluZyBpcyB0aGUgZGVmYXVsdCBhY3Rpb24g4oCUIG9ubHkgZmlyZXMgaWYgbm8gaGFuZGxlclxuICAgIC8vIGNhbGxlZCBwcmV2ZW50RGVmYXVsdCgpLiBNaXJyb3JzIGJyb3dzZXIgYmVoYXZpb3IuXG4gICAgaWYgKFxuICAgICAgIWV2ZW50LmRlZmF1bHRQcmV2ZW50ZWQgJiZcbiAgICAgIHBhcnNlZEtleS5uYW1lID09PSAndGFiJyAmJlxuICAgICAgIXBhcnNlZEtleS5jdHJsICYmXG4gICAgICAhcGFyc2VkS2V5Lm1ldGFcbiAgICApIHtcbiAgICAgIGlmIChwYXJzZWRLZXkuc2hpZnQpIHtcbiAgICAgICAgdGhpcy5mb2N1c01hbmFnZXIuZm9jdXNQcmV2aW91cyh0aGlzLnJvb3ROb2RlKVxuICAgICAgfSBlbHNlIHtcbiAgICAgICAgdGhpcy5mb2N1c01hbmFnZXIuZm9jdXNOZXh0KHRoaXMucm9vdE5vZGUpXG4gICAgICB9XG4gICAgfVxuICB9XG4gIC8qKlxuICAgKiBMb29rIHVwIHRoZSBVUkwgYXQgKGNvbCwgcm93KSBpbiB0aGUgY3VycmVudCBmcm9udCBmcmFtZS4gQ2hlY2tzIGZvclxuICAgKiBhbiBPU0MgOCBoeXBlcmxpbmsgZmlyc3QsIHRoZW4gZmFsbHMgYmFjayB0byBzY2FubmluZyB0aGUgcm93IGZvciBhXG4gICAqIHBsYWluLXRleHQgVVJMIChtb3VzZSB0cmFja2luZyBpbnRlcmNlcHRzIHRoZSB0ZXJtaW5hbCdzIG5hdGl2ZVxuICAgKiBDbWQrQ2xpY2sgVVJMIGRldGVjdGlvbiwgc28gd2UgcmVwbGljYXRlIGl0KS4gVGhpcyBpcyBhIHB1cmUgbG9va3VwXG4gICAqIHdpdGggbm8gc2lkZSBlZmZlY3RzIOKAlCBjYWxsIGl0IHN5bmNocm9ub3VzbHkgYXQgY2xpY2sgdGltZSBzbyB0aGVcbiAgICogcmVzdWx0IHJlZmxlY3RzIHRoZSBzY3JlZW4gdGhlIHVzZXIgYWN0dWFsbHkgY2xpY2tlZCBvbiwgdGhlbiBkZWZlclxuICAgKiB0aGUgYnJvd3Nlci1vcGVuIGFjdGlvbiB2aWEgYSB0aW1lci5cbiAgICovXG4gIGdldEh5cGVybGlua0F0KGNvbDogbnVtYmVyLCByb3c6IG51bWJlcik6IHN0cmluZyB8IHVuZGVmaW5lZCB7XG4gICAgaWYgKCF0aGlzLmFsdFNjcmVlbkFjdGl2ZSkgcmV0dXJuIHVuZGVmaW5lZFxuICAgIGNvbnN0IHNjcmVlbiA9IHRoaXMuZnJvbnRGcmFtZS5zY3JlZW5cbiAgICBjb25zdCBjZWxsID0gY2VsbEF0KHNjcmVlbiwgY29sLCByb3cpXG4gICAgbGV0IHVybCA9IGNlbGw/Lmh5cGVybGlua1xuICAgIC8vIFNwYWNlclRhaWwgY2VsbHMgKHJpZ2h0IGhhbGYgb2Ygd2lkZS9DSksvZW1vamkgY2hhcnMpIHN0b3JlIHRoZVxuICAgIC8vIGh5cGVybGluayBvbiB0aGUgaGVhZCBjZWxsIGF0IGNvbC0xLlxuICAgIGlmICghdXJsICYmIGNlbGw/LndpZHRoID09PSBDZWxsV2lkdGguU3BhY2VyVGFpbCAmJiBjb2wgPiAwKSB7XG4gICAgICB1cmwgPSBjZWxsQXQoc2NyZWVuLCBjb2wgLSAxLCByb3cpPy5oeXBlcmxpbmtcbiAgICB9XG4gICAgcmV0dXJuIHVybCA/PyBmaW5kUGxhaW5UZXh0VXJsQXQoc2NyZWVuLCBjb2wsIHJvdylcbiAgfVxuXG4gIC8qKlxuICAgKiBPcHRpb25hbCBjYWxsYmFjayBmaXJlZCB3aGVuIGNsaWNraW5nIGFuIE9TQyA4IGh5cGVybGluayBpbiBmdWxsc2NyZWVuXG4gICAqIG1vZGUuIFNldCBieSBGdWxsc2NyZWVuTGF5b3V0IHZpYSB1c2VMYXlvdXRFZmZlY3QuXG4gICAqL1xuICBvbkh5cGVybGlua0NsaWNrOiAoKHVybDogc3RyaW5nKSA9PiB2b2lkKSB8IHVuZGVmaW5lZFxuXG4gIC8qKlxuICAgKiBTdGFibGUgcHJvdG90eXBlIHdyYXBwZXIgZm9yIG9uSHlwZXJsaW5rQ2xpY2suIFBhc3NlZCB0byA8QXBwPiBhc1xuICAgKiBvbk9wZW5IeXBlcmxpbmsgc28gdGhlIHByb3AgaXMgYSBib3VuZCBtZXRob2QgKGF1dG9CaW5kJ2QpIHRoYXQgcmVhZHNcbiAgICogdGhlIG11dGFibGUgZmllbGQgYXQgY2FsbCB0aW1lIOKAlCBub3QgdGhlIHVuZGVmaW5lZC1hdC1yZW5kZXIgdmFsdWUuXG4gICAqL1xuICBvcGVuSHlwZXJsaW5rKHVybDogc3RyaW5nKTogdm9pZCB7XG4gICAgdGhpcy5vbkh5cGVybGlua0NsaWNrPy4odXJsKVxuICB9XG5cbiAgLyoqXG4gICAqIEhhbmRsZSBhIGRvdWJsZS0gb3IgdHJpcGxlLWNsaWNrIGF0IChjb2wsIHJvdyk6IHNlbGVjdCB0aGUgd29yZCBvclxuICAgKiBsaW5lIHVuZGVyIHRoZSBjdXJzb3IgYnkgcmVhZGluZyB0aGUgY3VycmVudCBzY3JlZW4gYnVmZmVyLiBDYWxsZWQgb25cbiAgICogUFJFU1MgKG5vdCByZWxlYXNlKSBzbyB0aGUgaGlnaGxpZ2h0IGFwcGVhcnMgaW1tZWRpYXRlbHkgYW5kIGRyYWcgY2FuXG4gICAqIGV4dGVuZCB0aGUgc2VsZWN0aW9uIHdvcmQtYnktd29yZCAvIGxpbmUtYnktbGluZS4gRmFsbHMgYmFjayB0b1xuICAgKiBjaGFyLW1vZGUgc3RhcnRTZWxlY3Rpb24gaWYgdGhlIGNsaWNrIGxhbmRzIG9uIGEgbm9TZWxlY3QgY2VsbC5cbiAgICovXG4gIGhhbmRsZU11bHRpQ2xpY2soY29sOiBudW1iZXIsIHJvdzogbnVtYmVyLCBjb3VudDogMiB8IDMpOiB2b2lkIHtcbiAgICBpZiAoIXRoaXMuYWx0U2NyZWVuQWN0aXZlKSByZXR1cm5cbiAgICBjb25zdCBzY3JlZW4gPSB0aGlzLmZyb250RnJhbWUuc2NyZWVuXG4gICAgLy8gc2VsZWN0V29yZEF0L3NlbGVjdExpbmVBdCBuby1vcCBvbiBub1NlbGVjdC9vdXQtb2YtYm91bmRzLiBTZWVkIHdpdGhcbiAgICAvLyBhIGNoYXItbW9kZSBzZWxlY3Rpb24gc28gdGhlIHByZXNzIHN0aWxsIHN0YXJ0cyBhIGRyYWcgZXZlbiBpZiB0aGVcbiAgICAvLyB3b3JkL2xpbmUgc2NhbiBmaW5kcyBub3RoaW5nIHNlbGVjdGFibGUuXG4gICAgc3RhcnRTZWxlY3Rpb24odGhpcy5zZWxlY3Rpb24sIGNvbCwgcm93KVxuICAgIGlmIChjb3VudCA9PT0gMikgc2VsZWN0V29yZEF0KHRoaXMuc2VsZWN0aW9uLCBzY3JlZW4sIGNvbCwgcm93KVxuICAgIGVsc2Ugc2VsZWN0TGluZUF0KHRoaXMuc2VsZWN0aW9uLCBzY3JlZW4sIHJvdylcbiAgICAvLyBFbnN1cmUgaGFzU2VsZWN0aW9uIGlzIHRydWUgc28gcmVsZWFzZSBkb2Vzbid0IHJlLWRpc3BhdGNoIG9uQ2xpY2tBdC5cbiAgICAvLyBzZWxlY3RXb3JkQXQgbm8tb3BzIG9uIG5vU2VsZWN0OyBzZWxlY3RMaW5lQXQgbm8tb3BzIG91dC1vZi1ib3VuZHMuXG4gICAgaWYgKCF0aGlzLnNlbGVjdGlvbi5mb2N1cykgdGhpcy5zZWxlY3Rpb24uZm9jdXMgPSB0aGlzLnNlbGVjdGlvbi5hbmNob3JcbiAgICB0aGlzLm5vdGlmeVNlbGVjdGlvbkNoYW5nZSgpXG4gIH1cblxuICAvKipcbiAgICogSGFuZGxlIGEgZHJhZy1tb3Rpb24gYXQgKGNvbCwgcm93KS4gSW4gY2hhciBtb2RlIHVwZGF0ZXMgZm9jdXMgdG8gdGhlXG4gICAqIGV4YWN0IGNlbGwuIEluIHdvcmQvbGluZSBtb2RlIHNuYXBzIHRvIHdvcmQvbGluZSBib3VuZGFyaWVzIHNvIHRoZVxuICAgKiBzZWxlY3Rpb24gZXh0ZW5kcyBieSB3b3JkL2xpbmUgbGlrZSBuYXRpdmUgbWFjT1MuIEdhdGVkIG9uXG4gICAqIGFsdFNjcmVlbkFjdGl2ZSBmb3IgdGhlIHNhbWUgcmVhc29uIGFzIGRpc3BhdGNoQ2xpY2suXG4gICAqL1xuICBoYW5kbGVTZWxlY3Rpb25EcmFnKGNvbDogbnVtYmVyLCByb3c6IG51bWJlcik6IHZvaWQge1xuICAgIGlmICghdGhpcy5hbHRTY3JlZW5BY3RpdmUpIHJldHVyblxuICAgIGNvbnN0IHNlbCA9IHRoaXMuc2VsZWN0aW9uXG4gICAgaWYgKHNlbC5hbmNob3JTcGFuKSB7XG4gICAgICBleHRlbmRTZWxlY3Rpb24oc2VsLCB0aGlzLmZyb250RnJhbWUuc2NyZWVuLCBjb2wsIHJvdylcbiAgICB9IGVsc2Uge1xuICAgICAgdXBkYXRlU2VsZWN0aW9uKHNlbCwgY29sLCByb3cpXG4gICAgfVxuICAgIHRoaXMubm90aWZ5U2VsZWN0aW9uQ2hhbmdlKClcbiAgfVxuXG4gIC8vIE1ldGhvZHMgdG8gcHJvcGVybHkgc3VzcGVuZCBzdGRpbiBmb3IgZXh0ZXJuYWwgZWRpdG9yIHVzYWdlXG4gIC8vIFRoaXMgaXMgbmVlZGVkIHRvIHByZXZlbnQgSW5rIGZyb20gc3dhbGxvd2luZyBrZXlzdHJva2VzIHdoZW4gYW4gZXh0ZXJuYWwgZWRpdG9yIGlzIGFjdGl2ZVxuICBwcml2YXRlIHN0ZGluTGlzdGVuZXJzOiBBcnJheTx7XG4gICAgZXZlbnQ6IHN0cmluZ1xuICAgIGxpc3RlbmVyOiAoLi4uYXJnczogdW5rbm93bltdKSA9PiB2b2lkXG4gIH0+ID0gW11cbiAgcHJpdmF0ZSB3YXNSYXdNb2RlID0gZmFsc2VcblxuICBzdXNwZW5kU3RkaW4oKTogdm9pZCB7XG4gICAgY29uc3Qgc3RkaW4gPSB0aGlzLm9wdGlvbnMuc3RkaW5cbiAgICBpZiAoIXN0ZGluLmlzVFRZKSB7XG4gICAgICByZXR1cm5cbiAgICB9XG5cbiAgICAvLyBTdG9yZSBhbmQgcmVtb3ZlIGFsbCAncmVhZGFibGUnIGV2ZW50IGxpc3RlbmVycyB0ZW1wb3JhcmlseVxuICAgIC8vIFRoaXMgcHJldmVudHMgSW5rIGZyb20gY29uc3VtaW5nIHN0ZGluIHdoaWxlIHRoZSBlZGl0b3IgaXMgYWN0aXZlXG4gICAgY29uc3QgcmVhZGFibGVMaXN0ZW5lcnMgPSBzdGRpbi5saXN0ZW5lcnMoJ3JlYWRhYmxlJylcbiAgICBsb2dGb3JEZWJ1Z2dpbmcoXG4gICAgICBgW3N0ZGluXSBzdXNwZW5kU3RkaW46IHJlbW92aW5nICR7cmVhZGFibGVMaXN0ZW5lcnMubGVuZ3RofSByZWFkYWJsZSBsaXN0ZW5lcihzKSwgd2FzUmF3TW9kZT0keyhzdGRpbiBhcyBOb2RlSlMuUmVhZFN0cmVhbSAmIHsgaXNSYXc/OiBib29sZWFuIH0pLmlzUmF3ID8/IGZhbHNlfWAsXG4gICAgKVxuICAgIHJlYWRhYmxlTGlzdGVuZXJzLmZvckVhY2gobGlzdGVuZXIgPT4ge1xuICAgICAgdGhpcy5zdGRpbkxpc3RlbmVycy5wdXNoKHtcbiAgICAgICAgZXZlbnQ6ICdyZWFkYWJsZScsXG4gICAgICAgIGxpc3RlbmVyOiBsaXN0ZW5lciBhcyAoLi4uYXJnczogdW5rbm93bltdKSA9PiB2b2lkLFxuICAgICAgfSlcbiAgICAgIHN0ZGluLnJlbW92ZUxpc3RlbmVyKCdyZWFkYWJsZScsIGxpc3RlbmVyIGFzICguLi5hcmdzOiB1bmtub3duW10pID0+IHZvaWQpXG4gICAgfSlcblxuICAgIC8vIElmIHJhdyBtb2RlIGlzIGVuYWJsZWQsIGRpc2FibGUgaXQgdGVtcG9yYXJpbHlcbiAgICBjb25zdCBzdGRpbldpdGhSYXcgPSBzdGRpbiBhcyBOb2RlSlMuUmVhZFN0cmVhbSAmIHtcbiAgICAgIGlzUmF3PzogYm9vbGVhblxuICAgICAgc2V0UmF3TW9kZT86IChtb2RlOiBib29sZWFuKSA9PiB2b2lkXG4gICAgfVxuICAgIGlmIChzdGRpbldpdGhSYXcuaXNSYXcgJiYgc3RkaW5XaXRoUmF3LnNldFJhd01vZGUpIHtcbiAgICAgIHN0ZGluV2l0aFJhdy5zZXRSYXdNb2RlKGZhbHNlKVxuICAgICAgdGhpcy53YXNSYXdNb2RlID0gdHJ1ZVxuICAgIH1cbiAgfVxuXG4gIHJlc3VtZVN0ZGluKCk6IHZvaWQge1xuICAgIGNvbnN0IHN0ZGluID0gdGhpcy5vcHRpb25zLnN0ZGluXG4gICAgaWYgKCFzdGRpbi5pc1RUWSkge1xuICAgICAgcmV0dXJuXG4gICAgfVxuXG4gICAgLy8gUmUtYXR0YWNoIGFsbCB0aGUgc3RvcmVkIGxpc3RlbmVyc1xuICAgIGlmICh0aGlzLnN0ZGluTGlzdGVuZXJzLmxlbmd0aCA9PT0gMCAmJiAhdGhpcy53YXNSYXdNb2RlKSB7XG4gICAgICBsb2dGb3JEZWJ1Z2dpbmcoXG4gICAgICAgICdbc3RkaW5dIHJlc3VtZVN0ZGluOiBjYWxsZWQgd2l0aCBubyBzdG9yZWQgbGlzdGVuZXJzIGFuZCB3YXNSYXdNb2RlPWZhbHNlIChwb3NzaWJsZSBkZXN5bmMpJyxcbiAgICAgICAgeyBsZXZlbDogJ3dhcm4nIH0sXG4gICAgICApXG4gICAgfVxuICAgIGxvZ0ZvckRlYnVnZ2luZyhcbiAgICAgIGBbc3RkaW5dIHJlc3VtZVN0ZGluOiByZS1hdHRhY2hpbmcgJHt0aGlzLnN0ZGluTGlzdGVuZXJzLmxlbmd0aH0gbGlzdGVuZXIocyksIHdhc1Jhd01vZGU9JHt0aGlzLndhc1Jhd01vZGV9YCxcbiAgICApXG4gICAgdGhpcy5zdGRpbkxpc3RlbmVycy5mb3JFYWNoKCh7IGV2ZW50LCBsaXN0ZW5lciB9KSA9PiB7XG4gICAgICBzdGRpbi5hZGRMaXN0ZW5lcihldmVudCwgbGlzdGVuZXIpXG4gICAgfSlcbiAgICB0aGlzLnN0ZGluTGlzdGVuZXJzID0gW11cblxuICAgIC8vIFJlLWVuYWJsZSByYXcgbW9kZSBpZiBpdCB3YXMgZW5hYmxlZCBiZWZvcmVcbiAgICBpZiAodGhpcy53YXNSYXdNb2RlKSB7XG4gICAgICBjb25zdCBzdGRpbldpdGhSYXcgPSBzdGRpbiBhcyBOb2RlSlMuUmVhZFN0cmVhbSAmIHtcbiAgICAgICAgc2V0UmF3TW9kZT86IChtb2RlOiBib29sZWFuKSA9PiB2b2lkXG4gICAgICB9XG4gICAgICBpZiAoc3RkaW5XaXRoUmF3LnNldFJhd01vZGUpIHtcbiAgICAgICAgc3RkaW5XaXRoUmF3LnNldFJhd01vZGUodHJ1ZSlcbiAgICAgIH1cbiAgICAgIHRoaXMud2FzUmF3TW9kZSA9IGZhbHNlXG4gICAgfVxuICB9XG5cbiAgLy8gU3RhYmxlIGlkZW50aXR5IGZvciBUZXJtaW5hbFdyaXRlQ29udGV4dC4gQW4gaW5saW5lIGFycm93IGhlcmUgd291bGRcbiAgLy8gY2hhbmdlIG9uIGV2ZXJ5IHJlbmRlcigpIGNhbGwgKGluaXRpYWwgbW91bnQgKyBlYWNoIHJlc2l6ZSksIHdoaWNoXG4gIC8vIGNhc2NhZGVzIHRocm91Z2ggdXNlQ29udGV4dCDihpIgPEFsdGVybmF0ZVNjcmVlbj4ncyB1c2VMYXlvdXRFZmZlY3QgZGVwXG4gIC8vIGFycmF5IOKGkiBzcHVyaW91cyBleGl0K3JlLWVudGVyIG9mIHRoZSBhbHQgc2NyZWVuIG9uIGV2ZXJ5IFNJR1dJTkNILlxuICBwcml2YXRlIHdyaXRlUmF3KGRhdGE6IHN0cmluZyk6IHZvaWQge1xuICAgIHRoaXMub3B0aW9ucy5zdGRvdXQud3JpdGUoZGF0YSlcbiAgfVxuXG4gIHByaXZhdGUgc2V0Q3Vyc29yRGVjbGFyYXRpb246IEN1cnNvckRlY2xhcmF0aW9uU2V0dGVyID0gKFxuICAgIGRlY2wsXG4gICAgY2xlYXJJZk5vZGUsXG4gICkgPT4ge1xuICAgIGlmIChcbiAgICAgIGRlY2wgPT09IG51bGwgJiZcbiAgICAgIGNsZWFySWZOb2RlICE9PSB1bmRlZmluZWQgJiZcbiAgICAgIHRoaXMuY3Vyc29yRGVjbGFyYXRpb24/Lm5vZGUgIT09IGNsZWFySWZOb2RlXG4gICAgKSB7XG4gICAgICByZXR1cm5cbiAgICB9XG4gICAgdGhpcy5jdXJzb3JEZWNsYXJhdGlvbiA9IGRlY2xcbiAgfVxuXG4gIHJlbmRlcihub2RlOiBSZWFjdE5vZGUpOiB2b2lkIHtcbiAgICB0aGlzLmN1cnJlbnROb2RlID0gbm9kZVxuXG4gICAgY29uc3QgdHJlZSA9IChcbiAgICAgIDxBcHBcbiAgICAgICAgc3RkaW49e3RoaXMub3B0aW9ucy5zdGRpbn1cbiAgICAgICAgc3Rkb3V0PXt0aGlzLm9wdGlvbnMuc3Rkb3V0fVxuICAgICAgICBzdGRlcnI9e3RoaXMub3B0aW9ucy5zdGRlcnJ9XG4gICAgICAgIGV4aXRPbkN0cmxDPXt0aGlzLm9wdGlvbnMuZXhpdE9uQ3RybEN9XG4gICAgICAgIG9uRXhpdD17dGhpcy51bm1vdW50fVxuICAgICAgICB0ZXJtaW5hbENvbHVtbnM9e3RoaXMudGVybWluYWxDb2x1bW5zfVxuICAgICAgICB0ZXJtaW5hbFJvd3M9e3RoaXMudGVybWluYWxSb3dzfVxuICAgICAgICBzZWxlY3Rpb249e3RoaXMuc2VsZWN0aW9ufVxuICAgICAgICBvblNlbGVjdGlvbkNoYW5nZT17dGhpcy5ub3RpZnlTZWxlY3Rpb25DaGFuZ2V9XG4gICAgICAgIG9uQ2xpY2tBdD17dGhpcy5kaXNwYXRjaENsaWNrfVxuICAgICAgICBvbkhvdmVyQXQ9e3RoaXMuZGlzcGF0Y2hIb3Zlcn1cbiAgICAgICAgZ2V0SHlwZXJsaW5rQXQ9e3RoaXMuZ2V0SHlwZXJsaW5rQXR9XG4gICAgICAgIG9uT3Blbkh5cGVybGluaz17dGhpcy5vcGVuSHlwZXJsaW5rfVxuICAgICAgICBvbk11bHRpQ2xpY2s9e3RoaXMuaGFuZGxlTXVsdGlDbGlja31cbiAgICAgICAgb25TZWxlY3Rpb25EcmFnPXt0aGlzLmhhbmRsZVNlbGVjdGlvbkRyYWd9XG4gICAgICAgIG9uU3RkaW5SZXN1bWU9e3RoaXMucmVhc3NlcnRUZXJtaW5hbE1vZGVzfVxuICAgICAgICBvbkN1cnNvckRlY2xhcmF0aW9uPXt0aGlzLnNldEN1cnNvckRlY2xhcmF0aW9ufVxuICAgICAgICBkaXNwYXRjaEtleWJvYXJkRXZlbnQ9e3RoaXMuZGlzcGF0Y2hLZXlib2FyZEV2ZW50fVxuICAgICAgPlxuICAgICAgICA8VGVybWluYWxXcml0ZVByb3ZpZGVyIHZhbHVlPXt0aGlzLndyaXRlUmF3fT5cbiAgICAgICAgICB7bm9kZX1cbiAgICAgICAgPC9UZXJtaW5hbFdyaXRlUHJvdmlkZXI+XG4gICAgICA8L0FwcD5cbiAgICApXG5cbiAgICAvLyBAdHMtZXhwZWN0LWVycm9yIHVwZGF0ZUNvbnRhaW5lclN5bmMgZXhpc3RzIGluIHJlYWN0LXJlY29uY2lsZXIgYnV0IG5vdCBpbiBAdHlwZXMvcmVhY3QtcmVjb25jaWxlclxuICAgIHJlY29uY2lsZXIudXBkYXRlQ29udGFpbmVyU3luYyh0cmVlLCB0aGlzLmNvbnRhaW5lciwgbnVsbCwgbm9vcClcbiAgICAvLyBAdHMtZXhwZWN0LWVycm9yIGZsdXNoU3luY1dvcmsgZXhpc3RzIGluIHJlYWN0LXJlY29uY2lsZXIgYnV0IG5vdCBpbiBAdHlwZXMvcmVhY3QtcmVjb25jaWxlclxuICAgIHJlY29uY2lsZXIuZmx1c2hTeW5jV29yaygpXG4gIH1cblxuICB1bm1vdW50KGVycm9yPzogRXJyb3IgfCBudW1iZXIgfCBudWxsKTogdm9pZCB7XG4gICAgaWYgKHRoaXMuaXNVbm1vdW50ZWQpIHtcbiAgICAgIHJldHVyblxuICAgIH1cblxuICAgIHRoaXMub25SZW5kZXIoKVxuICAgIHRoaXMudW5zdWJzY3JpYmVFeGl0KClcblxuICAgIGlmICh0eXBlb2YgdGhpcy5yZXN0b3JlQ29uc29sZSA9PT0gJ2Z1bmN0aW9uJykge1xuICAgICAgdGhpcy5yZXN0b3JlQ29uc29sZSgpXG4gICAgfVxuICAgIHRoaXMucmVzdG9yZVN0ZGVycj8uKClcblxuICAgIHRoaXMudW5zdWJzY3JpYmVUVFlIYW5kbGVycz8uKClcblxuICAgIC8vIE5vbi1UVFkgZW52aXJvbm1lbnRzIGRvbid0IGhhbmRsZSBlcmFzaW5nIGFuc2kgZXNjYXBlcyB3ZWxsLCBzbyBpdCdzIGJldHRlciB0b1xuICAgIC8vIG9ubHkgcmVuZGVyIGxhc3QgZnJhbWUgb2Ygbm9uLXN0YXRpYyBvdXRwdXRcbiAgICBjb25zdCBkaWZmID0gdGhpcy5sb2cucmVuZGVyUHJldmlvdXNPdXRwdXRfREVQUkVDQVRFRCh0aGlzLmZyb250RnJhbWUpXG4gICAgd3JpdGVEaWZmVG9UZXJtaW5hbCh0aGlzLnRlcm1pbmFsLCBvcHRpbWl6ZShkaWZmKSlcblxuICAgIC8vIENsZWFuIHVwIHRlcm1pbmFsIG1vZGVzIHN5bmNocm9ub3VzbHkgYmVmb3JlIHByb2Nlc3MgZXhpdC5cbiAgICAvLyBSZWFjdCdzIGNvbXBvbmVudFdpbGxVbm1vdW50IHdvbid0IHJ1biBpbiB0aW1lIHdoZW4gcHJvY2Vzcy5leGl0KCkgaXMgY2FsbGVkLFxuICAgIC8vIHNvIHdlIG11c3QgcmVzZXQgdGVybWluYWwgbW9kZXMgaGVyZSB0byBwcmV2ZW50IGVzY2FwZSBzZXF1ZW5jZSBsZWFrYWdlLlxuICAgIC8vIFVzZSB3cml0ZVN5bmMgdG8gc3Rkb3V0IChmZCAxKSB0byBlbnN1cmUgd3JpdGVzIGNvbXBsZXRlIGJlZm9yZSBleGl0LlxuICAgIC8vIFdlIHVuY29uZGl0aW9uYWxseSBzZW5kIGFsbCBkaXNhYmxlIHNlcXVlbmNlcyBiZWNhdXNlIHRlcm1pbmFsIGRldGVjdGlvblxuICAgIC8vIG1heSBub3Qgd29yayBjb3JyZWN0bHkgKGUuZy4sIGluIHRtdXgsIHNjcmVlbikgYW5kIHRoZXNlIGFyZSBuby1vcHMgb25cbiAgICAvLyB0ZXJtaW5hbHMgdGhhdCBkb24ndCBzdXBwb3J0IHRoZW0uXG4gICAgLyogZXNsaW50LWRpc2FibGUgY3VzdG9tLXJ1bGVzL25vLXN5bmMtZnMgLS0gcHJvY2VzcyBleGl0aW5nOyBhc3luYyB3cml0ZXMgd291bGQgYmUgZHJvcHBlZCAqL1xuICAgIGlmICh0aGlzLm9wdGlvbnMuc3Rkb3V0LmlzVFRZKSB7XG4gICAgICBpZiAodGhpcy5hbHRTY3JlZW5BY3RpdmUpIHtcbiAgICAgICAgLy8gPEFsdGVybmF0ZVNjcmVlbj4ncyB1bm1vdW50IGVmZmVjdCB3b24ndCBydW4gZHVyaW5nIHNpZ25hbC1leGl0LlxuICAgICAgICAvLyBFeGl0IGFsdCBzY3JlZW4gRklSU1Qgc28gb3RoZXIgY2xlYW51cCBzZXF1ZW5jZXMgZ28gdG8gdGhlIG1haW4gc2NyZWVuLlxuICAgICAgICB3cml0ZVN5bmMoMSwgRVhJVF9BTFRfU0NSRUVOKVxuICAgICAgfVxuICAgICAgLy8gRGlzYWJsZSBtb3VzZSB0cmFja2luZyDigJQgdW5jb25kaXRpb25hbCBiZWNhdXNlIGFsdFNjcmVlbkFjdGl2ZSBjYW4gYmVcbiAgICAgIC8vIHN0YWxlIGlmIEFsdGVybmF0ZVNjcmVlbidzIHVubW91bnQgKHdoaWNoIGZsaXBzIHRoZSBmbGFnKSByYWNlZCBhXG4gICAgICAvLyBibG9ja2VkIGV2ZW50IGxvb3AgKyBTSUdJTlQuIE5vLW9wIGlmIHRyYWNraW5nIHdhcyBuZXZlciBlbmFibGVkLlxuICAgICAgd3JpdGVTeW5jKDEsIERJU0FCTEVfTU9VU0VfVFJBQ0tJTkcpXG4gICAgICAvLyBEcmFpbiBzdGRpbiBzbyBpbi1mbGlnaHQgbW91c2UgZXZlbnRzIGRvbid0IGxlYWsgdG8gdGhlIHNoZWxsXG4gICAgICB0aGlzLmRyYWluU3RkaW4oKVxuICAgICAgLy8gRGlzYWJsZSBleHRlbmRlZCBrZXkgcmVwb3J0aW5nIChib3RoIGtpdHR5IGFuZCBtb2RpZnlPdGhlcktleXMpXG4gICAgICB3cml0ZVN5bmMoMSwgRElTQUJMRV9NT0RJRllfT1RIRVJfS0VZUylcbiAgICAgIHdyaXRlU3luYygxLCBESVNBQkxFX0tJVFRZX0tFWUJPQVJEKVxuICAgICAgLy8gRGlzYWJsZSBmb2N1cyBldmVudHMgKERFQ1NFVCAxMDA0KVxuICAgICAgd3JpdGVTeW5jKDEsIERGRSlcbiAgICAgIC8vIERpc2FibGUgYnJhY2tldGVkIHBhc3RlIG1vZGVcbiAgICAgIHdyaXRlU3luYygxLCBEQlApXG4gICAgICAvLyBTaG93IGN1cnNvclxuICAgICAgd3JpdGVTeW5jKDEsIFNIT1dfQ1VSU09SKVxuICAgICAgLy8gQ2xlYXIgaVRlcm0yIHByb2dyZXNzIGJhclxuICAgICAgd3JpdGVTeW5jKDEsIENMRUFSX0lURVJNMl9QUk9HUkVTUylcbiAgICAgIC8vIENsZWFyIHRhYiBzdGF0dXMgKE9TQyAyMTMzNykgc28gYSBzdGFsZSBkb3QgZG9lc24ndCBsaW5nZXJcbiAgICAgIGlmIChzdXBwb3J0c1RhYlN0YXR1cygpKVxuICAgICAgICB3cml0ZVN5bmMoMSwgd3JhcEZvck11bHRpcGxleGVyKENMRUFSX1RBQl9TVEFUVVMpKVxuICAgIH1cbiAgICAvKiBlc2xpbnQtZW5hYmxlIGN1c3RvbS1ydWxlcy9uby1zeW5jLWZzICovXG5cbiAgICB0aGlzLmlzVW5tb3VudGVkID0gdHJ1ZVxuXG4gICAgLy8gQ2FuY2VsIGFueSBwZW5kaW5nIHRocm90dGxlZCByZW5kZXJzIHRvIHByZXZlbnQgYWNjZXNzaW5nIGZyZWVkIFlvZ2Egbm9kZXNcbiAgICB0aGlzLnNjaGVkdWxlUmVuZGVyLmNhbmNlbD8uKClcbiAgICBpZiAodGhpcy5kcmFpblRpbWVyICE9PSBudWxsKSB7XG4gICAgICBjbGVhclRpbWVvdXQodGhpcy5kcmFpblRpbWVyKVxuICAgICAgdGhpcy5kcmFpblRpbWVyID0gbnVsbFxuICAgIH1cblxuICAgIC8vIEB0cy1leHBlY3QtZXJyb3IgdXBkYXRlQ29udGFpbmVyU3luYyBleGlzdHMgaW4gcmVhY3QtcmVjb25jaWxlciBidXQgbm90IGluIEB0eXBlcy9yZWFjdC1yZWNvbmNpbGVyXG4gICAgcmVjb25jaWxlci51cGRhdGVDb250YWluZXJTeW5jKG51bGwsIHRoaXMuY29udGFpbmVyLCBudWxsLCBub29wKVxuICAgIC8vIEB0cy1leHBlY3QtZXJyb3IgZmx1c2hTeW5jV29yayBleGlzdHMgaW4gcmVhY3QtcmVjb25jaWxlciBidXQgbm90IGluIEB0eXBlcy9yZWFjdC1yZWNvbmNpbGVyXG4gICAgcmVjb25jaWxlci5mbHVzaFN5bmNXb3JrKClcbiAgICBpbnN0YW5jZXMuZGVsZXRlKHRoaXMub3B0aW9ucy5zdGRvdXQpXG5cbiAgICAvLyBGcmVlIHRoZSByb290IHlvZ2Egbm9kZSwgdGhlbiBjbGVhciBpdHMgcmVmZXJlbmNlLiBDaGlsZHJlbiBhcmUgYWxyZWFkeVxuICAgIC8vIGZyZWVkIGJ5IHRoZSByZWNvbmNpbGVyJ3MgcmVtb3ZlQ2hpbGRGcm9tQ29udGFpbmVyOyB1c2luZyAuZnJlZSgpIChub3RcbiAgICAvLyAuZnJlZVJlY3Vyc2l2ZSgpKSBhdm9pZHMgZG91YmxlLWZyZWVpbmcgdGhlbS5cbiAgICB0aGlzLnJvb3ROb2RlLnlvZ2FOb2RlPy5mcmVlKClcbiAgICB0aGlzLnJvb3ROb2RlLnlvZ2FOb2RlID0gdW5kZWZpbmVkXG5cbiAgICBpZiAoZXJyb3IgaW5zdGFuY2VvZiBFcnJvcikge1xuICAgICAgdGhpcy5yZWplY3RFeGl0UHJvbWlzZShlcnJvcilcbiAgICB9IGVsc2Uge1xuICAgICAgdGhpcy5yZXNvbHZlRXhpdFByb21pc2UoKVxuICAgIH1cbiAgfVxuXG4gIGFzeW5jIHdhaXRVbnRpbEV4aXQoKTogUHJvbWlzZTx2b2lkPiB7XG4gICAgdGhpcy5leGl0UHJvbWlzZSB8fD0gbmV3IFByb21pc2UoKHJlc29sdmUsIHJlamVjdCkgPT4ge1xuICAgICAgdGhpcy5yZXNvbHZlRXhpdFByb21pc2UgPSByZXNvbHZlXG4gICAgICB0aGlzLnJlamVjdEV4aXRQcm9taXNlID0gcmVqZWN0XG4gICAgfSlcblxuICAgIHJldHVybiB0aGlzLmV4aXRQcm9taXNlXG4gIH1cblxuICByZXNldExpbmVDb3VudCgpOiB2b2lkIHtcbiAgICBpZiAodGhpcy5vcHRpb25zLnN0ZG91dC5pc1RUWSkge1xuICAgICAgLy8gU3dhcCBzbyBvbGQgZnJvbnQgYmVjb21lcyBiYWNrIChmb3Igc2NyZWVuIHJldXNlKSwgdGhlbiByZXNldCBmcm9udFxuICAgICAgdGhpcy5iYWNrRnJhbWUgPSB0aGlzLmZyb250RnJhbWVcbiAgICAgIHRoaXMuZnJvbnRGcmFtZSA9IGVtcHR5RnJhbWUoXG4gICAgICAgIHRoaXMuZnJvbnRGcmFtZS52aWV3cG9ydC5oZWlnaHQsXG4gICAgICAgIHRoaXMuZnJvbnRGcmFtZS52aWV3cG9ydC53aWR0aCxcbiAgICAgICAgdGhpcy5zdHlsZVBvb2wsXG4gICAgICAgIHRoaXMuY2hhclBvb2wsXG4gICAgICAgIHRoaXMuaHlwZXJsaW5rUG9vbCxcbiAgICAgIClcbiAgICAgIHRoaXMubG9nLnJlc2V0KClcbiAgICAgIC8vIGZyb250RnJhbWUgaXMgcmVzZXQsIHNvIGZyYW1lLmN1cnNvciBvbiB0aGUgbmV4dCByZW5kZXIgaXMgKDAsMCkuXG4gICAgICAvLyBDbGVhciBkaXNwbGF5Q3Vyc29yIHNvIHRoZSBwcmVhbWJsZSBkb2Vzbid0IGNvbXB1dGUgYSBzdGFsZSBkZWx0YS5cbiAgICAgIHRoaXMuZGlzcGxheUN1cnNvciA9IG51bGxcbiAgICB9XG4gIH1cblxuICAvKipcbiAgICogUmVwbGFjZSBjaGFyL2h5cGVybGluayBwb29scyB3aXRoIGZyZXNoIGluc3RhbmNlcyB0byBwcmV2ZW50IHVuYm91bmRlZFxuICAgKiBncm93dGggZHVyaW5nIGxvbmcgc2Vzc2lvbnMuIE1pZ3JhdGVzIHRoZSBmcm9udCBmcmFtZSdzIHNjcmVlbiBJRHMgaW50b1xuICAgKiB0aGUgbmV3IHBvb2xzIHNvIGRpZmZpbmcgcmVtYWlucyBjb3JyZWN0LiBUaGUgYmFjayBmcmFtZSBkb2Vzbid0IG5lZWRcbiAgICogbWlncmF0aW9uIOKAlCByZXNldFNjcmVlbiB6ZXJvcyBpdCBiZWZvcmUgYW55IHJlYWRzLlxuICAgKlxuICAgKiBDYWxsIGJldHdlZW4gY29udmVyc2F0aW9uIHR1cm5zIG9yIHBlcmlvZGljYWxseS5cbiAgICovXG4gIHJlc2V0UG9vbHMoKTogdm9pZCB7XG4gICAgdGhpcy5jaGFyUG9vbCA9IG5ldyBDaGFyUG9vbCgpXG4gICAgdGhpcy5oeXBlcmxpbmtQb29sID0gbmV3IEh5cGVybGlua1Bvb2woKVxuICAgIG1pZ3JhdGVTY3JlZW5Qb29scyhcbiAgICAgIHRoaXMuZnJvbnRGcmFtZS5zY3JlZW4sXG4gICAgICB0aGlzLmNoYXJQb29sLFxuICAgICAgdGhpcy5oeXBlcmxpbmtQb29sLFxuICAgIClcbiAgICAvLyBCYWNrIGZyYW1lJ3MgZGF0YSBpcyB6ZXJvZWQgYnkgcmVzZXRTY3JlZW4gYmVmb3JlIHJlYWRzLCBidXQgaXRzIHBvb2xcbiAgICAvLyByZWZlcmVuY2VzIGFyZSB1c2VkIGJ5IHRoZSByZW5kZXJlciB0byBpbnRlcm4gbmV3IGNoYXJhY3RlcnMuIFBvaW50XG4gICAgLy8gdGhlbSBhdCB0aGUgbmV3IHBvb2xzIHNvIHRoZSBuZXh0IGZyYW1lJ3MgSURzIGFyZSBjb21wYXJhYmxlLlxuICAgIHRoaXMuYmFja0ZyYW1lLnNjcmVlbi5jaGFyUG9vbCA9IHRoaXMuY2hhclBvb2xcbiAgICB0aGlzLmJhY2tGcmFtZS5zY3JlZW4uaHlwZXJsaW5rUG9vbCA9IHRoaXMuaHlwZXJsaW5rUG9vbFxuICB9XG5cbiAgcGF0Y2hDb25zb2xlKCk6ICgpID0+IHZvaWQge1xuICAgIC8vIGJpb21lLWlnbm9yZSBsaW50L3N1c3BpY2lvdXMvbm9Db25zb2xlOiBpbnRlbnRpb25hbGx5IHBhdGNoaW5nIGdsb2JhbCBjb25zb2xlXG4gICAgY29uc3QgY29uID0gY29uc29sZVxuICAgIGNvbnN0IG9yaWdpbmFsczogUGFydGlhbDxSZWNvcmQ8a2V5b2YgQ29uc29sZSwgQ29uc29sZVtrZXlvZiBDb25zb2xlXT4+ID0ge31cbiAgICBjb25zdCB0b0RlYnVnID0gKC4uLmFyZ3M6IHVua25vd25bXSkgPT5cbiAgICAgIGxvZ0ZvckRlYnVnZ2luZyhgY29uc29sZS5sb2c6ICR7Zm9ybWF0KC4uLmFyZ3MpfWApXG4gICAgY29uc3QgdG9FcnJvciA9ICguLi5hcmdzOiB1bmtub3duW10pID0+XG4gICAgICBsb2dFcnJvcihuZXcgRXJyb3IoYGNvbnNvbGUuZXJyb3I6ICR7Zm9ybWF0KC4uLmFyZ3MpfWApKVxuICAgIGZvciAoY29uc3QgbSBvZiBDT05TT0xFX1NURE9VVF9NRVRIT0RTKSB7XG4gICAgICBvcmlnaW5hbHNbbV0gPSBjb25bbV1cbiAgICAgIGNvblttXSA9IHRvRGVidWdcbiAgICB9XG4gICAgZm9yIChjb25zdCBtIG9mIENPTlNPTEVfU1RERVJSX01FVEhPRFMpIHtcbiAgICAgIG9yaWdpbmFsc1ttXSA9IGNvblttXVxuICAgICAgY29uW21dID0gdG9FcnJvclxuICAgIH1cbiAgICBvcmlnaW5hbHMuYXNzZXJ0ID0gY29uLmFzc2VydFxuICAgIGNvbi5hc3NlcnQgPSAoY29uZGl0aW9uOiB1bmtub3duLCAuLi5hcmdzOiB1bmtub3duW10pID0+IHtcbiAgICAgIGlmICghY29uZGl0aW9uKSB0b0Vycm9yKC4uLmFyZ3MpXG4gICAgfVxuICAgIHJldHVybiAoKSA9PiBPYmplY3QuYXNzaWduKGNvbiwgb3JpZ2luYWxzKVxuICB9XG5cbiAgLyoqXG4gICAqIEludGVyY2VwdCBwcm9jZXNzLnN0ZGVyci53cml0ZSBzbyBzdHJheSB3cml0ZXMgKGNvbmZpZy50cywgaG9va3MudHMsXG4gICAqIHRoaXJkLXBhcnR5IGRlcHMpIGRvbid0IGNvcnJ1cHQgdGhlIGFsdC1zY3JlZW4gYnVmZmVyLiBwYXRjaENvbnNvbGUgb25seVxuICAgKiBob29rcyBjb25zb2xlLiogbWV0aG9kcyDigJQgZGlyZWN0IHN0ZGVyciB3cml0ZXMgYnlwYXNzIGl0LCBsYW5kIGF0IHRoZVxuICAgKiBwYXJrZWQgY3Vyc29yLCBzY3JvbGwgdGhlIGFsdC1zY3JlZW4sIGFuZCBkZXN5bmMgZnJvbnRGcmFtZSBmcm9tIHRoZVxuICAgKiBwaHlzaWNhbCB0ZXJtaW5hbC4gTmV4dCBkaWZmIHdyaXRlcyBvbmx5IGNoYW5nZWQtaW4tUmVhY3QgY2VsbHMgYXRcbiAgICogYWJzb2x1dGUgY29vcmRzIOKGkiBpbnRlcmxlYXZlZCBnYXJiYWdlLlxuICAgKlxuICAgKiBTd2FsbG93cyB0aGUgd3JpdGUgKHJvdXRlcyB0ZXh0IHRvIHRoZSBkZWJ1ZyBsb2cpIGFuZCwgaW4gYWx0LXNjcmVlbixcbiAgICogZm9yY2VzIGEgZnVsbC1kYW1hZ2UgcmVwYWludCBhcyBhIGRlZmVuc2l2ZSByZWNvdmVyeS4gTm90IHBhdGNoaW5nXG4gICAqIHByb2Nlc3Muc3Rkb3V0IOKAlCBJbmsgaXRzZWxmIHdyaXRlcyB0aGVyZS5cbiAgICovXG4gIHByaXZhdGUgcGF0Y2hTdGRlcnIoKTogKCkgPT4gdm9pZCB7XG4gICAgY29uc3Qgc3RkZXJyID0gcHJvY2Vzcy5zdGRlcnJcbiAgICBjb25zdCBvcmlnaW5hbFdyaXRlID0gc3RkZXJyLndyaXRlXG4gICAgbGV0IHJlZW50ZXJlZCA9IGZhbHNlXG4gICAgY29uc3QgaW50ZXJjZXB0ID0gKFxuICAgICAgY2h1bms6IFVpbnQ4QXJyYXkgfCBzdHJpbmcsXG4gICAgICBlbmNvZGluZ09yQ2I/OiBCdWZmZXJFbmNvZGluZyB8ICgoZXJyPzogRXJyb3IpID0+IHZvaWQpLFxuICAgICAgY2I/OiAoZXJyPzogRXJyb3IpID0+IHZvaWQsXG4gICAgKTogYm9vbGVhbiA9PiB7XG4gICAgICBjb25zdCBjYWxsYmFjayA9IHR5cGVvZiBlbmNvZGluZ09yQ2IgPT09ICdmdW5jdGlvbicgPyBlbmNvZGluZ09yQ2IgOiBjYlxuICAgICAgLy8gUmVlbnRyYW5jeSBndWFyZDogbG9nRm9yRGVidWdnaW5nIOKGkiB3cml0ZVRvU3RkZXJyIOKGkiBoZXJlLiBQYXNzXG4gICAgICAvLyB0aHJvdWdoIHRvIHRoZSBvcmlnaW5hbCBzbyAtLWRlYnVnLXRvLXN0ZGVyciBzdGlsbCB3b3JrcyBhbmQgd2VcbiAgICAgIC8vIGRvbid0IHN0YWNrLW92ZXJmbG93LlxuICAgICAgaWYgKHJlZW50ZXJlZCkge1xuICAgICAgICBjb25zdCBlbmNvZGluZyA9XG4gICAgICAgICAgdHlwZW9mIGVuY29kaW5nT3JDYiA9PT0gJ3N0cmluZycgPyBlbmNvZGluZ09yQ2IgOiB1bmRlZmluZWRcbiAgICAgICAgcmV0dXJuIG9yaWdpbmFsV3JpdGUuY2FsbChzdGRlcnIsIGNodW5rLCBlbmNvZGluZywgY2FsbGJhY2spXG4gICAgICB9XG4gICAgICByZWVudGVyZWQgPSB0cnVlXG4gICAgICB0cnkge1xuICAgICAgICBjb25zdCB0ZXh0ID1cbiAgICAgICAgICB0eXBlb2YgY2h1bmsgPT09ICdzdHJpbmcnXG4gICAgICAgICAgICA/IGNodW5rXG4gICAgICAgICAgICA6IEJ1ZmZlci5mcm9tKGNodW5rKS50b1N0cmluZygndXRmOCcpXG4gICAgICAgIGxvZ0ZvckRlYnVnZ2luZyhgW3N0ZGVycl0gJHt0ZXh0fWAsIHsgbGV2ZWw6ICd3YXJuJyB9KVxuICAgICAgICBpZiAodGhpcy5hbHRTY3JlZW5BY3RpdmUgJiYgIXRoaXMuaXNVbm1vdW50ZWQgJiYgIXRoaXMuaXNQYXVzZWQpIHtcbiAgICAgICAgICB0aGlzLnByZXZGcmFtZUNvbnRhbWluYXRlZCA9IHRydWVcbiAgICAgICAgICB0aGlzLnNjaGVkdWxlUmVuZGVyKClcbiAgICAgICAgfVxuICAgICAgfSBmaW5hbGx5IHtcbiAgICAgICAgcmVlbnRlcmVkID0gZmFsc2VcbiAgICAgICAgY2FsbGJhY2s/LigpXG4gICAgICB9XG4gICAgICByZXR1cm4gdHJ1ZVxuICAgIH1cbiAgICBzdGRlcnIud3JpdGUgPSBpbnRlcmNlcHRcbiAgICByZXR1cm4gKCkgPT4ge1xuICAgICAgaWYgKHN0ZGVyci53cml0ZSA9PT0gaW50ZXJjZXB0KSB7XG4gICAgICAgIHN0ZGVyci53cml0ZSA9IG9yaWdpbmFsV3JpdGVcbiAgICAgIH1cbiAgICB9XG4gIH1cbn1cblxuLyoqXG4gKiBEaXNjYXJkIHBlbmRpbmcgc3RkaW4gYnl0ZXMgc28gaW4tZmxpZ2h0IGVzY2FwZSBzZXF1ZW5jZXMgKG1vdXNlIHRyYWNraW5nXG4gKiByZXBvcnRzLCBicmFja2V0ZWQtcGFzdGUgbWFya2VycykgZG9uJ3QgbGVhayB0byB0aGUgc2hlbGwgYWZ0ZXIgZXhpdC5cbiAqXG4gKiBUd28gbGF5ZXJzIG9mIHRyaWNraW5lc3M6XG4gKlxuICogMS4gc2V0UmF3TW9kZSBpcyB0ZXJtaW9zLCBub3QgZmNudGwg4oCUIHRoZSBzdGRpbiBmZCBzdGF5cyBibG9ja2luZywgc29cbiAqICAgIHJlYWRTeW5jIG9uIGl0IHdvdWxkIGhhbmcgZm9yZXZlci4gTm9kZSBkb2Vzbid0IGV4cG9zZSBmY250bCwgc28gd2VcbiAqICAgIG9wZW4gL2Rldi90dHkgZnJlc2ggd2l0aCBPX05PTkJMT0NLIChhbGwgZmRzIHRvIHRoZSBjb250cm9sbGluZ1xuICogICAgdGVybWluYWwgc2hhcmUgb25lIGxpbmUtZGlzY2lwbGluZSBpbnB1dCBxdWV1ZSkuXG4gKlxuICogMi4gQnkgdGhlIHRpbWUgZm9yY2VFeGl0IGNhbGxzIHRoaXMsIGRldGFjaEZvclNodXRkb3duIGhhcyBhbHJlYWR5IHB1dFxuICogICAgdGhlIFRUWSBiYWNrIGluIGNvb2tlZCAoY2Fub25pY2FsKSBtb2RlLiBDYW5vbmljYWwgbW9kZSBsaW5lLWJ1ZmZlcnNcbiAqICAgIGlucHV0IHVudGlsIG5ld2xpbmUsIHNvIE9fTk9OQkxPQ0sgcmVhZHMgcmV0dXJuIEVBR0FJTiBldmVuIHdoZW5cbiAqICAgIG1vdXNlIGJ5dGVzIGFyZSBzaXR0aW5nIGluIHRoZSBidWZmZXIuIFdlIGJyaWVmbHkgcmUtZW50ZXIgcmF3IG1vZGVcbiAqICAgIHNvIHJlYWRzIHJldHVybiBhbnkgYXZhaWxhYmxlIGJ5dGVzLCB0aGVuIHJlc3RvcmUgY29va2VkIG1vZGUuXG4gKlxuICogU2FmZSB0byBjYWxsIG11bHRpcGxlIHRpbWVzLiBDYWxsIGFzIExBVEUgYXMgcG9zc2libGUgaW4gdGhlIGV4aXQgcGF0aDpcbiAqIERJU0FCTEVfTU9VU0VfVFJBQ0tJTkcgaGFzIHRlcm1pbmFsIHJvdW5kLXRyaXAgbGF0ZW5jeSwgc28gZXZlbnRzIGNhblxuICogYXJyaXZlIGZvciBhIGZldyBtcyBhZnRlciBpdCdzIHdyaXR0ZW4uXG4gKi9cbi8qIGVzbGludC1kaXNhYmxlIGN1c3RvbS1ydWxlcy9uby1zeW5jLWZzIC0tIG11c3QgYmUgc3luYzsgY2FsbGVkIGZyb20gc2lnbmFsIGhhbmRsZXIgLyB1bm1vdW50ICovXG5leHBvcnQgZnVuY3Rpb24gZHJhaW5TdGRpbihzdGRpbjogTm9kZUpTLlJlYWRTdHJlYW0gPSBwcm9jZXNzLnN0ZGluKTogdm9pZCB7XG4gIGlmICghc3RkaW4uaXNUVFkpIHJldHVyblxuICAvLyBEcmFpbiBOb2RlJ3Mgc3RyZWFtIGJ1ZmZlciAoYnl0ZXMgbGlidXYgYWxyZWFkeSBwdWxsZWQgaW4pLiByZWFkKClcbiAgLy8gcmV0dXJucyBudWxsIHdoZW4gZW1wdHkg4oCUIG5ldmVyIGJsb2Nrcy5cbiAgdHJ5IHtcbiAgICB3aGlsZSAoc3RkaW4ucmVhZCgpICE9PSBudWxsKSB7XG4gICAgICAvKiBkaXNjYXJkICovXG4gICAgfVxuICB9IGNhdGNoIHtcbiAgICAvKiBzdHJlYW0gbWF5IGJlIGRlc3Ryb3llZCAqL1xuICB9XG4gIC8vIE5vIC9kZXYvdHR5IG9uIFdpbmRvd3M7IENPTklOJCBkb2Vzbid0IHN1cHBvcnQgT19OT05CTE9DSyBzZW1hbnRpY3MuXG4gIC8vIFdpbmRvd3MgVGVybWluYWwgYWxzbyBkb2Vzbid0IGJ1ZmZlciBtb3VzZSByZXBvcnRzIHRoZSBzYW1lIHdheS5cbiAgaWYgKHByb2Nlc3MucGxhdGZvcm0gPT09ICd3aW4zMicpIHJldHVyblxuICAvLyB0ZXJtaW9zIGlzIHBlci1kZXZpY2U6IGZsaXAgc3RkaW4gdG8gcmF3IHNvIGNhbm9uaWNhbC1tb2RlIGxpbmVcbiAgLy8gYnVmZmVyaW5nIGRvZXNuJ3QgaGlkZSBwYXJ0aWFsIGlucHV0IGZyb20gdGhlIG5vbi1ibG9ja2luZyByZWFkLlxuICAvLyBSZXN0b3JlZCBpbiB0aGUgZmluYWxseSBibG9jay5cbiAgY29uc3QgdHR5ID0gc3RkaW4gYXMgTm9kZUpTLlJlYWRTdHJlYW0gJiB7XG4gICAgaXNSYXc/OiBib29sZWFuXG4gICAgc2V0UmF3TW9kZT86IChyYXc6IGJvb2xlYW4pID0+IHZvaWRcbiAgfVxuICBjb25zdCB3YXNSYXcgPSB0dHkuaXNSYXcgPT09IHRydWVcbiAgLy8gRHJhaW4gdGhlIGtlcm5lbCBUVFkgYnVmZmVyIHZpYSBhIGZyZXNoIE9fTk9OQkxPQ0sgZmQuIEJvdW5kZWQgYXQgNjRcbiAgLy8gcmVhZHMgKDY0S0IpIOKAlCBhIHJlYWwgbW91c2UgYnVyc3QgaXMgYSBmZXcgaHVuZHJlZCBieXRlczsgdGhlIGNhcFxuICAvLyBndWFyZHMgYWdhaW5zdCBhIHRlcm1pbmFsIHRoYXQgaWdub3JlcyBPX05PTkJMT0NLLlxuICBsZXQgZmQgPSAtMVxuICB0cnkge1xuICAgIC8vIHNldFJhd01vZGUgaW5zaWRlIHRyeTogb24gcmV2b2tlZCBUVFkgKFNJR0hVUC9TU0ggZGlzY29ubmVjdCkgdGhlXG4gICAgLy8gaW9jdGwgdGhyb3dzIEVCQURGIOKAlCBzYW1lIHJlY292ZXJ5IHBhdGggYXMgb3BlblN5bmMvcmVhZFN5bmMgYmVsb3cuXG4gICAgaWYgKCF3YXNSYXcpIHR0eS5zZXRSYXdNb2RlPy4odHJ1ZSlcbiAgICBmZCA9IG9wZW5TeW5jKCcvZGV2L3R0eScsIGZzQ29uc3RhbnRzLk9fUkRPTkxZIHwgZnNDb25zdGFudHMuT19OT05CTE9DSylcbiAgICBjb25zdCBidWYgPSBCdWZmZXIuYWxsb2MoMTAyNClcbiAgICBmb3IgKGxldCBpID0gMDsgaSA8IDY0OyBpKyspIHtcbiAgICAgIGlmIChyZWFkU3luYyhmZCwgYnVmLCAwLCBidWYubGVuZ3RoLCBudWxsKSA8PSAwKSBicmVha1xuICAgIH1cbiAgfSBjYXRjaCB7XG4gICAgLy8gRUFHQUlOIChidWZmZXIgZW1wdHkg4oCUIGV4cGVjdGVkKSwgRU5YSU8vRU5PRU5UIChubyBjb250cm9sbGluZyB0dHkpLFxuICAgIC8vIEVCQURGL0VJTyAoVFRZIHJldm9rZWQg4oCUIFNJR0hVUCwgU1NIIGRpc2Nvbm5lY3QpXG4gIH0gZmluYWxseSB7XG4gICAgaWYgKGZkID49IDApIHtcbiAgICAgIHRyeSB7XG4gICAgICAgIGNsb3NlU3luYyhmZClcbiAgICAgIH0gY2F0Y2gge1xuICAgICAgICAvKiBpZ25vcmUgKi9cbiAgICAgIH1cbiAgICB9XG4gICAgaWYgKCF3YXNSYXcpIHtcbiAgICAgIHRyeSB7XG4gICAgICAgIHR0eS5zZXRSYXdNb2RlPy4oZmFsc2UpXG4gICAgICB9IGNhdGNoIHtcbiAgICAgICAgLyogVFRZIG1heSBiZSBnb25lICovXG4gICAgICB9XG4gICAgfVxuICB9XG59XG4vKiBlc2xpbnQtZW5hYmxlIGN1c3RvbS1ydWxlcy9uby1zeW5jLWZzICovXG5cbmNvbnN0IENPTlNPTEVfU1RET1VUX01FVEhPRFMgPSBbXG4gICdsb2cnLFxuICAnaW5mbycsXG4gICdkZWJ1ZycsXG4gICdkaXInLFxuICAnZGlyeG1sJyxcbiAgJ2NvdW50JyxcbiAgJ2NvdW50UmVzZXQnLFxuICAnZ3JvdXAnLFxuICAnZ3JvdXBDb2xsYXBzZWQnLFxuICAnZ3JvdXBFbmQnLFxuICAndGFibGUnLFxuICAndGltZScsXG4gICd0aW1lRW5kJyxcbiAgJ3RpbWVMb2cnLFxuXSBhcyBjb25zdFxuY29uc3QgQ09OU09MRV9TVERFUlJfTUVUSE9EUyA9IFsnd2FybicsICdlcnJvcicsICd0cmFjZSddIGFzIGNvbnN0XG4iXSwibWFwcGluZ3MiOiJBQUFBLE9BQU9BLFFBQVEsTUFBTSxXQUFXO0FBQ2hDLFNBQ0VDLFNBQVMsRUFDVEMsU0FBUyxJQUFJQyxXQUFXLEVBQ3hCQyxRQUFRLEVBQ1JDLFFBQVEsRUFDUkMsU0FBUyxRQUNKLElBQUk7QUFDWCxPQUFPQyxJQUFJLE1BQU0sbUJBQW1CO0FBQ3BDLE9BQU9DLFFBQVEsTUFBTSx1QkFBdUI7QUFDNUMsT0FBT0MsS0FBSyxJQUFJLEtBQUtDLFNBQVMsUUFBUSxPQUFPO0FBQzdDLGNBQWNDLFNBQVMsUUFBUSxrQkFBa0I7QUFDakQsU0FBU0MsY0FBYyxRQUFRLCtCQUErQjtBQUM5RCxTQUFTQyxNQUFNLFFBQVEsYUFBYTtBQUNwQyxTQUFTQyxvQkFBb0IsUUFBUSx3QkFBd0I7QUFDN0QsU0FBU0MsZUFBZSxRQUFRLG9DQUFvQztBQUNwRSxTQUFTQyxlQUFlLFFBQVEsb0JBQW9CO0FBQ3BELFNBQVNDLFFBQVEsUUFBUSxrQkFBa0I7QUFDM0MsU0FBU0MsTUFBTSxRQUFRLE1BQU07QUFDN0IsU0FBU0MsUUFBUSxRQUFRLGVBQWU7QUFDeEMsT0FBT0MsR0FBRyxNQUFNLHFCQUFxQjtBQUNyQyxjQUNFQyxpQkFBaUIsRUFDakJDLHVCQUF1QixRQUNsQiwwQ0FBMEM7QUFDakQsU0FBU0MsaUJBQWlCLFFBQVEsZ0JBQWdCO0FBQ2xELE9BQU8sS0FBS0MsR0FBRyxNQUFNLFVBQVU7QUFDL0IsU0FBU0MsYUFBYSxRQUFRLDRCQUE0QjtBQUMxRCxTQUFTQyxZQUFZLFFBQVEsWUFBWTtBQUN6QyxTQUFTQyxVQUFVLEVBQUUsS0FBS0MsS0FBSyxFQUFFLEtBQUtDLFVBQVUsUUFBUSxZQUFZO0FBQ3BFLFNBQVNDLGFBQWEsRUFBRUMsYUFBYSxRQUFRLGVBQWU7QUFDNUQsT0FBT0MsU0FBUyxNQUFNLGdCQUFnQjtBQUN0QyxTQUFTQyxTQUFTLFFBQVEsaUJBQWlCO0FBQzNDLFNBQVNDLFNBQVMsUUFBUSxpQkFBaUI7QUFDM0MsU0FBU0MsUUFBUSxRQUFRLGdCQUFnQjtBQUN6QyxPQUFPQyxNQUFNLE1BQU0sYUFBYTtBQUNoQyxjQUFjQyxTQUFTLFFBQVEscUJBQXFCO0FBQ3BELE9BQU9DLFVBQVUsSUFDZkMsVUFBVSxFQUNWQyxlQUFlLEVBQ2ZDLGFBQWEsRUFDYkMsc0JBQXNCLEVBQ3RCQyxZQUFZLEVBQ1pDLG9CQUFvQixRQUNmLGlCQUFpQjtBQUN4QixPQUFPQyxrQkFBa0IsSUFDdkJDLG1CQUFtQixFQUNuQkMsY0FBYyxRQUNULDRCQUE0QjtBQUNuQyxTQUNFQyx3QkFBd0IsRUFDeEIsS0FBS0MsYUFBYSxFQUNsQkMsYUFBYSxRQUNSLHVCQUF1QjtBQUM5QixPQUFPQyxjQUFjLElBQUksS0FBS0MsUUFBUSxRQUFRLGVBQWU7QUFDN0QsU0FDRUMsU0FBUyxFQUNUQyxRQUFRLEVBQ1JDLE1BQU0sRUFDTkMsWUFBWSxFQUNaQyxhQUFhLEVBQ2JDLGFBQWEsRUFDYkMsa0JBQWtCLEVBQ2xCQyxTQUFTLFFBQ0osYUFBYTtBQUNwQixTQUFTQyxvQkFBb0IsUUFBUSxzQkFBc0I7QUFDM0QsU0FDRUMscUJBQXFCLEVBQ3JCQyxtQkFBbUIsRUFDbkJDLGNBQWMsRUFDZEMsb0JBQW9CLEVBQ3BCQyxlQUFlLEVBQ2YsS0FBS0MsU0FBUyxFQUNkQyxrQkFBa0IsRUFDbEJDLGVBQWUsRUFDZkMsWUFBWSxFQUNaQyxTQUFTLEVBQ1QsS0FBS0MsY0FBYyxFQUNuQkMsWUFBWSxFQUNaQyxZQUFZLEVBQ1pDLFdBQVcsRUFDWEMsY0FBYyxFQUNkQyx1QkFBdUIsRUFDdkJDLGNBQWMsRUFDZEMsZUFBZSxRQUNWLGdCQUFnQjtBQUN2QixTQUNFQyxxQkFBcUIsRUFDckJDLG9CQUFvQixFQUNwQixLQUFLQyxRQUFRLEVBQ2JDLG1CQUFtQixRQUNkLGVBQWU7QUFDdEIsU0FDRUMsV0FBVyxFQUNYQyxVQUFVLEVBQ1ZDLGNBQWMsRUFDZEMsc0JBQXNCLEVBQ3RCQyx5QkFBeUIsRUFDekJDLHFCQUFxQixFQUNyQkMsd0JBQXdCLEVBQ3hCQyxZQUFZLFFBQ1AsaUJBQWlCO0FBQ3hCLFNBQ0VDLEdBQUcsRUFDSEMsR0FBRyxFQUNIQyxzQkFBc0IsRUFDdEJDLHFCQUFxQixFQUNyQkMsZ0JBQWdCLEVBQ2hCQyxlQUFlLEVBQ2ZDLFdBQVcsUUFDTixpQkFBaUI7QUFDeEIsU0FDRUMscUJBQXFCLEVBQ3JCQyxnQkFBZ0IsRUFDaEJDLFlBQVksRUFDWkMsaUJBQWlCLEVBQ2pCQyxrQkFBa0IsUUFDYixpQkFBaUI7QUFDeEIsU0FBU0MscUJBQXFCLFFBQVEsOEJBQThCOztBQUVwRTtBQUNBO0FBQ0E7QUFDQSxNQUFNQyx3QkFBd0IsR0FBR0MsTUFBTSxDQUFDQyxNQUFNLENBQUM7RUFBRUMsQ0FBQyxFQUFFLENBQUM7RUFBRUMsQ0FBQyxFQUFFLENBQUM7RUFBRUMsT0FBTyxFQUFFO0FBQU0sQ0FBQyxDQUFDO0FBQzlFLE1BQU1DLGlCQUFpQixHQUFHTCxNQUFNLENBQUNDLE1BQU0sQ0FBQztFQUN0Q0ssSUFBSSxFQUFFLFFBQVEsSUFBSUMsS0FBSztFQUN2QkMsT0FBTyxFQUFFOUI7QUFDWCxDQUFDLENBQUM7QUFDRixNQUFNK0IscUJBQXFCLEdBQUdULE1BQU0sQ0FBQ0MsTUFBTSxDQUFDO0VBQzFDSyxJQUFJLEVBQUUsUUFBUSxJQUFJQyxLQUFLO0VBQ3ZCQyxPQUFPLEVBQUV2QixZQUFZLEdBQUdQO0FBQzFCLENBQUMsQ0FBQzs7QUFFRjtBQUNBO0FBQ0EsU0FBU2dDLHNCQUFzQkEsQ0FBQ0MsWUFBWSxFQUFFLE1BQU0sRUFBRTtFQUNwRCxPQUFPWCxNQUFNLENBQUNDLE1BQU0sQ0FBQztJQUNuQkssSUFBSSxFQUFFLFFBQVEsSUFBSUMsS0FBSztJQUN2QkMsT0FBTyxFQUFFNUIsY0FBYyxDQUFDK0IsWUFBWSxFQUFFLENBQUM7RUFDekMsQ0FBQyxDQUFDO0FBQ0o7QUFFQSxPQUFPLEtBQUtDLE9BQU8sR0FBRztFQUNwQkMsTUFBTSxFQUFFQyxNQUFNLENBQUNDLFdBQVc7RUFDMUJDLEtBQUssRUFBRUYsTUFBTSxDQUFDRyxVQUFVO0VBQ3hCQyxNQUFNLEVBQUVKLE1BQU0sQ0FBQ0MsV0FBVztFQUMxQkksV0FBVyxFQUFFLE9BQU87RUFDcEJDLFlBQVksRUFBRSxPQUFPO0VBQ3JCQyxhQUFhLENBQUMsRUFBRSxHQUFHLEdBQUdDLE9BQU8sQ0FBQyxJQUFJLENBQUM7RUFDbkNDLE9BQU8sQ0FBQyxFQUFFLENBQUNDLEtBQUssRUFBRXJHLFVBQVUsRUFBRSxHQUFHLElBQUk7QUFDdkMsQ0FBQztBQUVELGVBQWUsTUFBTXNHLEdBQUcsQ0FBQztFQUN2QixpQkFBaUJDLEdBQUcsRUFBRW5HLFNBQVM7RUFDL0IsaUJBQWlCb0csUUFBUSxFQUFFbkQsUUFBUTtFQUNuQyxRQUFRb0QsY0FBYyxFQUFFLENBQUMsR0FBRyxHQUFHLElBQUksQ0FBQyxHQUFHO0lBQUVDLE1BQU0sQ0FBQyxFQUFFLEdBQUcsR0FBRyxJQUFJO0VBQUMsQ0FBQztFQUM5RDtFQUNBLFFBQVFDLFdBQVcsR0FBRyxLQUFLO0VBQzNCLFFBQVFDLFFBQVEsR0FBRyxLQUFLO0VBQ3hCLGlCQUFpQkMsU0FBUyxFQUFFL0gsU0FBUztFQUNyQyxRQUFRZ0ksUUFBUSxFQUFFbkgsR0FBRyxDQUFDb0gsVUFBVTtFQUNoQyxTQUFTQyxZQUFZLEVBQUVuSCxZQUFZO0VBQ25DLFFBQVFvSCxRQUFRLEVBQUUxRixRQUFRO0VBQzFCLGlCQUFpQjJGLFNBQVMsRUFBRW5GLFNBQVM7RUFDckMsUUFBUW9GLFFBQVEsRUFBRTFGLFFBQVE7RUFDMUIsUUFBUTJGLGFBQWEsRUFBRXhGLGFBQWE7RUFDcEMsUUFBUXlGLFdBQVcsQ0FBQyxFQUFFbEIsT0FBTyxDQUFDLElBQUksQ0FBQztFQUNuQyxRQUFRbUIsY0FBYyxDQUFDLEVBQUUsR0FBRyxHQUFHLElBQUk7RUFDbkMsUUFBUUMsYUFBYSxDQUFDLEVBQUUsR0FBRyxHQUFHLElBQUk7RUFDbEMsaUJBQWlCQyxzQkFBc0IsQ0FBQyxFQUFFLEdBQUcsR0FBRyxJQUFJO0VBQ3BELFFBQVFDLGVBQWUsRUFBRSxNQUFNO0VBQy9CLFFBQVFqQyxZQUFZLEVBQUUsTUFBTTtFQUM1QixRQUFRa0MsV0FBVyxFQUFFN0ksU0FBUyxHQUFHLElBQUk7RUFDckMsUUFBUThJLFVBQVUsRUFBRTVILEtBQUs7RUFDekIsUUFBUTZILFNBQVMsRUFBRTdILEtBQUs7RUFDeEIsUUFBUThILGlCQUFpQixHQUFHQyxXQUFXLENBQUNDLEdBQUcsQ0FBQyxDQUFDO0VBQzdDLFFBQVFDLFVBQVUsRUFBRUMsVUFBVSxDQUFDLE9BQU9DLFVBQVUsQ0FBQyxHQUFHLElBQUksR0FBRyxJQUFJO0VBQy9ELFFBQVFDLGdCQUFnQixFQUFFO0lBQ3hCQyxFQUFFLEVBQUUsTUFBTTtJQUNWQyxPQUFPLEVBQUUsTUFBTTtJQUNmQyxRQUFRLEVBQUUsTUFBTTtJQUNoQkMsU0FBUyxFQUFFLE1BQU07SUFDakJDLElBQUksRUFBRSxNQUFNO0VBQ2QsQ0FBQyxHQUFHO0lBQUVKLEVBQUUsRUFBRSxDQUFDO0lBQUVDLE9BQU8sRUFBRSxDQUFDO0lBQUVDLFFBQVEsRUFBRSxDQUFDO0lBQUVDLFNBQVMsRUFBRSxDQUFDO0lBQUVDLElBQUksRUFBRTtFQUFFLENBQUM7RUFDN0QsUUFBUUMsa0JBQWtCLEVBQUVDLFFBQVEsQ0FBQztJQUFFdkQsSUFBSSxFQUFFLFFBQVE7SUFBRUUsT0FBTyxFQUFFLE1BQU07RUFBQyxDQUFDLENBQUM7RUFDekU7RUFDQTtFQUNBO0VBQ0EsU0FBU3NELFNBQVMsRUFBRWhHLGNBQWMsR0FBR1Asb0JBQW9CLENBQUMsQ0FBQztFQUMzRDtFQUNBO0VBQ0EsUUFBUXdHLG9CQUFvQixHQUFHLEVBQUU7RUFDakM7RUFDQTtFQUNBO0VBQ0E7RUFDQTtFQUNBO0VBQ0EsUUFBUUMsZUFBZSxFQUFFO0lBQ3ZCQyxTQUFTLEVBQUUxSCxhQUFhLEVBQUU7SUFDMUIySCxTQUFTLEVBQUUsTUFBTTtJQUNqQkMsVUFBVSxFQUFFLE1BQU07RUFDcEIsQ0FBQyxHQUFHLElBQUksR0FBRyxJQUFJO0VBQ2Y7RUFDQTtFQUNBO0VBQ0EsaUJBQWlCQyxrQkFBa0IsR0FBRyxJQUFJQyxHQUFHLENBQUMsR0FBRyxHQUFHLElBQUksQ0FBQyxDQUFDLENBQUM7RUFDM0Q7RUFDQTtFQUNBO0VBQ0EsaUJBQWlCQyxZQUFZLEdBQUcsSUFBSUQsR0FBRyxDQUFDdkosR0FBRyxDQUFDb0gsVUFBVSxDQUFDLENBQUMsQ0FBQztFQUN6RDtFQUNBO0VBQ0E7RUFDQTtFQUNBLFFBQVFxQyxlQUFlLEdBQUcsS0FBSztFQUMvQjtFQUNBO0VBQ0EsUUFBUUMsc0JBQXNCLEdBQUcsS0FBSztFQUN0QztFQUNBO0VBQ0E7RUFDQTtFQUNBO0VBQ0EsUUFBUUMscUJBQXFCLEdBQUcsS0FBSztFQUNyQztFQUNBO0VBQ0E7RUFDQTtFQUNBO0VBQ0EsUUFBUUMscUJBQXFCLEdBQUcsS0FBSztFQUNyQztFQUNBO0VBQ0E7RUFDQTtFQUNBO0VBQ0EsUUFBUUMsaUJBQWlCLEVBQUVoSyxpQkFBaUIsR0FBRyxJQUFJLEdBQUcsSUFBSTtFQUMxRDtFQUNBO0VBQ0E7RUFDQTtFQUNBLFFBQVFpSyxhQUFhLEVBQUU7SUFBRTFFLENBQUMsRUFBRSxNQUFNO0lBQUVDLENBQUMsRUFBRSxNQUFNO0VBQUMsQ0FBQyxHQUFHLElBQUksR0FBRyxJQUFJO0VBRTdEMEUsV0FBV0EsQ0FBQyxpQkFBaUJDLE9BQU8sRUFBRWxFLE9BQU8sRUFBRTtJQUM3Q3RILFFBQVEsQ0FBQyxJQUFJLENBQUM7SUFFZCxJQUFJLElBQUksQ0FBQ3dMLE9BQU8sQ0FBQzFELFlBQVksRUFBRTtNQUM3QixJQUFJLENBQUNxQixjQUFjLEdBQUcsSUFBSSxDQUFDckIsWUFBWSxDQUFDLENBQUM7TUFDekMsSUFBSSxDQUFDc0IsYUFBYSxHQUFHLElBQUksQ0FBQ3FDLFdBQVcsQ0FBQyxDQUFDO0lBQ3pDO0lBRUEsSUFBSSxDQUFDcEQsUUFBUSxHQUFHO01BQ2RkLE1BQU0sRUFBRWlFLE9BQU8sQ0FBQ2pFLE1BQU07TUFDdEJLLE1BQU0sRUFBRTRELE9BQU8sQ0FBQzVEO0lBQ2xCLENBQUM7SUFFRCxJQUFJLENBQUMwQixlQUFlLEdBQUdrQyxPQUFPLENBQUNqRSxNQUFNLENBQUNtRSxPQUFPLElBQUksRUFBRTtJQUNuRCxJQUFJLENBQUNyRSxZQUFZLEdBQUdtRSxPQUFPLENBQUNqRSxNQUFNLENBQUNvRSxJQUFJLElBQUksRUFBRTtJQUM3QyxJQUFJLENBQUNyQixrQkFBa0IsR0FBR2xELHNCQUFzQixDQUFDLElBQUksQ0FBQ0MsWUFBWSxDQUFDO0lBQ25FLElBQUksQ0FBQzBCLFNBQVMsR0FBRyxJQUFJbkYsU0FBUyxDQUFDLENBQUM7SUFDaEMsSUFBSSxDQUFDb0YsUUFBUSxHQUFHLElBQUkxRixRQUFRLENBQUMsQ0FBQztJQUM5QixJQUFJLENBQUMyRixhQUFhLEdBQUcsSUFBSXhGLGFBQWEsQ0FBQyxDQUFDO0lBQ3hDLElBQUksQ0FBQytGLFVBQVUsR0FBRzdILFVBQVUsQ0FDMUIsSUFBSSxDQUFDMEYsWUFBWSxFQUNqQixJQUFJLENBQUNpQyxlQUFlLEVBQ3BCLElBQUksQ0FBQ1AsU0FBUyxFQUNkLElBQUksQ0FBQ0MsUUFBUSxFQUNiLElBQUksQ0FBQ0MsYUFDUCxDQUFDO0lBQ0QsSUFBSSxDQUFDUSxTQUFTLEdBQUc5SCxVQUFVLENBQ3pCLElBQUksQ0FBQzBGLFlBQVksRUFDakIsSUFBSSxDQUFDaUMsZUFBZSxFQUNwQixJQUFJLENBQUNQLFNBQVMsRUFDZCxJQUFJLENBQUNDLFFBQVEsRUFDYixJQUFJLENBQUNDLGFBQ1AsQ0FBQztJQUVELElBQUksQ0FBQ2IsR0FBRyxHQUFHLElBQUluRyxTQUFTLENBQUM7TUFDdkIySixLQUFLLEVBQUdKLE9BQU8sQ0FBQ2pFLE1BQU0sQ0FBQ3FFLEtBQUssSUFBSSxPQUFPLEdBQUcsU0FBUyxJQUFLLEtBQUs7TUFDN0Q3QyxTQUFTLEVBQUUsSUFBSSxDQUFDQTtJQUNsQixDQUFDLENBQUM7O0lBRUY7SUFDQTtJQUNBO0lBQ0E7SUFDQTtJQUNBO0lBQ0E7SUFDQTtJQUNBO0lBQ0EsTUFBTThDLGNBQWMsR0FBR0EsQ0FBQSxDQUFFLEVBQUUsSUFBSSxJQUFJQyxjQUFjLENBQUMsSUFBSSxDQUFDQyxRQUFRLENBQUM7SUFDaEUsSUFBSSxDQUFDekQsY0FBYyxHQUFHOUgsUUFBUSxDQUFDcUwsY0FBYyxFQUFFdEssaUJBQWlCLEVBQUU7TUFDaEV5SyxPQUFPLEVBQUUsSUFBSTtNQUNiQyxRQUFRLEVBQUU7SUFDWixDQUFDLENBQUM7O0lBRUY7SUFDQSxJQUFJLENBQUN6RCxXQUFXLEdBQUcsS0FBSzs7SUFFeEI7SUFDQSxJQUFJLENBQUMwRCxlQUFlLEdBQUdyTCxNQUFNLENBQUMsSUFBSSxDQUFDc0wsT0FBTyxFQUFFO01BQUVDLFVBQVUsRUFBRTtJQUFNLENBQUMsQ0FBQztJQUVsRSxJQUFJWixPQUFPLENBQUNqRSxNQUFNLENBQUNxRSxLQUFLLEVBQUU7TUFDeEJKLE9BQU8sQ0FBQ2pFLE1BQU0sQ0FBQzhFLEVBQUUsQ0FBQyxRQUFRLEVBQUUsSUFBSSxDQUFDQyxZQUFZLENBQUM7TUFDOUNDLE9BQU8sQ0FBQ0YsRUFBRSxDQUFDLFNBQVMsRUFBRSxJQUFJLENBQUNHLFlBQVksQ0FBQztNQUV4QyxJQUFJLENBQUNuRCxzQkFBc0IsR0FBRyxNQUFNO1FBQ2xDbUMsT0FBTyxDQUFDakUsTUFBTSxDQUFDa0YsR0FBRyxDQUFDLFFBQVEsRUFBRSxJQUFJLENBQUNILFlBQVksQ0FBQztRQUMvQ0MsT0FBTyxDQUFDRSxHQUFHLENBQUMsU0FBUyxFQUFFLElBQUksQ0FBQ0QsWUFBWSxDQUFDO01BQzNDLENBQUM7SUFDSDtJQUVBLElBQUksQ0FBQzdELFFBQVEsR0FBR25ILEdBQUcsQ0FBQ2tMLFVBQVUsQ0FBQyxVQUFVLENBQUM7SUFDMUMsSUFBSSxDQUFDN0QsWUFBWSxHQUFHLElBQUluSCxZQUFZLENBQUMsQ0FBQ2lMLE1BQU0sRUFBRXpFLEtBQUssS0FDakQzRixVQUFVLENBQUNxSyxnQkFBZ0IsQ0FBQ0QsTUFBTSxFQUFFekUsS0FBSyxDQUMzQyxDQUFDO0lBQ0QsSUFBSSxDQUFDUyxRQUFRLENBQUNFLFlBQVksR0FBRyxJQUFJLENBQUNBLFlBQVk7SUFDOUMsSUFBSSxDQUFDQyxRQUFRLEdBQUczRixjQUFjLENBQUMsSUFBSSxDQUFDd0YsUUFBUSxFQUFFLElBQUksQ0FBQ0ksU0FBUyxDQUFDO0lBQzdELElBQUksQ0FBQ0osUUFBUSxDQUFDb0QsUUFBUSxHQUFHLElBQUksQ0FBQ3pELGNBQWM7SUFDNUMsSUFBSSxDQUFDSyxRQUFRLENBQUNrRSxpQkFBaUIsR0FBRyxJQUFJLENBQUNkLFFBQVE7SUFDL0MsSUFBSSxDQUFDcEQsUUFBUSxDQUFDbUUsZUFBZSxHQUFHLE1BQU07TUFDcEM7TUFDQTtNQUNBO01BQ0EsSUFBSSxJQUFJLENBQUN0RSxXQUFXLEVBQUU7UUFDcEI7TUFDRjtNQUVBLElBQUksSUFBSSxDQUFDRyxRQUFRLENBQUNvRSxRQUFRLEVBQUU7UUFDMUIsTUFBTUMsRUFBRSxHQUFHckQsV0FBVyxDQUFDQyxHQUFHLENBQUMsQ0FBQztRQUM1QixJQUFJLENBQUNqQixRQUFRLENBQUNvRSxRQUFRLENBQUNFLFFBQVEsQ0FBQyxJQUFJLENBQUMzRCxlQUFlLENBQUM7UUFDckQsSUFBSSxDQUFDWCxRQUFRLENBQUNvRSxRQUFRLENBQUNHLGVBQWUsQ0FBQyxJQUFJLENBQUM1RCxlQUFlLENBQUM7UUFDNUQsTUFBTVcsRUFBRSxHQUFHTixXQUFXLENBQUNDLEdBQUcsQ0FBQyxDQUFDLEdBQUdvRCxFQUFFO1FBQ2pDckssWUFBWSxDQUFDc0gsRUFBRSxDQUFDO1FBQ2hCLE1BQU1rRCxDQUFDLEdBQUdwTSxlQUFlLENBQUMsQ0FBQztRQUMzQixJQUFJLENBQUNpSixnQkFBZ0IsR0FBRztVQUFFQyxFQUFFO1VBQUUsR0FBR2tEO1FBQUUsQ0FBQztNQUN0QztJQUNGLENBQUM7O0lBRUQ7SUFDQTtJQUNBLElBQUksQ0FBQ3pFLFNBQVMsR0FBR3BHLFVBQVUsQ0FBQzhLLGVBQWUsQ0FDekMsSUFBSSxDQUFDekUsUUFBUSxFQUNiL0gsY0FBYyxFQUNkLElBQUksRUFDSixLQUFLLEVBQ0wsSUFBSSxFQUNKLElBQUksRUFDSkwsSUFBSTtJQUFFO0lBQ05BLElBQUk7SUFBRTtJQUNOQSxJQUFJO0lBQUU7SUFDTkEsSUFBSSxDQUFFO0lBQ1IsQ0FBQztJQUVELElBQUksWUFBWSxLQUFLLGFBQWEsRUFBRTtNQUNsQytCLFVBQVUsQ0FBQytLLGtCQUFrQixDQUFDO1FBQzVCQyxVQUFVLEVBQUUsQ0FBQztRQUNiO1FBQ0E7UUFDQUMsT0FBTyxFQUFFLFNBQVM7UUFDbEJDLG1CQUFtQixFQUFFO01BQ3ZCLENBQUMsQ0FBQztJQUNKO0VBQ0Y7RUFFQSxRQUFRaEIsWUFBWSxHQUFHQSxDQUFBLEtBQU07SUFDM0IsSUFBSSxDQUFDLElBQUksQ0FBQ2hCLE9BQU8sQ0FBQ2pFLE1BQU0sQ0FBQ3FFLEtBQUssRUFBRTtNQUM5QjtJQUNGOztJQUVBO0lBQ0E7SUFDQTtJQUNBLElBQUksSUFBSSxDQUFDWCxlQUFlLEVBQUU7TUFDeEIsSUFBSSxDQUFDd0MsZ0JBQWdCLENBQUMsQ0FBQztNQUN2QjtJQUNGOztJQUVBO0lBQ0EsSUFBSSxDQUFDakUsVUFBVSxHQUFHN0gsVUFBVSxDQUMxQixJQUFJLENBQUM2SCxVQUFVLENBQUNrRSxRQUFRLENBQUNDLE1BQU0sRUFDL0IsSUFBSSxDQUFDbkUsVUFBVSxDQUFDa0UsUUFBUSxDQUFDRSxLQUFLLEVBQzlCLElBQUksQ0FBQzdFLFNBQVMsRUFDZCxJQUFJLENBQUNDLFFBQVEsRUFDYixJQUFJLENBQUNDLGFBQ1AsQ0FBQztJQUNELElBQUksQ0FBQ1EsU0FBUyxHQUFHOUgsVUFBVSxDQUN6QixJQUFJLENBQUM4SCxTQUFTLENBQUNpRSxRQUFRLENBQUNDLE1BQU0sRUFDOUIsSUFBSSxDQUFDbEUsU0FBUyxDQUFDaUUsUUFBUSxDQUFDRSxLQUFLLEVBQzdCLElBQUksQ0FBQzdFLFNBQVMsRUFDZCxJQUFJLENBQUNDLFFBQVEsRUFDYixJQUFJLENBQUNDLGFBQ1AsQ0FBQztJQUNELElBQUksQ0FBQ2IsR0FBRyxDQUFDeUYsS0FBSyxDQUFDLENBQUM7SUFDaEI7SUFDQTtJQUNBO0lBQ0EsSUFBSSxDQUFDdkMsYUFBYSxHQUFHLElBQUk7RUFDM0IsQ0FBQzs7RUFFRDtFQUNBO0VBQ0E7RUFDQTtFQUNBO0VBQ0E7RUFDQSxRQUFRZ0IsWUFBWSxHQUFHQSxDQUFBLEtBQU07SUFDM0IsTUFBTXdCLElBQUksR0FBRyxJQUFJLENBQUN0QyxPQUFPLENBQUNqRSxNQUFNLENBQUNtRSxPQUFPLElBQUksRUFBRTtJQUM5QyxNQUFNQyxJQUFJLEdBQUcsSUFBSSxDQUFDSCxPQUFPLENBQUNqRSxNQUFNLENBQUNvRSxJQUFJLElBQUksRUFBRTtJQUMzQztJQUNBO0lBQ0E7SUFDQSxJQUFJbUMsSUFBSSxLQUFLLElBQUksQ0FBQ3hFLGVBQWUsSUFBSXFDLElBQUksS0FBSyxJQUFJLENBQUN0RSxZQUFZLEVBQUU7SUFDakUsSUFBSSxDQUFDaUMsZUFBZSxHQUFHd0UsSUFBSTtJQUMzQixJQUFJLENBQUN6RyxZQUFZLEdBQUdzRSxJQUFJO0lBQ3hCLElBQUksQ0FBQ3JCLGtCQUFrQixHQUFHbEQsc0JBQXNCLENBQUMsSUFBSSxDQUFDQyxZQUFZLENBQUM7O0lBRW5FO0lBQ0E7SUFDQTtJQUNBO0lBQ0E7SUFDQTtJQUNBO0lBQ0E7SUFDQTtJQUNBO0lBQ0EsSUFBSSxJQUFJLENBQUM0RCxlQUFlLElBQUksQ0FBQyxJQUFJLENBQUN4QyxRQUFRLElBQUksSUFBSSxDQUFDK0MsT0FBTyxDQUFDakUsTUFBTSxDQUFDcUUsS0FBSyxFQUFFO01BQ3ZFLElBQUksSUFBSSxDQUFDVixzQkFBc0IsRUFBRTtRQUMvQixJQUFJLENBQUNNLE9BQU8sQ0FBQ2pFLE1BQU0sQ0FBQ3dHLEtBQUssQ0FBQ2hJLHFCQUFxQixDQUFDO01BQ2xEO01BQ0EsSUFBSSxDQUFDaUksdUJBQXVCLENBQUMsQ0FBQztNQUM5QixJQUFJLENBQUM1QyxxQkFBcUIsR0FBRyxJQUFJO0lBQ25DOztJQUVBO0lBQ0E7SUFDQTtJQUNBO0lBQ0E7SUFDQSxJQUFJLElBQUksQ0FBQzdCLFdBQVcsS0FBSyxJQUFJLEVBQUU7TUFDN0IsSUFBSSxDQUFDMEUsTUFBTSxDQUFDLElBQUksQ0FBQzFFLFdBQVcsQ0FBQztJQUMvQjtFQUNGLENBQUM7RUFFRDJFLGtCQUFrQixFQUFFLEdBQUcsR0FBRyxJQUFJLEdBQUdBLENBQUEsS0FBTSxDQUFDLENBQUM7RUFDekNDLGlCQUFpQixFQUFFLENBQUNDLE1BQWMsQ0FBUCxFQUFFQyxLQUFLLEVBQUUsR0FBRyxJQUFJLEdBQUdGLENBQUEsS0FBTSxDQUFDLENBQUM7RUFDdERqQyxlQUFlLEVBQUUsR0FBRyxHQUFHLElBQUksR0FBR0EsQ0FBQSxLQUFNLENBQUMsQ0FBQzs7RUFFdEM7QUFDRjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0VvQyxvQkFBb0JBLENBQUEsQ0FBRSxFQUFFLElBQUksQ0FBQztJQUMzQixJQUFJLENBQUNDLEtBQUssQ0FBQyxDQUFDO0lBQ1osSUFBSSxDQUFDQyxZQUFZLENBQUMsQ0FBQztJQUNuQixJQUFJLENBQUNoRCxPQUFPLENBQUNqRSxNQUFNLENBQUN3RyxLQUFLO0lBQ3ZCO0lBQ0E7SUFDQTtJQUNBeEksc0JBQXNCLEdBQ3BCQyx5QkFBeUIsSUFDeEIsSUFBSSxDQUFDMEYsc0JBQXNCLEdBQUdwRixzQkFBc0IsR0FBRyxFQUFFLENBQUM7SUFBRztJQUM3RCxJQUFJLENBQUNtRixlQUFlLEdBQUcsRUFBRSxHQUFHLGFBQWEsQ0FBQztJQUFHO0lBQzlDLGFBQWE7SUFBRztJQUNoQixTQUFTO0lBQUc7SUFDWixXQUFXO0lBQUc7SUFDZCxTQUFTO0lBQUc7SUFDWixRQUFRLENBQUU7SUFDZCxDQUFDO0VBQ0g7O0VBRUE7QUFDRjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0V3RCxtQkFBbUJBLENBQUEsQ0FBRSxFQUFFLElBQUksQ0FBQztJQUMxQixJQUFJLENBQUNqRCxPQUFPLENBQUNqRSxNQUFNLENBQUN3RyxLQUFLLENBQ3ZCLENBQUMsSUFBSSxDQUFDOUMsZUFBZSxHQUFHakYsZ0JBQWdCLEdBQUcsRUFBRTtJQUFJO0lBQy9DLFNBQVM7SUFBRztJQUNaLFFBQVE7SUFBRztJQUNWLElBQUksQ0FBQ2tGLHNCQUFzQixHQUFHbkYscUJBQXFCLEdBQUcsRUFBRSxDQUFDO0lBQUc7SUFDNUQsSUFBSSxDQUFDa0YsZUFBZSxHQUFHLEVBQUUsR0FBRyxhQUFhLENBQUM7SUFBRztJQUM5QyxXQUFXLENBQUU7SUFDakIsQ0FBQztJQUNELElBQUksQ0FBQ3lELFdBQVcsQ0FBQyxDQUFDO0lBQ2xCLElBQUksSUFBSSxDQUFDekQsZUFBZSxFQUFFO01BQ3hCLElBQUksQ0FBQytDLHVCQUF1QixDQUFDLENBQUM7SUFDaEMsQ0FBQyxNQUFNO01BQ0wsSUFBSSxDQUFDVyxPQUFPLENBQUMsQ0FBQztJQUNoQjtJQUNBLElBQUksQ0FBQ0MsTUFBTSxDQUFDLENBQUM7SUFDYjtJQUNBO0lBQ0E7SUFDQTtJQUNBO0lBQ0E7SUFDQSxJQUFJLENBQUNwRCxPQUFPLENBQUNqRSxNQUFNLENBQUN3RyxLQUFLLENBQ3ZCLGFBQWEsSUFDVjlJLG9CQUFvQixDQUFDLENBQUMsR0FDbkJNLHNCQUFzQixHQUN0QkUscUJBQXFCLEdBQ3JCQyx3QkFBd0IsR0FDeEIsRUFBRSxDQUNWLENBQUM7RUFDSDtFQUVBcUcsUUFBUUEsQ0FBQSxFQUFHO0lBQ1QsSUFBSSxJQUFJLENBQUN2RCxXQUFXLElBQUksSUFBSSxDQUFDQyxRQUFRLEVBQUU7TUFDckM7SUFDRjtJQUNBO0lBQ0E7SUFDQTtJQUNBLElBQUksSUFBSSxDQUFDb0IsVUFBVSxLQUFLLElBQUksRUFBRTtNQUM1QmdGLFlBQVksQ0FBQyxJQUFJLENBQUNoRixVQUFVLENBQUM7TUFDN0IsSUFBSSxDQUFDQSxVQUFVLEdBQUcsSUFBSTtJQUN4Qjs7SUFFQTtJQUNBO0lBQ0E7SUFDQTtJQUNBL0ksb0JBQW9CLENBQUMsQ0FBQztJQUV0QixNQUFNZ08sV0FBVyxHQUFHbkYsV0FBVyxDQUFDQyxHQUFHLENBQUMsQ0FBQztJQUNyQyxNQUFNbUYsYUFBYSxHQUFHLElBQUksQ0FBQ3ZELE9BQU8sQ0FBQ2pFLE1BQU0sQ0FBQ21FLE9BQU8sSUFBSSxFQUFFO0lBQ3ZELE1BQU1yRSxZQUFZLEdBQUcsSUFBSSxDQUFDbUUsT0FBTyxDQUFDakUsTUFBTSxDQUFDb0UsSUFBSSxJQUFJLEVBQUU7SUFFbkQsTUFBTXFELEtBQUssR0FBRyxJQUFJLENBQUNsRyxRQUFRLENBQUM7TUFDMUJVLFVBQVUsRUFBRSxJQUFJLENBQUNBLFVBQVU7TUFDM0JDLFNBQVMsRUFBRSxJQUFJLENBQUNBLFNBQVM7TUFDekJtQyxLQUFLLEVBQUUsSUFBSSxDQUFDSixPQUFPLENBQUNqRSxNQUFNLENBQUNxRSxLQUFLO01BQ2hDbUQsYUFBYTtNQUNiMUgsWUFBWTtNQUNaNEgsU0FBUyxFQUFFLElBQUksQ0FBQ2hFLGVBQWU7TUFDL0JFLHFCQUFxQixFQUFFLElBQUksQ0FBQ0E7SUFDOUIsQ0FBQyxDQUFDO0lBQ0YsTUFBTStELFVBQVUsR0FBR3ZGLFdBQVcsQ0FBQ0MsR0FBRyxDQUFDLENBQUMsR0FBR2tGLFdBQVc7O0lBRWxEO0lBQ0E7SUFDQTtJQUNBO0lBQ0E7SUFDQTtJQUNBO0lBQ0E7SUFDQTtJQUNBO0lBQ0E7SUFDQSxNQUFNSyxNQUFNLEdBQUdyTSxtQkFBbUIsQ0FBQyxDQUFDO0lBQ3BDLElBQ0VxTSxNQUFNLElBQ04sSUFBSSxDQUFDM0UsU0FBUyxDQUFDNEUsTUFBTTtJQUNyQjtJQUNBO0lBQ0E7SUFDQTtJQUNBO0lBQ0E7SUFDQSxJQUFJLENBQUM1RSxTQUFTLENBQUM0RSxNQUFNLENBQUNDLEdBQUcsSUFBSUYsTUFBTSxDQUFDRyxXQUFXLElBQy9DLElBQUksQ0FBQzlFLFNBQVMsQ0FBQzRFLE1BQU0sQ0FBQ0MsR0FBRyxJQUFJRixNQUFNLENBQUNJLGNBQWMsRUFDbEQ7TUFDQSxNQUFNO1FBQUVDLEtBQUs7UUFBRUYsV0FBVztRQUFFQztNQUFlLENBQUMsR0FBR0osTUFBTTtNQUNyRDtNQUNBO01BQ0E7TUFDQTtNQUNBO01BQ0E7TUFDQTtNQUNBLElBQUksSUFBSSxDQUFDM0UsU0FBUyxDQUFDaUYsVUFBVSxFQUFFO1FBQzdCLElBQUluTCxZQUFZLENBQUMsSUFBSSxDQUFDa0csU0FBUyxDQUFDLEVBQUU7VUFDaEN6RyxtQkFBbUIsQ0FDakIsSUFBSSxDQUFDeUcsU0FBUyxFQUNkLElBQUksQ0FBQ2hCLFVBQVUsQ0FBQ2tHLE1BQU0sRUFDdEJKLFdBQVcsRUFDWEEsV0FBVyxHQUFHRSxLQUFLLEdBQUcsQ0FBQyxFQUN2QixPQUNGLENBQUM7UUFDSDtRQUNBN0ssV0FBVyxDQUFDLElBQUksQ0FBQzZGLFNBQVMsRUFBRSxDQUFDZ0YsS0FBSyxFQUFFRixXQUFXLEVBQUVDLGNBQWMsQ0FBQztNQUNsRSxDQUFDLE1BQU07TUFDTDtNQUNBO01BQ0E7TUFDQTtNQUNBO01BQ0E7TUFDQTtNQUNBO01BQ0E7TUFDQTtNQUNBO01BQ0E7TUFDQSxDQUFDLElBQUksQ0FBQy9FLFNBQVMsQ0FBQ21GLEtBQUssSUFDcEIsSUFBSSxDQUFDbkYsU0FBUyxDQUFDbUYsS0FBSyxDQUFDTixHQUFHLElBQUlDLFdBQVcsSUFDdEMsSUFBSSxDQUFDOUUsU0FBUyxDQUFDbUYsS0FBSyxDQUFDTixHQUFHLElBQUlFLGNBQWUsRUFDN0M7UUFDQSxJQUFJakwsWUFBWSxDQUFDLElBQUksQ0FBQ2tHLFNBQVMsQ0FBQyxFQUFFO1VBQ2hDekcsbUJBQW1CLENBQ2pCLElBQUksQ0FBQ3lHLFNBQVMsRUFDZCxJQUFJLENBQUNoQixVQUFVLENBQUNrRyxNQUFNLEVBQ3RCSixXQUFXLEVBQ1hBLFdBQVcsR0FBR0UsS0FBSyxHQUFHLENBQUMsRUFDdkIsT0FDRixDQUFDO1FBQ0g7UUFDQSxNQUFNSSxPQUFPLEdBQUcvSyx1QkFBdUIsQ0FDckMsSUFBSSxDQUFDMkYsU0FBUyxFQUNkLENBQUNnRixLQUFLLEVBQ05GLFdBQVcsRUFDWEMsY0FDRixDQUFDO1FBQ0Q7UUFDQTtRQUNBO1FBQ0E7UUFDQTtRQUNBLElBQUlLLE9BQU8sRUFBRSxLQUFLLE1BQU1DLEVBQUUsSUFBSSxJQUFJLENBQUMvRSxrQkFBa0IsRUFBRStFLEVBQUUsQ0FBQyxDQUFDO01BQzdEO0lBQ0Y7O0lBRUE7SUFDQTtJQUNBO0lBQ0E7SUFDQTtJQUNBO0lBQ0E7SUFDQTtJQUNBO0lBQ0E7SUFDQTtJQUNBO0lBQ0E7SUFDQTtJQUNBO0lBQ0E7SUFDQTtJQUNBO0lBQ0E7SUFDQSxJQUFJQyxTQUFTLEdBQUcsS0FBSztJQUNyQixJQUFJQyxRQUFRLEdBQUcsS0FBSztJQUNwQixJQUFJLElBQUksQ0FBQzlFLGVBQWUsRUFBRTtNQUN4QjZFLFNBQVMsR0FBR3hMLFlBQVksQ0FBQyxJQUFJLENBQUNrRyxTQUFTLENBQUM7TUFDeEMsSUFBSXNGLFNBQVMsRUFBRTtRQUNiaE0scUJBQXFCLENBQUNrTCxLQUFLLENBQUNVLE1BQU0sRUFBRSxJQUFJLENBQUNsRixTQUFTLEVBQUUsSUFBSSxDQUFDekIsU0FBUyxDQUFDO01BQ3JFO01BQ0E7TUFDQTtNQUNBZ0gsUUFBUSxHQUFHbE0sb0JBQW9CLENBQzdCbUwsS0FBSyxDQUFDVSxNQUFNLEVBQ1osSUFBSSxDQUFDakYsb0JBQW9CLEVBQ3pCLElBQUksQ0FBQzFCLFNBQ1AsQ0FBQztNQUNEO01BQ0E7TUFDQTtNQUNBLElBQUksSUFBSSxDQUFDMkIsZUFBZSxFQUFFO1FBQ3hCLE1BQU1zRixFQUFFLEdBQUcsSUFBSSxDQUFDdEYsZUFBZTtRQUMvQixNQUFNdUYsVUFBVSxHQUFHak4sd0JBQXdCLENBQ3pDZ00sS0FBSyxDQUFDVSxNQUFNLEVBQ1osSUFBSSxDQUFDM0csU0FBUyxFQUNkaUgsRUFBRSxDQUFDckYsU0FBUyxFQUNacUYsRUFBRSxDQUFDcEYsU0FBUyxFQUNab0YsRUFBRSxDQUFDbkYsVUFDTCxDQUFDO1FBQ0RrRixRQUFRLEdBQUdBLFFBQVEsSUFBSUUsVUFBVTtNQUNuQztJQUNGOztJQUVBO0lBQ0E7SUFDQTtJQUNBO0lBQ0E7SUFDQSxJQUNFbE4sY0FBYyxDQUFDLENBQUMsSUFDaEIrTSxTQUFTLElBQ1RDLFFBQVEsSUFDUixJQUFJLENBQUM1RSxxQkFBcUIsRUFDMUI7TUFDQTZELEtBQUssQ0FBQ1UsTUFBTSxDQUFDUSxNQUFNLEdBQUc7UUFDcEJ0SixDQUFDLEVBQUUsQ0FBQztRQUNKQyxDQUFDLEVBQUUsQ0FBQztRQUNKK0csS0FBSyxFQUFFb0IsS0FBSyxDQUFDVSxNQUFNLENBQUM5QixLQUFLO1FBQ3pCRCxNQUFNLEVBQUVxQixLQUFLLENBQUNVLE1BQU0sQ0FBQy9CO01BQ3ZCLENBQUM7SUFDSDs7SUFFQTtJQUNBO0lBQ0E7SUFDQTtJQUNBO0lBQ0E7SUFDQTtJQUNBO0lBQ0E7SUFDQTtJQUNBLElBQUl3QyxTQUFTLEdBQUcsSUFBSSxDQUFDM0csVUFBVTtJQUMvQixJQUFJLElBQUksQ0FBQ3lCLGVBQWUsRUFBRTtNQUN4QmtGLFNBQVMsR0FBRztRQUFFLEdBQUcsSUFBSSxDQUFDM0csVUFBVTtRQUFFNEcsTUFBTSxFQUFFM0o7TUFBeUIsQ0FBQztJQUN0RTtJQUVBLE1BQU00SixLQUFLLEdBQUcxRyxXQUFXLENBQUNDLEdBQUcsQ0FBQyxDQUFDO0lBQy9CLE1BQU0wRyxJQUFJLEdBQUcsSUFBSSxDQUFDbEksR0FBRyxDQUFDNkYsTUFBTSxDQUMxQmtDLFNBQVMsRUFDVG5CLEtBQUssRUFDTCxJQUFJLENBQUMvRCxlQUFlO0lBQ3BCO0lBQ0E7SUFDQTtJQUNBO0lBQ0FqRyxxQkFDRixDQUFDO0lBQ0QsTUFBTXVMLE1BQU0sR0FBRzVHLFdBQVcsQ0FBQ0MsR0FBRyxDQUFDLENBQUMsR0FBR3lHLEtBQUs7SUFDeEM7SUFDQSxJQUFJLENBQUM1RyxTQUFTLEdBQUcsSUFBSSxDQUFDRCxVQUFVO0lBQ2hDLElBQUksQ0FBQ0EsVUFBVSxHQUFHd0YsS0FBSzs7SUFFdkI7SUFDQTtJQUNBO0lBQ0EsSUFBSUYsV0FBVyxHQUFHLElBQUksQ0FBQ3BGLGlCQUFpQixHQUFHLENBQUMsR0FBRyxFQUFFLEdBQUcsSUFBSSxFQUFFO01BQ3hELElBQUksQ0FBQzhHLFVBQVUsQ0FBQyxDQUFDO01BQ2pCLElBQUksQ0FBQzlHLGlCQUFpQixHQUFHb0YsV0FBVztJQUN0QztJQUVBLE1BQU0yQixRQUFRLEVBQUU1TyxVQUFVLENBQUMsVUFBVSxDQUFDLEdBQUcsRUFBRTtJQUMzQyxLQUFLLE1BQU02TyxLQUFLLElBQUlKLElBQUksRUFBRTtNQUN4QixJQUFJSSxLQUFLLENBQUMxSixJQUFJLEtBQUssZUFBZSxFQUFFO1FBQ2xDeUosUUFBUSxDQUFDRSxJQUFJLENBQUM7VUFDWkMsYUFBYSxFQUFFNUIsS0FBSyxDQUFDVSxNQUFNLENBQUMvQixNQUFNO1VBQ2xDa0QsZUFBZSxFQUFFN0IsS0FBSyxDQUFDdEIsUUFBUSxDQUFDQyxNQUFNO1VBQ3RDUyxNQUFNLEVBQUVzQyxLQUFLLENBQUN0QztRQUNoQixDQUFDLENBQUM7UUFDRixJQUFJMUwsc0JBQXNCLENBQUMsQ0FBQyxJQUFJZ08sS0FBSyxDQUFDSSxLQUFLLEVBQUU7VUFDM0MsTUFBTUMsS0FBSyxHQUFHdlAsR0FBRyxDQUFDd1AsbUJBQW1CLENBQ25DLElBQUksQ0FBQ3JJLFFBQVEsRUFDYitILEtBQUssQ0FBQ0ksS0FBSyxDQUFDRyxRQUNkLENBQUM7VUFDRGpRLGVBQWUsQ0FDYiwwQkFBMEIwUCxLQUFLLENBQUN0QyxNQUFNLFVBQVVzQyxLQUFLLENBQUNJLEtBQUssQ0FBQ0csUUFBUSxJQUFJLEdBQ3RFLFlBQVlQLEtBQUssQ0FBQ0ksS0FBSyxDQUFDSSxRQUFRLEtBQUssR0FDckMsWUFBWVIsS0FBSyxDQUFDSSxLQUFLLENBQUNLLFFBQVEsS0FBSyxHQUNyQyxjQUFjSixLQUFLLENBQUNLLE1BQU0sR0FBR0wsS0FBSyxDQUFDTSxJQUFJLENBQUMsS0FBSyxDQUFDLEdBQUcsMkJBQTJCLEVBQUUsRUFDaEY7WUFBRUMsS0FBSyxFQUFFO1VBQU8sQ0FDbEIsQ0FBQztRQUNIO01BQ0Y7SUFDRjtJQUVBLE1BQU1DLFNBQVMsR0FBRzVILFdBQVcsQ0FBQ0MsR0FBRyxDQUFDLENBQUM7SUFDbkMsTUFBTTRILFNBQVMsR0FBR3JQLFFBQVEsQ0FBQ21PLElBQUksQ0FBQztJQUNoQyxNQUFNbUIsVUFBVSxHQUFHOUgsV0FBVyxDQUFDQyxHQUFHLENBQUMsQ0FBQyxHQUFHMkgsU0FBUztJQUNoRCxNQUFNRyxPQUFPLEdBQUdGLFNBQVMsQ0FBQ0osTUFBTSxHQUFHLENBQUM7SUFDcEMsSUFBSSxJQUFJLENBQUNuRyxlQUFlLElBQUl5RyxPQUFPLEVBQUU7TUFDbkM7TUFDQTtNQUNBO01BQ0E7TUFDQTtNQUNBO01BQ0E7TUFDQTtNQUNBO01BQ0E7TUFDQTtNQUNBO01BQ0E7TUFDQTtNQUNBO01BQ0E7TUFDQTtNQUNBO01BQ0E7TUFDQSxJQUFJLElBQUksQ0FBQ3RHLHFCQUFxQixFQUFFO1FBQzlCLElBQUksQ0FBQ0EscUJBQXFCLEdBQUcsS0FBSztRQUNsQ29HLFNBQVMsQ0FBQ0csT0FBTyxDQUFDeEsscUJBQXFCLENBQUM7TUFDMUMsQ0FBQyxNQUFNO1FBQ0xxSyxTQUFTLENBQUNHLE9BQU8sQ0FBQzVLLGlCQUFpQixDQUFDO01BQ3RDO01BQ0F5SyxTQUFTLENBQUNiLElBQUksQ0FBQyxJQUFJLENBQUNyRyxrQkFBa0IsQ0FBQztJQUN6Qzs7SUFFQTtJQUNBO0lBQ0E7SUFDQTtJQUNBO0lBQ0E7SUFDQTtJQUNBLE1BQU1zSCxJQUFJLEdBQUcsSUFBSSxDQUFDdkcsaUJBQWlCO0lBQ25DLE1BQU13RyxJQUFJLEdBQUdELElBQUksS0FBSyxJQUFJLEdBQUcxUCxTQUFTLENBQUM0UCxHQUFHLENBQUNGLElBQUksQ0FBQ0csSUFBSSxDQUFDLEdBQUdDLFNBQVM7SUFDakUsTUFBTXJGLE1BQU0sR0FDVmlGLElBQUksS0FBSyxJQUFJLElBQUlDLElBQUksS0FBS0csU0FBUyxHQUMvQjtNQUFFcEwsQ0FBQyxFQUFFaUwsSUFBSSxDQUFDakwsQ0FBQyxHQUFHZ0wsSUFBSSxDQUFDSyxTQUFTO01BQUVwTCxDQUFDLEVBQUVnTCxJQUFJLENBQUNoTCxDQUFDLEdBQUcrSyxJQUFJLENBQUNNO0lBQVUsQ0FBQyxHQUMxRCxJQUFJO0lBQ1YsTUFBTUMsTUFBTSxHQUFHLElBQUksQ0FBQzdHLGFBQWE7O0lBRWpDO0lBQ0E7SUFDQSxNQUFNOEcsV0FBVyxHQUNmekYsTUFBTSxLQUFLLElBQUksS0FDZHdGLE1BQU0sS0FBSyxJQUFJLElBQUlBLE1BQU0sQ0FBQ3ZMLENBQUMsS0FBSytGLE1BQU0sQ0FBQy9GLENBQUMsSUFBSXVMLE1BQU0sQ0FBQ3RMLENBQUMsS0FBSzhGLE1BQU0sQ0FBQzlGLENBQUMsQ0FBQztJQUNyRSxJQUFJNkssT0FBTyxJQUFJVSxXQUFXLElBQUt6RixNQUFNLEtBQUssSUFBSSxJQUFJd0YsTUFBTSxLQUFLLElBQUssRUFBRTtNQUNsRTtNQUNBO01BQ0E7TUFDQTtNQUNBLElBQUlBLE1BQU0sS0FBSyxJQUFJLElBQUksQ0FBQyxJQUFJLENBQUNsSCxlQUFlLElBQUl5RyxPQUFPLEVBQUU7UUFDdkQsTUFBTVcsR0FBRyxHQUFHbEMsU0FBUyxDQUFDQyxNQUFNLENBQUN4SixDQUFDLEdBQUd1TCxNQUFNLENBQUN2TCxDQUFDO1FBQ3pDLE1BQU0wTCxHQUFHLEdBQUduQyxTQUFTLENBQUNDLE1BQU0sQ0FBQ3ZKLENBQUMsR0FBR3NMLE1BQU0sQ0FBQ3RMLENBQUM7UUFDekMsSUFBSXdMLEdBQUcsS0FBSyxDQUFDLElBQUlDLEdBQUcsS0FBSyxDQUFDLEVBQUU7VUFDMUJkLFNBQVMsQ0FBQ0csT0FBTyxDQUFDO1lBQUUzSyxJQUFJLEVBQUUsUUFBUTtZQUFFRSxPQUFPLEVBQUU3QixVQUFVLENBQUNnTixHQUFHLEVBQUVDLEdBQUc7VUFBRSxDQUFDLENBQUM7UUFDdEU7TUFDRjtNQUVBLElBQUkzRixNQUFNLEtBQUssSUFBSSxFQUFFO1FBQ25CLElBQUksSUFBSSxDQUFDMUIsZUFBZSxFQUFFO1VBQ3hCO1VBQ0E7VUFDQSxNQUFNb0UsR0FBRyxHQUFHa0QsSUFBSSxDQUFDQyxHQUFHLENBQUNELElBQUksQ0FBQ0UsR0FBRyxDQUFDOUYsTUFBTSxDQUFDOUYsQ0FBQyxHQUFHLENBQUMsRUFBRSxDQUFDLENBQUMsRUFBRVEsWUFBWSxDQUFDO1VBQzdELE1BQU1xTCxHQUFHLEdBQUdILElBQUksQ0FBQ0MsR0FBRyxDQUFDRCxJQUFJLENBQUNFLEdBQUcsQ0FBQzlGLE1BQU0sQ0FBQy9GLENBQUMsR0FBRyxDQUFDLEVBQUUsQ0FBQyxDQUFDLEVBQUVtSSxhQUFhLENBQUM7VUFDOUR5QyxTQUFTLENBQUNiLElBQUksQ0FBQztZQUFFM0osSUFBSSxFQUFFLFFBQVE7WUFBRUUsT0FBTyxFQUFFNUIsY0FBYyxDQUFDK0osR0FBRyxFQUFFcUQsR0FBRztVQUFFLENBQUMsQ0FBQztRQUN2RSxDQUFDLE1BQU07VUFDTDtVQUNBO1VBQ0E7VUFDQSxNQUFNQyxJQUFJLEdBQ1IsQ0FBQ2pCLE9BQU8sSUFBSVMsTUFBTSxLQUFLLElBQUksR0FDdkJBLE1BQU0sR0FDTjtZQUFFdkwsQ0FBQyxFQUFFb0ksS0FBSyxDQUFDb0IsTUFBTSxDQUFDeEosQ0FBQztZQUFFQyxDQUFDLEVBQUVtSSxLQUFLLENBQUNvQixNQUFNLENBQUN2SjtVQUFFLENBQUM7VUFDOUMsTUFBTStMLEVBQUUsR0FBR2pHLE1BQU0sQ0FBQy9GLENBQUMsR0FBRytMLElBQUksQ0FBQy9MLENBQUM7VUFDNUIsTUFBTWlNLEVBQUUsR0FBR2xHLE1BQU0sQ0FBQzlGLENBQUMsR0FBRzhMLElBQUksQ0FBQzlMLENBQUM7VUFDNUIsSUFBSStMLEVBQUUsS0FBSyxDQUFDLElBQUlDLEVBQUUsS0FBSyxDQUFDLEVBQUU7WUFDeEJyQixTQUFTLENBQUNiLElBQUksQ0FBQztjQUFFM0osSUFBSSxFQUFFLFFBQVE7Y0FBRUUsT0FBTyxFQUFFN0IsVUFBVSxDQUFDdU4sRUFBRSxFQUFFQyxFQUFFO1lBQUUsQ0FBQyxDQUFDO1VBQ2pFO1FBQ0Y7UUFDQSxJQUFJLENBQUN2SCxhQUFhLEdBQUdxQixNQUFNO01BQzdCLENBQUMsTUFBTTtRQUNMO1FBQ0E7UUFDQTtRQUNBO1FBQ0E7UUFDQTtRQUNBO1FBQ0EsSUFBSXdGLE1BQU0sS0FBSyxJQUFJLElBQUksQ0FBQyxJQUFJLENBQUNsSCxlQUFlLElBQUksQ0FBQ3lHLE9BQU8sRUFBRTtVQUN4RCxNQUFNb0IsR0FBRyxHQUFHOUQsS0FBSyxDQUFDb0IsTUFBTSxDQUFDeEosQ0FBQyxHQUFHdUwsTUFBTSxDQUFDdkwsQ0FBQztVQUNyQyxNQUFNbU0sR0FBRyxHQUFHL0QsS0FBSyxDQUFDb0IsTUFBTSxDQUFDdkosQ0FBQyxHQUFHc0wsTUFBTSxDQUFDdEwsQ0FBQztVQUNyQyxJQUFJaU0sR0FBRyxLQUFLLENBQUMsSUFBSUMsR0FBRyxLQUFLLENBQUMsRUFBRTtZQUMxQnZCLFNBQVMsQ0FBQ2IsSUFBSSxDQUFDO2NBQUUzSixJQUFJLEVBQUUsUUFBUTtjQUFFRSxPQUFPLEVBQUU3QixVQUFVLENBQUN5TixHQUFHLEVBQUVDLEdBQUc7WUFBRSxDQUFDLENBQUM7VUFDbkU7UUFDRjtRQUNBLElBQUksQ0FBQ3pILGFBQWEsR0FBRyxJQUFJO01BQzNCO0lBQ0Y7SUFFQSxNQUFNMEgsTUFBTSxHQUFHckosV0FBVyxDQUFDQyxHQUFHLENBQUMsQ0FBQztJQUNoQ3pFLG1CQUFtQixDQUNqQixJQUFJLENBQUNrRCxRQUFRLEVBQ2JtSixTQUFTLEVBQ1QsSUFBSSxDQUFDdkcsZUFBZSxJQUFJLENBQUNqRyxxQkFDM0IsQ0FBQztJQUNELE1BQU1pTyxPQUFPLEdBQUd0SixXQUFXLENBQUNDLEdBQUcsQ0FBQyxDQUFDLEdBQUdvSixNQUFNOztJQUUxQztJQUNBO0lBQ0E7SUFDQTtJQUNBLElBQUksQ0FBQzdILHFCQUFxQixHQUFHMkUsU0FBUyxJQUFJQyxRQUFROztJQUVsRDtJQUNBO0lBQ0E7SUFDQTtJQUNBO0lBQ0E7SUFDQTtJQUNBO0lBQ0E7SUFDQTtJQUNBO0lBQ0E7SUFDQSxJQUFJZixLQUFLLENBQUNrRSxrQkFBa0IsRUFBRTtNQUM1QixJQUFJLENBQUNySixVQUFVLEdBQUdFLFVBQVUsQ0FDMUIsTUFBTSxJQUFJLENBQUNnQyxRQUFRLENBQUMsQ0FBQyxFQUNyQnhLLGlCQUFpQixJQUFJLENBQ3ZCLENBQUM7SUFDSDtJQUVBLE1BQU00UixNQUFNLEdBQUcxUSxhQUFhLENBQUMsQ0FBQztJQUM5QixNQUFNMlEsUUFBUSxHQUFHNVEsZUFBZSxDQUFDLENBQUM7SUFDbEMsTUFBTTZRLEVBQUUsR0FBRyxJQUFJLENBQUNySixnQkFBZ0I7SUFDaEM7SUFDQXBILG9CQUFvQixDQUFDLENBQUM7SUFDdEIsSUFBSSxDQUFDb0gsZ0JBQWdCLEdBQUc7TUFDdEJDLEVBQUUsRUFBRSxDQUFDO01BQ0xDLE9BQU8sRUFBRSxDQUFDO01BQ1ZDLFFBQVEsRUFBRSxDQUFDO01BQ1hDLFNBQVMsRUFBRSxDQUFDO01BQ1pDLElBQUksRUFBRTtJQUNSLENBQUM7SUFDRCxJQUFJLENBQUNtQixPQUFPLENBQUN2RCxPQUFPLEdBQUc7TUFDckJxTCxVQUFVLEVBQUUzSixXQUFXLENBQUNDLEdBQUcsQ0FBQyxDQUFDLEdBQUdrRixXQUFXO01BQzNDeUUsTUFBTSxFQUFFO1FBQ056SyxRQUFRLEVBQUVvRyxVQUFVO1FBQ3BCb0IsSUFBSSxFQUFFQyxNQUFNO1FBQ1pwTyxRQUFRLEVBQUVzUCxVQUFVO1FBQ3BCMUQsS0FBSyxFQUFFa0YsT0FBTztRQUNkTyxPQUFPLEVBQUVsRCxJQUFJLENBQUNjLE1BQU07UUFDcEJxQyxJQUFJLEVBQUVOLE1BQU07UUFDWk8sTUFBTSxFQUFFTixRQUFRO1FBQ2hCTyxXQUFXLEVBQUVOLEVBQUUsQ0FBQ25KLE9BQU87UUFDdkIwSixZQUFZLEVBQUVQLEVBQUUsQ0FBQ2xKLFFBQVE7UUFDekIwSixhQUFhLEVBQUVSLEVBQUUsQ0FBQ2pKLFNBQVM7UUFDM0IwSixRQUFRLEVBQUVULEVBQUUsQ0FBQ2hKO01BQ2YsQ0FBQztNQUNEb0c7SUFDRixDQUFDLENBQUM7RUFDSjtFQUVBbEMsS0FBS0EsQ0FBQSxDQUFFLEVBQUUsSUFBSSxDQUFDO0lBQ1o7SUFDQTtJQUNBak0sVUFBVSxDQUFDeVIsdUJBQXVCLENBQUMsQ0FBQztJQUNwQyxJQUFJLENBQUNoSSxRQUFRLENBQUMsQ0FBQztJQUVmLElBQUksQ0FBQ3RELFFBQVEsR0FBRyxJQUFJO0VBQ3RCO0VBRUFtRyxNQUFNQSxDQUFBLENBQUUsRUFBRSxJQUFJLENBQUM7SUFDYixJQUFJLENBQUNuRyxRQUFRLEdBQUcsS0FBSztJQUNyQixJQUFJLENBQUNzRCxRQUFRLENBQUMsQ0FBQztFQUNqQjs7RUFFQTtBQUNGO0FBQ0E7QUFDQTtBQUNBO0VBQ0U0QyxPQUFPQSxDQUFBLENBQUUsRUFBRSxJQUFJLENBQUM7SUFDZCxJQUFJLENBQUNuRixVQUFVLEdBQUc3SCxVQUFVLENBQzFCLElBQUksQ0FBQzZILFVBQVUsQ0FBQ2tFLFFBQVEsQ0FBQ0MsTUFBTSxFQUMvQixJQUFJLENBQUNuRSxVQUFVLENBQUNrRSxRQUFRLENBQUNFLEtBQUssRUFDOUIsSUFBSSxDQUFDN0UsU0FBUyxFQUNkLElBQUksQ0FBQ0MsUUFBUSxFQUNiLElBQUksQ0FBQ0MsYUFDUCxDQUFDO0lBQ0QsSUFBSSxDQUFDUSxTQUFTLEdBQUc5SCxVQUFVLENBQ3pCLElBQUksQ0FBQzhILFNBQVMsQ0FBQ2lFLFFBQVEsQ0FBQ0MsTUFBTSxFQUM5QixJQUFJLENBQUNsRSxTQUFTLENBQUNpRSxRQUFRLENBQUNFLEtBQUssRUFDN0IsSUFBSSxDQUFDN0UsU0FBUyxFQUNkLElBQUksQ0FBQ0MsUUFBUSxFQUNiLElBQUksQ0FBQ0MsYUFDUCxDQUFDO0lBQ0QsSUFBSSxDQUFDYixHQUFHLENBQUN5RixLQUFLLENBQUMsQ0FBQztJQUNoQjtJQUNBO0lBQ0E7SUFDQSxJQUFJLENBQUN2QyxhQUFhLEdBQUcsSUFBSTtFQUMzQjs7RUFFQTtBQUNGO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0UwSSxXQUFXQSxDQUFBLENBQUUsRUFBRSxJQUFJLENBQUM7SUFDbEIsSUFBSSxDQUFDLElBQUksQ0FBQ3hJLE9BQU8sQ0FBQ2pFLE1BQU0sQ0FBQ3FFLEtBQUssSUFBSSxJQUFJLENBQUNwRCxXQUFXLElBQUksSUFBSSxDQUFDQyxRQUFRLEVBQUU7SUFDckUsSUFBSSxDQUFDK0MsT0FBTyxDQUFDakUsTUFBTSxDQUFDd0csS0FBSyxDQUFDcEksWUFBWSxHQUFHUCxXQUFXLENBQUM7SUFDckQsSUFBSSxJQUFJLENBQUM2RixlQUFlLEVBQUU7TUFDeEIsSUFBSSxDQUFDK0MsdUJBQXVCLENBQUMsQ0FBQztJQUNoQyxDQUFDLE1BQU07TUFDTCxJQUFJLENBQUNXLE9BQU8sQ0FBQyxDQUFDO01BQ2Q7TUFDQTtNQUNBO01BQ0EsSUFBSSxDQUFDeEQscUJBQXFCLEdBQUcsSUFBSTtJQUNuQztJQUNBLElBQUksQ0FBQ1ksUUFBUSxDQUFDLENBQUM7RUFDakI7O0VBRUE7QUFDRjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7RUFDRWtJLG1CQUFtQkEsQ0FBQSxDQUFFLEVBQUUsSUFBSSxDQUFDO0lBQzFCLElBQUksQ0FBQzlJLHFCQUFxQixHQUFHLElBQUk7RUFDbkM7O0VBRUE7QUFDRjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7RUFDRStJLGtCQUFrQkEsQ0FBQ0MsTUFBTSxFQUFFLE9BQU8sRUFBRUMsYUFBYSxHQUFHLEtBQUssQ0FBQyxFQUFFLElBQUksQ0FBQztJQUMvRCxJQUFJLElBQUksQ0FBQ25KLGVBQWUsS0FBS2tKLE1BQU0sRUFBRTtJQUNyQyxJQUFJLENBQUNsSixlQUFlLEdBQUdrSixNQUFNO0lBQzdCLElBQUksQ0FBQ2pKLHNCQUFzQixHQUFHaUosTUFBTSxJQUFJQyxhQUFhO0lBQ3JELElBQUlELE1BQU0sRUFBRTtNQUNWLElBQUksQ0FBQ25HLHVCQUF1QixDQUFDLENBQUM7SUFDaEMsQ0FBQyxNQUFNO01BQ0wsSUFBSSxDQUFDVyxPQUFPLENBQUMsQ0FBQztJQUNoQjtFQUNGO0VBRUEsSUFBSTBGLGlCQUFpQkEsQ0FBQSxDQUFFLEVBQUUsT0FBTyxDQUFDO0lBQy9CLE9BQU8sSUFBSSxDQUFDcEosZUFBZTtFQUM3Qjs7RUFFQTtBQUNGO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7RUFDRXFKLHFCQUFxQixHQUFHQSxDQUFDQyxnQkFBZ0IsR0FBRyxLQUFLLENBQUMsRUFBRSxJQUFJLElBQUk7SUFDMUQsSUFBSSxDQUFDLElBQUksQ0FBQy9JLE9BQU8sQ0FBQ2pFLE1BQU0sQ0FBQ3FFLEtBQUssRUFBRTtJQUNoQztJQUNBO0lBQ0E7SUFDQSxJQUFJLElBQUksQ0FBQ25ELFFBQVEsRUFBRTtJQUNuQjtJQUNBO0lBQ0E7SUFDQTtJQUNBLElBQUl4RCxvQkFBb0IsQ0FBQyxDQUFDLEVBQUU7TUFDMUIsSUFBSSxDQUFDdUcsT0FBTyxDQUFDakUsTUFBTSxDQUFDd0csS0FBSyxDQUN2QnhJLHNCQUFzQixHQUNwQkUscUJBQXFCLEdBQ3JCQyx3QkFDSixDQUFDO0lBQ0g7SUFDQSxJQUFJLENBQUMsSUFBSSxDQUFDdUYsZUFBZSxFQUFFO0lBQzNCO0lBQ0EsSUFBSSxJQUFJLENBQUNDLHNCQUFzQixFQUFFO01BQy9CLElBQUksQ0FBQ00sT0FBTyxDQUFDakUsTUFBTSxDQUFDd0csS0FBSyxDQUFDaEkscUJBQXFCLENBQUM7SUFDbEQ7SUFDQTtJQUNBO0lBQ0EsSUFBSXdPLGdCQUFnQixFQUFFO01BQ3BCLElBQUksQ0FBQzlHLGdCQUFnQixDQUFDLENBQUM7SUFDekI7RUFDRixDQUFDOztFQUVEO0FBQ0Y7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7RUFDRStHLGlCQUFpQkEsQ0FBQSxDQUFFLEVBQUUsSUFBSSxDQUFDO0lBQ3hCLElBQUksQ0FBQ2hNLFdBQVcsR0FBRyxJQUFJO0lBQ3ZCO0lBQ0E7SUFDQSxJQUFJLENBQUNGLGNBQWMsQ0FBQ0MsTUFBTSxHQUFHLENBQUM7SUFDOUI7SUFDQTtJQUNBO0lBQ0E7SUFDQTtJQUNBLE1BQU1iLEtBQUssR0FBRyxJQUFJLENBQUM4RCxPQUFPLENBQUM5RCxLQUFLLElBQUlGLE1BQU0sQ0FBQ0csVUFBVSxHQUFHO01BQ3REOE0sS0FBSyxDQUFDLEVBQUUsT0FBTztNQUNmQyxVQUFVLENBQUMsRUFBRSxDQUFDQyxDQUFDLEVBQUUsT0FBTyxFQUFFLEdBQUcsSUFBSTtJQUNuQyxDQUFDO0lBQ0QsSUFBSSxDQUFDQyxVQUFVLENBQUMsQ0FBQztJQUNqQixJQUFJbE4sS0FBSyxDQUFDa0UsS0FBSyxJQUFJbEUsS0FBSyxDQUFDK00sS0FBSyxJQUFJL00sS0FBSyxDQUFDZ04sVUFBVSxFQUFFO01BQ2xEaE4sS0FBSyxDQUFDZ04sVUFBVSxDQUFDLEtBQUssQ0FBQztJQUN6QjtFQUNGOztFQUVBO0VBQ0FFLFVBQVVBLENBQUEsQ0FBRSxFQUFFLElBQUksQ0FBQztJQUNqQkEsVUFBVSxDQUFDLElBQUksQ0FBQ3BKLE9BQU8sQ0FBQzlELEtBQUssQ0FBQztFQUNoQzs7RUFFQTtBQUNGO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtFQUNFLFFBQVErRixnQkFBZ0JBLENBQUEsQ0FBRSxFQUFFLElBQUksQ0FBQztJQUMvQixJQUFJLENBQUNqQyxPQUFPLENBQUNqRSxNQUFNLENBQUN3RyxLQUFLLENBQ3ZCL0gsZ0JBQWdCLEdBQ2RMLFlBQVksR0FDWlAsV0FBVyxJQUNWLElBQUksQ0FBQzhGLHNCQUFzQixHQUFHbkYscUJBQXFCLEdBQUcsRUFBRSxDQUM3RCxDQUFDO0lBQ0QsSUFBSSxDQUFDaUksdUJBQXVCLENBQUMsQ0FBQztFQUNoQzs7RUFFQTtBQUNGO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7RUFDRSxRQUFRQSx1QkFBdUJBLENBQUEsQ0FBRSxFQUFFLElBQUksQ0FBQztJQUN0QyxNQUFNckMsSUFBSSxHQUFHLElBQUksQ0FBQ3RFLFlBQVk7SUFDOUIsTUFBTXlHLElBQUksR0FBRyxJQUFJLENBQUN4RSxlQUFlO0lBQ2pDLE1BQU11TCxLQUFLLEdBQUdBLENBQUEsQ0FBRSxFQUFFalQsS0FBSyxLQUFLO01BQzFCOE4sTUFBTSxFQUFFbE0sWUFBWSxDQUNsQnNLLElBQUksRUFDSm5DLElBQUksRUFDSixJQUFJLENBQUM1QyxTQUFTLEVBQ2QsSUFBSSxDQUFDQyxRQUFRLEVBQ2IsSUFBSSxDQUFDQyxhQUNQLENBQUM7TUFDRHlFLFFBQVEsRUFBRTtRQUFFRSxLQUFLLEVBQUVFLElBQUk7UUFBRUgsTUFBTSxFQUFFaEMsSUFBSSxHQUFHO01BQUUsQ0FBQztNQUMzQ3lFLE1BQU0sRUFBRTtRQUFFeEosQ0FBQyxFQUFFLENBQUM7UUFBRUMsQ0FBQyxFQUFFLENBQUM7UUFBRUMsT0FBTyxFQUFFO01BQUs7SUFDdEMsQ0FBQyxDQUFDO0lBQ0YsSUFBSSxDQUFDMEMsVUFBVSxHQUFHcUwsS0FBSyxDQUFDLENBQUM7SUFDekIsSUFBSSxDQUFDcEwsU0FBUyxHQUFHb0wsS0FBSyxDQUFDLENBQUM7SUFDeEIsSUFBSSxDQUFDek0sR0FBRyxDQUFDeUYsS0FBSyxDQUFDLENBQUM7SUFDaEI7SUFDQTtJQUNBO0lBQ0EsSUFBSSxDQUFDdkMsYUFBYSxHQUFHLElBQUk7SUFDekI7SUFDQTtJQUNBLElBQUksQ0FBQ0gscUJBQXFCLEdBQUcsSUFBSTtFQUNuQzs7RUFFQTtBQUNGO0FBQ0E7QUFDQTtBQUNBO0VBQ0UySixvQkFBb0JBLENBQUEsQ0FBRSxFQUFFLE1BQU0sQ0FBQztJQUM3QixJQUFJLENBQUN4USxZQUFZLENBQUMsSUFBSSxDQUFDa0csU0FBUyxDQUFDLEVBQUUsT0FBTyxFQUFFO0lBQzVDLE1BQU11SyxJQUFJLEdBQUcxUSxlQUFlLENBQUMsSUFBSSxDQUFDbUcsU0FBUyxFQUFFLElBQUksQ0FBQ2hCLFVBQVUsQ0FBQ2tHLE1BQU0sQ0FBQztJQUNwRSxJQUFJcUYsSUFBSSxFQUFFO01BQ1I7TUFDQTtNQUNBLEtBQUsxTyxZQUFZLENBQUMwTyxJQUFJLENBQUMsQ0FBQ0MsSUFBSSxDQUFDQyxHQUFHLElBQUk7UUFDbEMsSUFBSUEsR0FBRyxFQUFFLElBQUksQ0FBQ3pKLE9BQU8sQ0FBQ2pFLE1BQU0sQ0FBQ3dHLEtBQUssQ0FBQ2tILEdBQUcsQ0FBQztNQUN6QyxDQUFDLENBQUM7SUFDSjtJQUNBLE9BQU9GLElBQUk7RUFDYjs7RUFFQTtBQUNGO0FBQ0E7QUFDQTtFQUNFRyxhQUFhQSxDQUFBLENBQUUsRUFBRSxNQUFNLENBQUM7SUFDdEIsSUFBSSxDQUFDNVEsWUFBWSxDQUFDLElBQUksQ0FBQ2tHLFNBQVMsQ0FBQyxFQUFFLE9BQU8sRUFBRTtJQUM1QyxNQUFNdUssSUFBSSxHQUFHLElBQUksQ0FBQ0Qsb0JBQW9CLENBQUMsQ0FBQztJQUN4QzlRLGNBQWMsQ0FBQyxJQUFJLENBQUN3RyxTQUFTLENBQUM7SUFDOUIsSUFBSSxDQUFDMksscUJBQXFCLENBQUMsQ0FBQztJQUM1QixPQUFPSixJQUFJO0VBQ2I7O0VBRUE7RUFDQUssa0JBQWtCQSxDQUFBLENBQUUsRUFBRSxJQUFJLENBQUM7SUFDekIsSUFBSSxDQUFDOVEsWUFBWSxDQUFDLElBQUksQ0FBQ2tHLFNBQVMsQ0FBQyxFQUFFO0lBQ25DeEcsY0FBYyxDQUFDLElBQUksQ0FBQ3dHLFNBQVMsQ0FBQztJQUM5QixJQUFJLENBQUMySyxxQkFBcUIsQ0FBQyxDQUFDO0VBQzlCOztFQUVBO0FBQ0Y7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0VFLGtCQUFrQkEsQ0FBQ0MsS0FBSyxFQUFFLE1BQU0sQ0FBQyxFQUFFLElBQUksQ0FBQztJQUN0QyxJQUFJLElBQUksQ0FBQzdLLG9CQUFvQixLQUFLNkssS0FBSyxFQUFFO0lBQ3pDLElBQUksQ0FBQzdLLG9CQUFvQixHQUFHNkssS0FBSztJQUNqQyxJQUFJLENBQUNoTixjQUFjLENBQUMsQ0FBQztFQUN2Qjs7RUFFQTtBQUNGO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtFQUNFaU4sa0JBQWtCQSxDQUFDQyxFQUFFLEVBQUVoVSxHQUFHLENBQUNvSCxVQUFVLENBQUMsRUFBRTNGLGFBQWEsRUFBRSxDQUFDO0lBQ3RELElBQUksQ0FBQyxJQUFJLENBQUN3SCxvQkFBb0IsSUFBSSxDQUFDK0ssRUFBRSxDQUFDekksUUFBUSxFQUFFLE9BQU8sRUFBRTtJQUN6RCxNQUFNYSxLQUFLLEdBQUcyRSxJQUFJLENBQUNrRCxJQUFJLENBQUNELEVBQUUsQ0FBQ3pJLFFBQVEsQ0FBQzJJLGdCQUFnQixDQUFDLENBQUMsQ0FBQztJQUN2RCxNQUFNL0gsTUFBTSxHQUFHNEUsSUFBSSxDQUFDa0QsSUFBSSxDQUFDRCxFQUFFLENBQUN6SSxRQUFRLENBQUM0SSxpQkFBaUIsQ0FBQyxDQUFDLENBQUM7SUFDekQsSUFBSS9ILEtBQUssSUFBSSxDQUFDLElBQUlELE1BQU0sSUFBSSxDQUFDLEVBQUUsT0FBTyxFQUFFO0lBQ3hDO0lBQ0E7SUFDQSxNQUFNaUksTUFBTSxHQUFHSixFQUFFLENBQUN6SSxRQUFRLENBQUM4SSxlQUFlLENBQUMsQ0FBQztJQUM1QyxNQUFNQyxLQUFLLEdBQUdOLEVBQUUsQ0FBQ3pJLFFBQVEsQ0FBQ2dKLGNBQWMsQ0FBQyxDQUFDO0lBQzFDLE1BQU1yRyxNQUFNLEdBQUdsTSxZQUFZLENBQ3pCb0ssS0FBSyxFQUNMRCxNQUFNLEVBQ04sSUFBSSxDQUFDNUUsU0FBUyxFQUNkLElBQUksQ0FBQ0MsUUFBUSxFQUNiLElBQUksQ0FBQ0MsYUFDUCxDQUFDO0lBQ0QsTUFBTStNLE1BQU0sR0FBRyxJQUFJNVQsTUFBTSxDQUFDO01BQ3hCd0wsS0FBSztNQUNMRCxNQUFNO01BQ041RSxTQUFTLEVBQUUsSUFBSSxDQUFDQSxTQUFTO01BQ3pCMkc7SUFDRixDQUFDLENBQUM7SUFDRjdNLGtCQUFrQixDQUFDMlMsRUFBRSxFQUFFUSxNQUFNLEVBQUU7TUFDN0JDLE9BQU8sRUFBRSxDQUFDTCxNQUFNO01BQ2hCTSxPQUFPLEVBQUUsQ0FBQ0osS0FBSztNQUNmSyxVQUFVLEVBQUVuRTtJQUNkLENBQUMsQ0FBQztJQUNGLE1BQU1vRSxRQUFRLEdBQUdKLE1BQU0sQ0FBQ2xFLEdBQUcsQ0FBQyxDQUFDO0lBQzdCO0lBQ0E7SUFDQTtJQUNBO0lBQ0F0USxHQUFHLENBQUM2VSxTQUFTLENBQUNiLEVBQUUsQ0FBQztJQUNqQixNQUFNN0ssU0FBUyxHQUFHekgsYUFBYSxDQUFDa1QsUUFBUSxFQUFFLElBQUksQ0FBQzNMLG9CQUFvQixDQUFDO0lBQ3BFekosZUFBZSxDQUNiLDBCQUEwQixJQUFJLENBQUN5SixvQkFBb0IsSUFBSSxHQUNyRCxNQUFNbUQsS0FBSyxJQUFJRCxNQUFNLEtBQUtpSSxNQUFNLElBQUlFLEtBQUssT0FBT25MLFNBQVMsQ0FBQ3lHLE1BQU0sR0FBRyxHQUNuRSxJQUFJekcsU0FBUyxDQUNWMkwsS0FBSyxDQUFDLENBQUMsRUFBRSxFQUFFLENBQUMsQ0FDWkMsR0FBRyxDQUFDQyxDQUFDLElBQUksR0FBR0EsQ0FBQyxDQUFDbkgsR0FBRyxJQUFJbUgsQ0FBQyxDQUFDOUQsR0FBRyxFQUFFLENBQUMsQ0FDN0JyQixJQUFJLENBQUMsR0FBRyxDQUFDLEVBQUUsR0FDZCxHQUFHMUcsU0FBUyxDQUFDeUcsTUFBTSxHQUFHLEVBQUUsR0FBRyxJQUFJLEdBQUcsRUFBRSxHQUN4QyxDQUFDO0lBQ0QsT0FBT3pHLFNBQVM7RUFDbEI7O0VBRUE7QUFDRjtBQUNBO0FBQ0E7QUFDQTtFQUNFOEwsa0JBQWtCQSxDQUNoQkMsS0FBSyxFQUFFO0lBQ0wvTCxTQUFTLEVBQUUxSCxhQUFhLEVBQUU7SUFDMUIySCxTQUFTLEVBQUUsTUFBTTtJQUNqQkMsVUFBVSxFQUFFLE1BQU07RUFDcEIsQ0FBQyxHQUFHLElBQUksQ0FDVCxFQUFFLElBQUksQ0FBQztJQUNOLElBQUksQ0FBQ0gsZUFBZSxHQUFHZ00sS0FBSztJQUM1QixJQUFJLENBQUNwTyxjQUFjLENBQUMsQ0FBQztFQUN2Qjs7RUFFQTtBQUNGO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0VxTyxtQkFBbUJBLENBQUNDLEtBQUssRUFBRSxNQUFNLENBQUMsRUFBRSxJQUFJLENBQUM7SUFDdkM7SUFDQTtJQUNBO0lBQ0EsTUFBTUMsT0FBTyxHQUFHMVYsUUFBUSxDQUFDLElBQUksRUFBRXlWLEtBQUssRUFBRSxZQUFZLENBQUM7SUFDbkQsTUFBTUUsR0FBRyxHQUFHRCxPQUFPLENBQUNFLE9BQU8sQ0FBQyxJQUFJLENBQUM7SUFDakMsSUFBSUQsR0FBRyxJQUFJLENBQUMsSUFBSUEsR0FBRyxLQUFLRCxPQUFPLENBQUN6RixNQUFNLEdBQUcsQ0FBQyxFQUFFO01BQzFDLElBQUksQ0FBQ3JJLFNBQVMsQ0FBQ2lPLGNBQWMsQ0FBQyxJQUFJLENBQUM7TUFDbkM7SUFDRjtJQUNBLElBQUksQ0FBQ2pPLFNBQVMsQ0FBQ2lPLGNBQWMsQ0FBQztNQUM1QmhRLElBQUksRUFBRSxNQUFNO01BQ1ppUSxJQUFJLEVBQUVKLE9BQU8sQ0FBQ1AsS0FBSyxDQUFDLENBQUMsRUFBRVEsR0FBRyxDQUFDO01BQzNCSSxPQUFPLEVBQUVMLE9BQU8sQ0FBQ1AsS0FBSyxDQUFDUSxHQUFHLEdBQUcsQ0FBQyxDQUFDLENBQUU7SUFDbkMsQ0FBQyxDQUFDO0lBQ0Y7SUFDQTtJQUNBO0VBQ0Y7O0VBRUE7QUFDRjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0UvUyxtQkFBbUJBLENBQ2pCb1QsUUFBUSxFQUFFLE1BQU0sRUFDaEJDLE9BQU8sRUFBRSxNQUFNLEVBQ2ZDLElBQUksRUFBRSxPQUFPLEdBQUcsT0FBTyxDQUN4QixFQUFFLElBQUksQ0FBQztJQUNOdFQsbUJBQW1CLENBQ2pCLElBQUksQ0FBQ3lHLFNBQVMsRUFDZCxJQUFJLENBQUNoQixVQUFVLENBQUNrRyxNQUFNLEVBQ3RCeUgsUUFBUSxFQUNSQyxPQUFPLEVBQ1BDLElBQ0YsQ0FBQztFQUNIOztFQUVBO0FBQ0Y7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0VDLHVCQUF1QkEsQ0FBQ0MsSUFBSSxFQUFFLE1BQU0sRUFBRUMsTUFBTSxFQUFFLE1BQU0sRUFBRUMsTUFBTSxFQUFFLE1BQU0sQ0FBQyxFQUFFLElBQUksQ0FBQztJQUMxRSxNQUFNQyxNQUFNLEdBQUdwVCxZQUFZLENBQUMsSUFBSSxDQUFDa0csU0FBUyxDQUFDO0lBQzNDNUYsY0FBYyxDQUNaLElBQUksQ0FBQzRGLFNBQVMsRUFDZCtNLElBQUksRUFDSkMsTUFBTSxFQUNOQyxNQUFNLEVBQ04sSUFBSSxDQUFDak8sVUFBVSxDQUFDa0csTUFBTSxDQUFDOUIsS0FDekIsQ0FBQztJQUNEO0lBQ0E7SUFDQTtJQUNBO0lBQ0EsSUFBSThKLE1BQU0sSUFBSSxDQUFDcFQsWUFBWSxDQUFDLElBQUksQ0FBQ2tHLFNBQVMsQ0FBQyxFQUFFO01BQzNDLElBQUksQ0FBQzJLLHFCQUFxQixDQUFDLENBQUM7SUFDOUI7RUFDRjs7RUFFQTtBQUNGO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0V3QyxrQkFBa0JBLENBQUNDLElBQUksRUFBRXpULFNBQVMsQ0FBQyxFQUFFLElBQUksQ0FBQztJQUN4QyxJQUFJLENBQUMsSUFBSSxDQUFDOEcsZUFBZSxFQUFFO0lBQzNCLE1BQU07TUFBRTBFO0lBQU0sQ0FBQyxHQUFHLElBQUksQ0FBQ25GLFNBQVM7SUFDaEMsSUFBSSxDQUFDbUYsS0FBSyxFQUFFO0lBQ1osTUFBTTtNQUFFL0IsS0FBSztNQUFFRDtJQUFPLENBQUMsR0FBRyxJQUFJLENBQUNuRSxVQUFVLENBQUNrRyxNQUFNO0lBQ2hELE1BQU1tSSxNQUFNLEdBQUdqSyxLQUFLLEdBQUcsQ0FBQztJQUN4QixNQUFNNkosTUFBTSxHQUFHOUosTUFBTSxHQUFHLENBQUM7SUFDekIsSUFBSTtNQUFFK0UsR0FBRztNQUFFckQ7SUFBSSxDQUFDLEdBQUdNLEtBQUs7SUFDeEIsUUFBUWlJLElBQUk7TUFDVixLQUFLLE1BQU07UUFDVCxJQUFJbEYsR0FBRyxHQUFHLENBQUMsRUFBRUEsR0FBRyxFQUFFLE1BQ2IsSUFBSXJELEdBQUcsR0FBRyxDQUFDLEVBQUU7VUFDaEJxRCxHQUFHLEdBQUdtRixNQUFNO1VBQ1p4SSxHQUFHLEVBQUU7UUFDUDtRQUNBO01BQ0YsS0FBSyxPQUFPO1FBQ1YsSUFBSXFELEdBQUcsR0FBR21GLE1BQU0sRUFBRW5GLEdBQUcsRUFBRSxNQUNsQixJQUFJckQsR0FBRyxHQUFHb0ksTUFBTSxFQUFFO1VBQ3JCL0UsR0FBRyxHQUFHLENBQUM7VUFDUHJELEdBQUcsRUFBRTtRQUNQO1FBQ0E7TUFDRixLQUFLLElBQUk7UUFDUCxJQUFJQSxHQUFHLEdBQUcsQ0FBQyxFQUFFQSxHQUFHLEVBQUU7UUFDbEI7TUFDRixLQUFLLE1BQU07UUFDVCxJQUFJQSxHQUFHLEdBQUdvSSxNQUFNLEVBQUVwSSxHQUFHLEVBQUU7UUFDdkI7TUFDRixLQUFLLFdBQVc7UUFDZHFELEdBQUcsR0FBRyxDQUFDO1FBQ1A7TUFDRixLQUFLLFNBQVM7UUFDWkEsR0FBRyxHQUFHbUYsTUFBTTtRQUNaO0lBQ0o7SUFDQSxJQUFJbkYsR0FBRyxLQUFLL0MsS0FBSyxDQUFDK0MsR0FBRyxJQUFJckQsR0FBRyxLQUFLTSxLQUFLLENBQUNOLEdBQUcsRUFBRTtJQUM1QzlLLFNBQVMsQ0FBQyxJQUFJLENBQUNpRyxTQUFTLEVBQUVrSSxHQUFHLEVBQUVyRCxHQUFHLENBQUM7SUFDbkMsSUFBSSxDQUFDOEYscUJBQXFCLENBQUMsQ0FBQztFQUM5Qjs7RUFFQTtFQUNBMkMsZ0JBQWdCQSxDQUFBLENBQUUsRUFBRSxPQUFPLENBQUM7SUFDMUIsT0FBT3hULFlBQVksQ0FBQyxJQUFJLENBQUNrRyxTQUFTLENBQUM7RUFDckM7O0VBRUE7QUFDRjtBQUNBO0FBQ0E7RUFDRXVOLDBCQUEwQkEsQ0FBQ2xJLEVBQUUsRUFBRSxHQUFHLEdBQUcsSUFBSSxDQUFDLEVBQUUsR0FBRyxHQUFHLElBQUksQ0FBQztJQUNyRCxJQUFJLENBQUMvRSxrQkFBa0IsQ0FBQ2tOLEdBQUcsQ0FBQ25JLEVBQUUsQ0FBQztJQUMvQixPQUFPLE1BQU0sSUFBSSxDQUFDL0Usa0JBQWtCLENBQUNtTixNQUFNLENBQUNwSSxFQUFFLENBQUM7RUFDakQ7RUFFQSxRQUFRc0YscUJBQXFCQSxDQUFBLENBQUUsRUFBRSxJQUFJLENBQUM7SUFDcEMsSUFBSSxDQUFDcEosUUFBUSxDQUFDLENBQUM7SUFDZixLQUFLLE1BQU04RCxFQUFFLElBQUksSUFBSSxDQUFDL0Usa0JBQWtCLEVBQUUrRSxFQUFFLENBQUMsQ0FBQztFQUNoRDs7RUFFQTtBQUNGO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtFQUNFL04sYUFBYUEsQ0FBQzRRLEdBQUcsRUFBRSxNQUFNLEVBQUVyRCxHQUFHLEVBQUUsTUFBTSxDQUFDLEVBQUUsT0FBTyxDQUFDO0lBQy9DLElBQUksQ0FBQyxJQUFJLENBQUNwRSxlQUFlLEVBQUUsT0FBTyxLQUFLO0lBQ3ZDLE1BQU00SixLQUFLLEdBQUduUixhQUFhLENBQUMsSUFBSSxDQUFDOEYsVUFBVSxDQUFDa0csTUFBTSxFQUFFZ0QsR0FBRyxFQUFFckQsR0FBRyxDQUFDO0lBQzdELE9BQU92TixhQUFhLENBQUMsSUFBSSxDQUFDNkcsUUFBUSxFQUFFK0osR0FBRyxFQUFFckQsR0FBRyxFQUFFd0YsS0FBSyxDQUFDO0VBQ3REO0VBRUE5UyxhQUFhQSxDQUFDMlEsR0FBRyxFQUFFLE1BQU0sRUFBRXJELEdBQUcsRUFBRSxNQUFNLENBQUMsRUFBRSxJQUFJLENBQUM7SUFDNUMsSUFBSSxDQUFDLElBQUksQ0FBQ3BFLGVBQWUsRUFBRTtJQUMzQmxKLGFBQWEsQ0FBQyxJQUFJLENBQUM0RyxRQUFRLEVBQUUrSixHQUFHLEVBQUVyRCxHQUFHLEVBQUUsSUFBSSxDQUFDckUsWUFBWSxDQUFDO0VBQzNEO0VBRUFrTixxQkFBcUJBLENBQUNDLFNBQVMsRUFBRTlWLFNBQVMsQ0FBQyxFQUFFLElBQUksQ0FBQztJQUNoRCxNQUFNc0ssTUFBTSxHQUFHLElBQUksQ0FBQzlELFlBQVksQ0FBQ3VQLGFBQWEsSUFBSSxJQUFJLENBQUN6UCxRQUFRO0lBQy9ELE1BQU1ULEtBQUssR0FBRyxJQUFJekcsYUFBYSxDQUFDMFcsU0FBUyxDQUFDO0lBQzFDNVYsVUFBVSxDQUFDcUssZ0JBQWdCLENBQUNELE1BQU0sRUFBRXpFLEtBQUssQ0FBQzs7SUFFMUM7SUFDQTtJQUNBLElBQ0UsQ0FBQ0EsS0FBSyxDQUFDbVEsZ0JBQWdCLElBQ3ZCRixTQUFTLENBQUNHLElBQUksS0FBSyxLQUFLLElBQ3hCLENBQUNILFNBQVMsQ0FBQ0ksSUFBSSxJQUNmLENBQUNKLFNBQVMsQ0FBQ0ssSUFBSSxFQUNmO01BQ0EsSUFBSUwsU0FBUyxDQUFDTSxLQUFLLEVBQUU7UUFDbkIsSUFBSSxDQUFDNVAsWUFBWSxDQUFDNlAsYUFBYSxDQUFDLElBQUksQ0FBQy9QLFFBQVEsQ0FBQztNQUNoRCxDQUFDLE1BQU07UUFDTCxJQUFJLENBQUNFLFlBQVksQ0FBQzhQLFNBQVMsQ0FBQyxJQUFJLENBQUNoUSxRQUFRLENBQUM7TUFDNUM7SUFDRjtFQUNGO0VBQ0E7QUFDRjtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0VBQ0VpUSxjQUFjQSxDQUFDbEcsR0FBRyxFQUFFLE1BQU0sRUFBRXJELEdBQUcsRUFBRSxNQUFNLENBQUMsRUFBRSxNQUFNLEdBQUcsU0FBUyxDQUFDO0lBQzNELElBQUksQ0FBQyxJQUFJLENBQUNwRSxlQUFlLEVBQUUsT0FBTytHLFNBQVM7SUFDM0MsTUFBTXRDLE1BQU0sR0FBRyxJQUFJLENBQUNsRyxVQUFVLENBQUNrRyxNQUFNO0lBQ3JDLE1BQU1tSixJQUFJLEdBQUd0VixNQUFNLENBQUNtTSxNQUFNLEVBQUVnRCxHQUFHLEVBQUVyRCxHQUFHLENBQUM7SUFDckMsSUFBSXlKLEdBQUcsR0FBR0QsSUFBSSxFQUFFRSxTQUFTO0lBQ3pCO0lBQ0E7SUFDQSxJQUFJLENBQUNELEdBQUcsSUFBSUQsSUFBSSxFQUFFakwsS0FBSyxLQUFLdkssU0FBUyxDQUFDMlYsVUFBVSxJQUFJdEcsR0FBRyxHQUFHLENBQUMsRUFBRTtNQUMzRG9HLEdBQUcsR0FBR3ZWLE1BQU0sQ0FBQ21NLE1BQU0sRUFBRWdELEdBQUcsR0FBRyxDQUFDLEVBQUVyRCxHQUFHLENBQUMsRUFBRTBKLFNBQVM7SUFDL0M7SUFDQSxPQUFPRCxHQUFHLElBQUkxVSxrQkFBa0IsQ0FBQ3NMLE1BQU0sRUFBRWdELEdBQUcsRUFBRXJELEdBQUcsQ0FBQztFQUNwRDs7RUFFQTtBQUNGO0FBQ0E7QUFDQTtFQUNFNEosZ0JBQWdCLEVBQUUsQ0FBQyxDQUFDSCxHQUFHLEVBQUUsTUFBTSxFQUFFLEdBQUcsSUFBSSxDQUFDLEdBQUcsU0FBUzs7RUFFckQ7QUFDRjtBQUNBO0FBQ0E7QUFDQTtFQUNFSSxhQUFhQSxDQUFDSixHQUFHLEVBQUUsTUFBTSxDQUFDLEVBQUUsSUFBSSxDQUFDO0lBQy9CLElBQUksQ0FBQ0csZ0JBQWdCLEdBQUdILEdBQUcsQ0FBQztFQUM5Qjs7RUFFQTtBQUNGO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtFQUNFSyxnQkFBZ0JBLENBQUN6RyxHQUFHLEVBQUUsTUFBTSxFQUFFckQsR0FBRyxFQUFFLE1BQU0sRUFBRStKLEtBQUssRUFBRSxDQUFDLEdBQUcsQ0FBQyxDQUFDLEVBQUUsSUFBSSxDQUFDO0lBQzdELElBQUksQ0FBQyxJQUFJLENBQUNuTyxlQUFlLEVBQUU7SUFDM0IsTUFBTXlFLE1BQU0sR0FBRyxJQUFJLENBQUNsRyxVQUFVLENBQUNrRyxNQUFNO0lBQ3JDO0lBQ0E7SUFDQTtJQUNBNUssY0FBYyxDQUFDLElBQUksQ0FBQzBGLFNBQVMsRUFBRWtJLEdBQUcsRUFBRXJELEdBQUcsQ0FBQztJQUN4QyxJQUFJK0osS0FBSyxLQUFLLENBQUMsRUFBRTFVLFlBQVksQ0FBQyxJQUFJLENBQUM4RixTQUFTLEVBQUVrRixNQUFNLEVBQUVnRCxHQUFHLEVBQUVyRCxHQUFHLENBQUMsTUFDMUQ1SyxZQUFZLENBQUMsSUFBSSxDQUFDK0YsU0FBUyxFQUFFa0YsTUFBTSxFQUFFTCxHQUFHLENBQUM7SUFDOUM7SUFDQTtJQUNBLElBQUksQ0FBQyxJQUFJLENBQUM3RSxTQUFTLENBQUNtRixLQUFLLEVBQUUsSUFBSSxDQUFDbkYsU0FBUyxDQUFDbUYsS0FBSyxHQUFHLElBQUksQ0FBQ25GLFNBQVMsQ0FBQzRFLE1BQU07SUFDdkUsSUFBSSxDQUFDK0YscUJBQXFCLENBQUMsQ0FBQztFQUM5Qjs7RUFFQTtBQUNGO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7RUFDRWtFLG1CQUFtQkEsQ0FBQzNHLEdBQUcsRUFBRSxNQUFNLEVBQUVyRCxHQUFHLEVBQUUsTUFBTSxDQUFDLEVBQUUsSUFBSSxDQUFDO0lBQ2xELElBQUksQ0FBQyxJQUFJLENBQUNwRSxlQUFlLEVBQUU7SUFDM0IsTUFBTXFPLEdBQUcsR0FBRyxJQUFJLENBQUM5TyxTQUFTO0lBQzFCLElBQUk4TyxHQUFHLENBQUNDLFVBQVUsRUFBRTtNQUNsQnJWLGVBQWUsQ0FBQ29WLEdBQUcsRUFBRSxJQUFJLENBQUM5UCxVQUFVLENBQUNrRyxNQUFNLEVBQUVnRCxHQUFHLEVBQUVyRCxHQUFHLENBQUM7SUFDeEQsQ0FBQyxNQUFNO01BQ0x0SyxlQUFlLENBQUN1VSxHQUFHLEVBQUU1RyxHQUFHLEVBQUVyRCxHQUFHLENBQUM7SUFDaEM7SUFDQSxJQUFJLENBQUM4RixxQkFBcUIsQ0FBQyxDQUFDO0VBQzlCOztFQUVBO0VBQ0E7RUFDQSxRQUFRcUUsY0FBYyxFQUFFQyxLQUFLLENBQUM7SUFDNUJ2UixLQUFLLEVBQUUsTUFBTTtJQUNid1IsUUFBUSxFQUFFLENBQUMsR0FBR0MsSUFBSSxFQUFFLE9BQU8sRUFBRSxFQUFFLEdBQUcsSUFBSTtFQUN4QyxDQUFDLENBQUMsR0FBRyxFQUFFO0VBQ1AsUUFBUUMsVUFBVSxHQUFHLEtBQUs7RUFFMUJwTCxZQUFZQSxDQUFBLENBQUUsRUFBRSxJQUFJLENBQUM7SUFDbkIsTUFBTTlHLEtBQUssR0FBRyxJQUFJLENBQUM4RCxPQUFPLENBQUM5RCxLQUFLO0lBQ2hDLElBQUksQ0FBQ0EsS0FBSyxDQUFDa0UsS0FBSyxFQUFFO01BQ2hCO0lBQ0Y7O0lBRUE7SUFDQTtJQUNBLE1BQU1pTyxpQkFBaUIsR0FBR25TLEtBQUssQ0FBQ29TLFNBQVMsQ0FBQyxVQUFVLENBQUM7SUFDckQ5WSxlQUFlLENBQ2Isa0NBQWtDNlksaUJBQWlCLENBQUN6SSxNQUFNLHFDQUFxQyxDQUFDMUosS0FBSyxJQUFJRixNQUFNLENBQUNHLFVBQVUsR0FBRztNQUFFOE0sS0FBSyxDQUFDLEVBQUUsT0FBTztJQUFDLENBQUMsRUFBRUEsS0FBSyxJQUFJLEtBQUssRUFDbEssQ0FBQztJQUNEb0YsaUJBQWlCLENBQUNFLE9BQU8sQ0FBQ0wsUUFBUSxJQUFJO01BQ3BDLElBQUksQ0FBQ0YsY0FBYyxDQUFDN0ksSUFBSSxDQUFDO1FBQ3ZCekksS0FBSyxFQUFFLFVBQVU7UUFDakJ3UixRQUFRLEVBQUVBLFFBQVEsSUFBSSxDQUFDLEdBQUdDLElBQUksRUFBRSxPQUFPLEVBQUUsRUFBRSxHQUFHO01BQ2hELENBQUMsQ0FBQztNQUNGalMsS0FBSyxDQUFDc1MsY0FBYyxDQUFDLFVBQVUsRUFBRU4sUUFBUSxJQUFJLENBQUMsR0FBR0MsSUFBSSxFQUFFLE9BQU8sRUFBRSxFQUFFLEdBQUcsSUFBSSxDQUFDO0lBQzVFLENBQUMsQ0FBQzs7SUFFRjtJQUNBLE1BQU1NLFlBQVksR0FBR3ZTLEtBQUssSUFBSUYsTUFBTSxDQUFDRyxVQUFVLEdBQUc7TUFDaEQ4TSxLQUFLLENBQUMsRUFBRSxPQUFPO01BQ2ZDLFVBQVUsQ0FBQyxFQUFFLENBQUN3RixJQUFJLEVBQUUsT0FBTyxFQUFFLEdBQUcsSUFBSTtJQUN0QyxDQUFDO0lBQ0QsSUFBSUQsWUFBWSxDQUFDeEYsS0FBSyxJQUFJd0YsWUFBWSxDQUFDdkYsVUFBVSxFQUFFO01BQ2pEdUYsWUFBWSxDQUFDdkYsVUFBVSxDQUFDLEtBQUssQ0FBQztNQUM5QixJQUFJLENBQUNrRixVQUFVLEdBQUcsSUFBSTtJQUN4QjtFQUNGO0VBRUFsTCxXQUFXQSxDQUFBLENBQUUsRUFBRSxJQUFJLENBQUM7SUFDbEIsTUFBTWhILEtBQUssR0FBRyxJQUFJLENBQUM4RCxPQUFPLENBQUM5RCxLQUFLO0lBQ2hDLElBQUksQ0FBQ0EsS0FBSyxDQUFDa0UsS0FBSyxFQUFFO01BQ2hCO0lBQ0Y7O0lBRUE7SUFDQSxJQUFJLElBQUksQ0FBQzROLGNBQWMsQ0FBQ3BJLE1BQU0sS0FBSyxDQUFDLElBQUksQ0FBQyxJQUFJLENBQUN3SSxVQUFVLEVBQUU7TUFDeEQ1WSxlQUFlLENBQ2IsNkZBQTZGLEVBQzdGO1FBQUVzUSxLQUFLLEVBQUU7TUFBTyxDQUNsQixDQUFDO0lBQ0g7SUFDQXRRLGVBQWUsQ0FDYixxQ0FBcUMsSUFBSSxDQUFDd1ksY0FBYyxDQUFDcEksTUFBTSw0QkFBNEIsSUFBSSxDQUFDd0ksVUFBVSxFQUM1RyxDQUFDO0lBQ0QsSUFBSSxDQUFDSixjQUFjLENBQUNPLE9BQU8sQ0FBQyxDQUFDO01BQUU3UixLQUFLO01BQUV3UjtJQUFTLENBQUMsS0FBSztNQUNuRGhTLEtBQUssQ0FBQ3lTLFdBQVcsQ0FBQ2pTLEtBQUssRUFBRXdSLFFBQVEsQ0FBQztJQUNwQyxDQUFDLENBQUM7SUFDRixJQUFJLENBQUNGLGNBQWMsR0FBRyxFQUFFOztJQUV4QjtJQUNBLElBQUksSUFBSSxDQUFDSSxVQUFVLEVBQUU7TUFDbkIsTUFBTUssWUFBWSxHQUFHdlMsS0FBSyxJQUFJRixNQUFNLENBQUNHLFVBQVUsR0FBRztRQUNoRCtNLFVBQVUsQ0FBQyxFQUFFLENBQUN3RixJQUFJLEVBQUUsT0FBTyxFQUFFLEdBQUcsSUFBSTtNQUN0QyxDQUFDO01BQ0QsSUFBSUQsWUFBWSxDQUFDdkYsVUFBVSxFQUFFO1FBQzNCdUYsWUFBWSxDQUFDdkYsVUFBVSxDQUFDLElBQUksQ0FBQztNQUMvQjtNQUNBLElBQUksQ0FBQ2tGLFVBQVUsR0FBRyxLQUFLO0lBQ3pCO0VBQ0Y7O0VBRUE7RUFDQTtFQUNBO0VBQ0E7RUFDQSxRQUFRUSxRQUFRQSxDQUFDQyxJQUFJLEVBQUUsTUFBTSxDQUFDLEVBQUUsSUFBSSxDQUFDO0lBQ25DLElBQUksQ0FBQzdPLE9BQU8sQ0FBQ2pFLE1BQU0sQ0FBQ3dHLEtBQUssQ0FBQ3NNLElBQUksQ0FBQztFQUNqQztFQUVBLFFBQVFDLG9CQUFvQixFQUFFaFosdUJBQXVCLEdBQUdnWixDQUN0RDFJLElBQUksRUFDSjJJLFdBQVcsS0FDUjtJQUNILElBQ0UzSSxJQUFJLEtBQUssSUFBSSxJQUNiMkksV0FBVyxLQUFLdkksU0FBUyxJQUN6QixJQUFJLENBQUMzRyxpQkFBaUIsRUFBRTBHLElBQUksS0FBS3dJLFdBQVcsRUFDNUM7TUFDQTtJQUNGO0lBQ0EsSUFBSSxDQUFDbFAsaUJBQWlCLEdBQUd1RyxJQUFJO0VBQy9CLENBQUM7RUFFRDNELE1BQU1BLENBQUM4RCxJQUFJLEVBQUVyUixTQUFTLENBQUMsRUFBRSxJQUFJLENBQUM7SUFDNUIsSUFBSSxDQUFDNkksV0FBVyxHQUFHd0ksSUFBSTtJQUV2QixNQUFNeUksSUFBSSxHQUNSLENBQUMsR0FBRyxDQUNGLEtBQUssQ0FBQyxDQUFDLElBQUksQ0FBQ2hQLE9BQU8sQ0FBQzlELEtBQUssQ0FBQyxDQUMxQixNQUFNLENBQUMsQ0FBQyxJQUFJLENBQUM4RCxPQUFPLENBQUNqRSxNQUFNLENBQUMsQ0FDNUIsTUFBTSxDQUFDLENBQUMsSUFBSSxDQUFDaUUsT0FBTyxDQUFDNUQsTUFBTSxDQUFDLENBQzVCLFdBQVcsQ0FBQyxDQUFDLElBQUksQ0FBQzRELE9BQU8sQ0FBQzNELFdBQVcsQ0FBQyxDQUN0QyxNQUFNLENBQUMsQ0FBQyxJQUFJLENBQUNzRSxPQUFPLENBQUMsQ0FDckIsZUFBZSxDQUFDLENBQUMsSUFBSSxDQUFDN0MsZUFBZSxDQUFDLENBQ3RDLFlBQVksQ0FBQyxDQUFDLElBQUksQ0FBQ2pDLFlBQVksQ0FBQyxDQUNoQyxTQUFTLENBQUMsQ0FBQyxJQUFJLENBQUNtRCxTQUFTLENBQUMsQ0FDMUIsaUJBQWlCLENBQUMsQ0FBQyxJQUFJLENBQUMySyxxQkFBcUIsQ0FBQyxDQUM5QyxTQUFTLENBQUMsQ0FBQyxJQUFJLENBQUNyVCxhQUFhLENBQUMsQ0FDOUIsU0FBUyxDQUFDLENBQUMsSUFBSSxDQUFDQyxhQUFhLENBQUMsQ0FDOUIsY0FBYyxDQUFDLENBQUMsSUFBSSxDQUFDNlcsY0FBYyxDQUFDLENBQ3BDLGVBQWUsQ0FBQyxDQUFDLElBQUksQ0FBQ00sYUFBYSxDQUFDLENBQ3BDLFlBQVksQ0FBQyxDQUFDLElBQUksQ0FBQ0MsZ0JBQWdCLENBQUMsQ0FDcEMsZUFBZSxDQUFDLENBQUMsSUFBSSxDQUFDRSxtQkFBbUIsQ0FBQyxDQUMxQyxhQUFhLENBQUMsQ0FBQyxJQUFJLENBQUMvRSxxQkFBcUIsQ0FBQyxDQUMxQyxtQkFBbUIsQ0FBQyxDQUFDLElBQUksQ0FBQ2dHLG9CQUFvQixDQUFDLENBQy9DLHFCQUFxQixDQUFDLENBQUMsSUFBSSxDQUFDcEMscUJBQXFCLENBQUM7QUFFMUQsUUFBUSxDQUFDLHFCQUFxQixDQUFDLEtBQUssQ0FBQyxDQUFDLElBQUksQ0FBQ2tDLFFBQVEsQ0FBQztBQUNwRCxVQUFVLENBQUNySSxJQUFJO0FBQ2YsUUFBUSxFQUFFLHFCQUFxQjtBQUMvQixNQUFNLEVBQUUsR0FBRyxDQUNOOztJQUVEO0lBQ0F6UCxVQUFVLENBQUNtWSxtQkFBbUIsQ0FBQ0QsSUFBSSxFQUFFLElBQUksQ0FBQzlSLFNBQVMsRUFBRSxJQUFJLEVBQUVuSSxJQUFJLENBQUM7SUFDaEU7SUFDQStCLFVBQVUsQ0FBQ29ZLGFBQWEsQ0FBQyxDQUFDO0VBQzVCO0VBRUF2TyxPQUFPQSxDQUFDd08sS0FBNkIsQ0FBdkIsRUFBRXRNLEtBQUssR0FBRyxNQUFNLEdBQUcsSUFBSSxDQUFDLEVBQUUsSUFBSSxDQUFDO0lBQzNDLElBQUksSUFBSSxDQUFDN0YsV0FBVyxFQUFFO01BQ3BCO0lBQ0Y7SUFFQSxJQUFJLENBQUN1RCxRQUFRLENBQUMsQ0FBQztJQUNmLElBQUksQ0FBQ0csZUFBZSxDQUFDLENBQUM7SUFFdEIsSUFBSSxPQUFPLElBQUksQ0FBQy9DLGNBQWMsS0FBSyxVQUFVLEVBQUU7TUFDN0MsSUFBSSxDQUFDQSxjQUFjLENBQUMsQ0FBQztJQUN2QjtJQUNBLElBQUksQ0FBQ0MsYUFBYSxHQUFHLENBQUM7SUFFdEIsSUFBSSxDQUFDQyxzQkFBc0IsR0FBRyxDQUFDOztJQUUvQjtJQUNBO0lBQ0EsTUFBTWlILElBQUksR0FBRyxJQUFJLENBQUNsSSxHQUFHLENBQUN3UywrQkFBK0IsQ0FBQyxJQUFJLENBQUNwUixVQUFVLENBQUM7SUFDdEVyRSxtQkFBbUIsQ0FBQyxJQUFJLENBQUNrRCxRQUFRLEVBQUVsRyxRQUFRLENBQUNtTyxJQUFJLENBQUMsQ0FBQzs7SUFFbEQ7SUFDQTtJQUNBO0lBQ0E7SUFDQTtJQUNBO0lBQ0E7SUFDQTtJQUNBLElBQUksSUFBSSxDQUFDOUUsT0FBTyxDQUFDakUsTUFBTSxDQUFDcUUsS0FBSyxFQUFFO01BQzdCLElBQUksSUFBSSxDQUFDWCxlQUFlLEVBQUU7UUFDeEI7UUFDQTtRQUNBM0ssU0FBUyxDQUFDLENBQUMsRUFBRTJGLGVBQWUsQ0FBQztNQUMvQjtNQUNBO01BQ0E7TUFDQTtNQUNBM0YsU0FBUyxDQUFDLENBQUMsRUFBRXdGLHNCQUFzQixDQUFDO01BQ3BDO01BQ0EsSUFBSSxDQUFDOE8sVUFBVSxDQUFDLENBQUM7TUFDakI7TUFDQXRVLFNBQVMsQ0FBQyxDQUFDLEVBQUVrRix5QkFBeUIsQ0FBQztNQUN2Q2xGLFNBQVMsQ0FBQyxDQUFDLEVBQUVpRixzQkFBc0IsQ0FBQztNQUNwQztNQUNBakYsU0FBUyxDQUFDLENBQUMsRUFBRXVGLEdBQUcsQ0FBQztNQUNqQjtNQUNBdkYsU0FBUyxDQUFDLENBQUMsRUFBRXNGLEdBQUcsQ0FBQztNQUNqQjtNQUNBdEYsU0FBUyxDQUFDLENBQUMsRUFBRTRGLFdBQVcsQ0FBQztNQUN6QjtNQUNBNUYsU0FBUyxDQUFDLENBQUMsRUFBRTZGLHFCQUFxQixDQUFDO01BQ25DO01BQ0EsSUFBSUcsaUJBQWlCLENBQUMsQ0FBQyxFQUNyQmhHLFNBQVMsQ0FBQyxDQUFDLEVBQUVpRyxrQkFBa0IsQ0FBQ0gsZ0JBQWdCLENBQUMsQ0FBQztJQUN0RDtJQUNBOztJQUVBLElBQUksQ0FBQ29DLFdBQVcsR0FBRyxJQUFJOztJQUV2QjtJQUNBLElBQUksQ0FBQ0YsY0FBYyxDQUFDQyxNQUFNLEdBQUcsQ0FBQztJQUM5QixJQUFJLElBQUksQ0FBQ3NCLFVBQVUsS0FBSyxJQUFJLEVBQUU7TUFDNUJnRixZQUFZLENBQUMsSUFBSSxDQUFDaEYsVUFBVSxDQUFDO01BQzdCLElBQUksQ0FBQ0EsVUFBVSxHQUFHLElBQUk7SUFDeEI7O0lBRUE7SUFDQXZILFVBQVUsQ0FBQ21ZLG1CQUFtQixDQUFDLElBQUksRUFBRSxJQUFJLENBQUMvUixTQUFTLEVBQUUsSUFBSSxFQUFFbkksSUFBSSxDQUFDO0lBQ2hFO0lBQ0ErQixVQUFVLENBQUNvWSxhQUFhLENBQUMsQ0FBQztJQUMxQjFZLFNBQVMsQ0FBQ2lXLE1BQU0sQ0FBQyxJQUFJLENBQUN6TSxPQUFPLENBQUNqRSxNQUFNLENBQUM7O0lBRXJDO0lBQ0E7SUFDQTtJQUNBLElBQUksQ0FBQ29CLFFBQVEsQ0FBQ29FLFFBQVEsRUFBRThOLElBQUksQ0FBQyxDQUFDO0lBQzlCLElBQUksQ0FBQ2xTLFFBQVEsQ0FBQ29FLFFBQVEsR0FBR2lGLFNBQVM7SUFFbEMsSUFBSTJJLEtBQUssWUFBWXRNLEtBQUssRUFBRTtNQUMxQixJQUFJLENBQUNGLGlCQUFpQixDQUFDd00sS0FBSyxDQUFDO0lBQy9CLENBQUMsTUFBTTtNQUNMLElBQUksQ0FBQ3pNLGtCQUFrQixDQUFDLENBQUM7SUFDM0I7RUFDRjtFQUVBLE1BQU1uRyxhQUFhQSxDQUFBLENBQUUsRUFBRUMsT0FBTyxDQUFDLElBQUksQ0FBQyxDQUFDO0lBQ25DLElBQUksQ0FBQ2tCLFdBQVcsS0FBSyxJQUFJbEIsT0FBTyxDQUFDLENBQUM4UyxPQUFPLEVBQUVDLE1BQU0sS0FBSztNQUNwRCxJQUFJLENBQUM3TSxrQkFBa0IsR0FBRzRNLE9BQU87TUFDakMsSUFBSSxDQUFDM00saUJBQWlCLEdBQUc0TSxNQUFNO0lBQ2pDLENBQUMsQ0FBQztJQUVGLE9BQU8sSUFBSSxDQUFDN1IsV0FBVztFQUN6QjtFQUVBOFIsY0FBY0EsQ0FBQSxDQUFFLEVBQUUsSUFBSSxDQUFDO0lBQ3JCLElBQUksSUFBSSxDQUFDeFAsT0FBTyxDQUFDakUsTUFBTSxDQUFDcUUsS0FBSyxFQUFFO01BQzdCO01BQ0EsSUFBSSxDQUFDbkMsU0FBUyxHQUFHLElBQUksQ0FBQ0QsVUFBVTtNQUNoQyxJQUFJLENBQUNBLFVBQVUsR0FBRzdILFVBQVUsQ0FDMUIsSUFBSSxDQUFDNkgsVUFBVSxDQUFDa0UsUUFBUSxDQUFDQyxNQUFNLEVBQy9CLElBQUksQ0FBQ25FLFVBQVUsQ0FBQ2tFLFFBQVEsQ0FBQ0UsS0FBSyxFQUM5QixJQUFJLENBQUM3RSxTQUFTLEVBQ2QsSUFBSSxDQUFDQyxRQUFRLEVBQ2IsSUFBSSxDQUFDQyxhQUNQLENBQUM7TUFDRCxJQUFJLENBQUNiLEdBQUcsQ0FBQ3lGLEtBQUssQ0FBQyxDQUFDO01BQ2hCO01BQ0E7TUFDQSxJQUFJLENBQUN2QyxhQUFhLEdBQUcsSUFBSTtJQUMzQjtFQUNGOztFQUVBO0FBQ0Y7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7RUFDRWtGLFVBQVVBLENBQUEsQ0FBRSxFQUFFLElBQUksQ0FBQztJQUNqQixJQUFJLENBQUN4SCxRQUFRLEdBQUcsSUFBSTFGLFFBQVEsQ0FBQyxDQUFDO0lBQzlCLElBQUksQ0FBQzJGLGFBQWEsR0FBRyxJQUFJeEYsYUFBYSxDQUFDLENBQUM7SUFDeENFLGtCQUFrQixDQUNoQixJQUFJLENBQUM2RixVQUFVLENBQUNrRyxNQUFNLEVBQ3RCLElBQUksQ0FBQzFHLFFBQVEsRUFDYixJQUFJLENBQUNDLGFBQ1AsQ0FBQztJQUNEO0lBQ0E7SUFDQTtJQUNBLElBQUksQ0FBQ1EsU0FBUyxDQUFDaUcsTUFBTSxDQUFDMUcsUUFBUSxHQUFHLElBQUksQ0FBQ0EsUUFBUTtJQUM5QyxJQUFJLENBQUNTLFNBQVMsQ0FBQ2lHLE1BQU0sQ0FBQ3pHLGFBQWEsR0FBRyxJQUFJLENBQUNBLGFBQWE7RUFDMUQ7RUFFQW5CLFlBQVlBLENBQUEsQ0FBRSxFQUFFLEdBQUcsR0FBRyxJQUFJLENBQUM7SUFDekI7SUFDQSxNQUFNbVQsR0FBRyxHQUFHQyxPQUFPO0lBQ25CLE1BQU1DLFNBQVMsRUFBRUMsT0FBTyxDQUFDQyxNQUFNLENBQUMsTUFBTUMsT0FBTyxFQUFFQSxPQUFPLENBQUMsTUFBTUEsT0FBTyxDQUFDLENBQUMsQ0FBQyxHQUFHLENBQUMsQ0FBQztJQUM1RSxNQUFNQyxPQUFPLEdBQUdBLENBQUMsR0FBRzVCLElBQUksRUFBRSxPQUFPLEVBQUUsS0FDakMzWSxlQUFlLENBQUMsZ0JBQWdCRSxNQUFNLENBQUMsR0FBR3lZLElBQUksQ0FBQyxFQUFFLENBQUM7SUFDcEQsTUFBTTZCLE9BQU8sR0FBR0EsQ0FBQyxHQUFHN0IsSUFBSSxFQUFFLE9BQU8sRUFBRSxLQUNqQzFZLFFBQVEsQ0FBQyxJQUFJb04sS0FBSyxDQUFDLGtCQUFrQm5OLE1BQU0sQ0FBQyxHQUFHeVksSUFBSSxDQUFDLEVBQUUsQ0FBQyxDQUFDO0lBQzFELEtBQUssTUFBTWhGLENBQUMsSUFBSThHLHNCQUFzQixFQUFFO01BQ3RDTixTQUFTLENBQUN4RyxDQUFDLENBQUMsR0FBR3NHLEdBQUcsQ0FBQ3RHLENBQUMsQ0FBQztNQUNyQnNHLEdBQUcsQ0FBQ3RHLENBQUMsQ0FBQyxHQUFHNEcsT0FBTztJQUNsQjtJQUNBLEtBQUssTUFBTTVHLENBQUMsSUFBSStHLHNCQUFzQixFQUFFO01BQ3RDUCxTQUFTLENBQUN4RyxDQUFDLENBQUMsR0FBR3NHLEdBQUcsQ0FBQ3RHLENBQUMsQ0FBQztNQUNyQnNHLEdBQUcsQ0FBQ3RHLENBQUMsQ0FBQyxHQUFHNkcsT0FBTztJQUNsQjtJQUNBTCxTQUFTLENBQUNRLE1BQU0sR0FBR1YsR0FBRyxDQUFDVSxNQUFNO0lBQzdCVixHQUFHLENBQUNVLE1BQU0sR0FBRyxDQUFDQyxTQUFTLEVBQUUsT0FBTyxFQUFFLEdBQUdqQyxJQUFJLEVBQUUsT0FBTyxFQUFFLEtBQUs7TUFDdkQsSUFBSSxDQUFDaUMsU0FBUyxFQUFFSixPQUFPLENBQUMsR0FBRzdCLElBQUksQ0FBQztJQUNsQyxDQUFDO0lBQ0QsT0FBTyxNQUFNalQsTUFBTSxDQUFDbVYsTUFBTSxDQUFDWixHQUFHLEVBQUVFLFNBQVMsQ0FBQztFQUM1Qzs7RUFFQTtBQUNGO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7RUFDRSxRQUFRMVAsV0FBV0EsQ0FBQSxDQUFFLEVBQUUsR0FBRyxHQUFHLElBQUksQ0FBQztJQUNoQyxNQUFNN0QsTUFBTSxHQUFHMkUsT0FBTyxDQUFDM0UsTUFBTTtJQUM3QixNQUFNa1UsYUFBYSxHQUFHbFUsTUFBTSxDQUFDbUcsS0FBSztJQUNsQyxJQUFJZ08sU0FBUyxHQUFHLEtBQUs7SUFDckIsTUFBTUMsU0FBUyxHQUFHQSxDQUNoQkMsS0FBSyxFQUFFQyxVQUFVLEdBQUcsTUFBTSxFQUMxQkMsWUFBdUQsQ0FBMUMsRUFBRUMsY0FBYyxHQUFHLENBQUMsQ0FBQ0MsR0FBVyxDQUFQLEVBQUVoTyxLQUFLLEVBQUUsR0FBRyxJQUFJLENBQUMsRUFDdkR3QixFQUEwQixDQUF2QixFQUFFLENBQUN3TSxHQUFXLENBQVAsRUFBRWhPLEtBQUssRUFBRSxHQUFHLElBQUksQ0FDM0IsRUFBRSxPQUFPLElBQUk7TUFDWixNQUFNaU8sUUFBUSxHQUFHLE9BQU9ILFlBQVksS0FBSyxVQUFVLEdBQUdBLFlBQVksR0FBR3RNLEVBQUU7TUFDdkU7TUFDQTtNQUNBO01BQ0EsSUFBSWtNLFNBQVMsRUFBRTtRQUNiLE1BQU1RLFFBQVEsR0FDWixPQUFPSixZQUFZLEtBQUssUUFBUSxHQUFHQSxZQUFZLEdBQUduSyxTQUFTO1FBQzdELE9BQU84SixhQUFhLENBQUNVLElBQUksQ0FBQzVVLE1BQU0sRUFBRXFVLEtBQUssRUFBRU0sUUFBUSxFQUFFRCxRQUFRLENBQUM7TUFDOUQ7TUFDQVAsU0FBUyxHQUFHLElBQUk7TUFDaEIsSUFBSTtRQUNGLE1BQU1oSCxJQUFJLEdBQ1IsT0FBT2tILEtBQUssS0FBSyxRQUFRLEdBQ3JCQSxLQUFLLEdBQ0xRLE1BQU0sQ0FBQzlKLElBQUksQ0FBQ3NKLEtBQUssQ0FBQyxDQUFDUyxRQUFRLENBQUMsTUFBTSxDQUFDO1FBQ3pDMWIsZUFBZSxDQUFDLFlBQVkrVCxJQUFJLEVBQUUsRUFBRTtVQUFFekQsS0FBSyxFQUFFO1FBQU8sQ0FBQyxDQUFDO1FBQ3RELElBQUksSUFBSSxDQUFDckcsZUFBZSxJQUFJLENBQUMsSUFBSSxDQUFDekMsV0FBVyxJQUFJLENBQUMsSUFBSSxDQUFDQyxRQUFRLEVBQUU7VUFDL0QsSUFBSSxDQUFDMEMscUJBQXFCLEdBQUcsSUFBSTtVQUNqQyxJQUFJLENBQUM3QyxjQUFjLENBQUMsQ0FBQztRQUN2QjtNQUNGLENBQUMsU0FBUztRQUNSeVQsU0FBUyxHQUFHLEtBQUs7UUFDakJPLFFBQVEsR0FBRyxDQUFDO01BQ2Q7TUFDQSxPQUFPLElBQUk7SUFDYixDQUFDO0lBQ0QxVSxNQUFNLENBQUNtRyxLQUFLLEdBQUdpTyxTQUFTO0lBQ3hCLE9BQU8sTUFBTTtNQUNYLElBQUlwVSxNQUFNLENBQUNtRyxLQUFLLEtBQUtpTyxTQUFTLEVBQUU7UUFDOUJwVSxNQUFNLENBQUNtRyxLQUFLLEdBQUcrTixhQUFhO01BQzlCO0lBQ0YsQ0FBQztFQUNIO0FBQ0Y7O0FBRUE7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQTtBQUNBO0FBQ0E7QUFDQSxPQUFPLFNBQVNsSCxVQUFVQSxDQUFDbE4sS0FBSyxFQUFFRixNQUFNLENBQUNHLFVBQVUsR0FBRzRFLE9BQU8sQ0FBQzdFLEtBQUssQ0FBQyxFQUFFLElBQUksQ0FBQztFQUN6RSxJQUFJLENBQUNBLEtBQUssQ0FBQ2tFLEtBQUssRUFBRTtFQUNsQjtFQUNBO0VBQ0EsSUFBSTtJQUNGLE9BQU9sRSxLQUFLLENBQUNpVixJQUFJLENBQUMsQ0FBQyxLQUFLLElBQUksRUFBRTtNQUM1QjtJQUFBO0VBRUosQ0FBQyxDQUFDLE1BQU07SUFDTjtFQUFBO0VBRUY7RUFDQTtFQUNBLElBQUlwUSxPQUFPLENBQUNxUSxRQUFRLEtBQUssT0FBTyxFQUFFO0VBQ2xDO0VBQ0E7RUFDQTtFQUNBLE1BQU1DLEdBQUcsR0FBR25WLEtBQUssSUFBSUYsTUFBTSxDQUFDRyxVQUFVLEdBQUc7SUFDdkM4TSxLQUFLLENBQUMsRUFBRSxPQUFPO0lBQ2ZDLFVBQVUsQ0FBQyxFQUFFLENBQUNPLEdBQUcsRUFBRSxPQUFPLEVBQUUsR0FBRyxJQUFJO0VBQ3JDLENBQUM7RUFDRCxNQUFNNkgsTUFBTSxHQUFHRCxHQUFHLENBQUNwSSxLQUFLLEtBQUssSUFBSTtFQUNqQztFQUNBO0VBQ0E7RUFDQSxJQUFJc0ksRUFBRSxHQUFHLENBQUMsQ0FBQztFQUNYLElBQUk7SUFDRjtJQUNBO0lBQ0EsSUFBSSxDQUFDRCxNQUFNLEVBQUVELEdBQUcsQ0FBQ25JLFVBQVUsR0FBRyxJQUFJLENBQUM7SUFDbkNxSSxFQUFFLEdBQUczYyxRQUFRLENBQUMsVUFBVSxFQUFFRCxXQUFXLENBQUM2YyxRQUFRLEdBQUc3YyxXQUFXLENBQUM4YyxVQUFVLENBQUM7SUFDeEUsTUFBTUMsR0FBRyxHQUFHVCxNQUFNLENBQUNVLEtBQUssQ0FBQyxJQUFJLENBQUM7SUFDOUIsS0FBSyxJQUFJQyxDQUFDLEdBQUcsQ0FBQyxFQUFFQSxDQUFDLEdBQUcsRUFBRSxFQUFFQSxDQUFDLEVBQUUsRUFBRTtNQUMzQixJQUFJL2MsUUFBUSxDQUFDMGMsRUFBRSxFQUFFRyxHQUFHLEVBQUUsQ0FBQyxFQUFFQSxHQUFHLENBQUM5TCxNQUFNLEVBQUUsSUFBSSxDQUFDLElBQUksQ0FBQyxFQUFFO0lBQ25EO0VBQ0YsQ0FBQyxDQUFDLE1BQU07SUFDTjtJQUNBO0VBQUEsQ0FDRCxTQUFTO0lBQ1IsSUFBSTJMLEVBQUUsSUFBSSxDQUFDLEVBQUU7TUFDWCxJQUFJO1FBQ0Y5YyxTQUFTLENBQUM4YyxFQUFFLENBQUM7TUFDZixDQUFDLENBQUMsTUFBTTtRQUNOO01BQUE7SUFFSjtJQUNBLElBQUksQ0FBQ0QsTUFBTSxFQUFFO01BQ1gsSUFBSTtRQUNGRCxHQUFHLENBQUNuSSxVQUFVLEdBQUcsS0FBSyxDQUFDO01BQ3pCLENBQUMsQ0FBQyxNQUFNO1FBQ047TUFBQTtJQUVKO0VBQ0Y7QUFDRjtBQUNBOztBQUVBLE1BQU0rRyxzQkFBc0IsR0FBRyxDQUM3QixLQUFLLEVBQ0wsTUFBTSxFQUNOLE9BQU8sRUFDUCxLQUFLLEVBQ0wsUUFBUSxFQUNSLE9BQU8sRUFDUCxZQUFZLEVBQ1osT0FBTyxFQUNQLGdCQUFnQixFQUNoQixVQUFVLEVBQ1YsT0FBTyxFQUNQLE1BQU0sRUFDTixTQUFTLEVBQ1QsU0FBUyxDQUNWLElBQUl4VSxLQUFLO0FBQ1YsTUFBTXlVLHNCQUFzQixHQUFHLENBQUMsTUFBTSxFQUFFLE9BQU8sRUFBRSxPQUFPLENBQUMsSUFBSXpVLEtBQUsiLCJpZ25vcmVMaXN0IjpbXX0=

--- a/packages/renderer/src/ink.tsx
+++ b/packages/renderer/src/ink.tsx
@@ -1,5 +1,5 @@
-import { closeSync, constants as fsConstants, openSync, readSync, writeSync } from 'fs'
-import { format } from 'util'
+import { closeSync, constants as fsConstants, openSync, readSync, writeSync } from 'node:fs'
+import { format } from 'node:util'
 import { logForDebugging } from '@yokai/shared'
 import { logError } from '@yokai/shared'
 import { getYogaCounters } from '@yokai/shared/yoga-layout'
@@ -353,6 +353,7 @@ export default class Ink {
       noop, // onDefaultTransitionIndicator
     )
     // @ts-ignore dead code from production build
+    // biome-ignore lint/correctness/noConstantCondition: intentional dead-code branch — bundlers (tsup/esbuild) statically tree-shake this entire if-block out of production builds
     if ('production' === 'development') {
       reconciler.injectIntoDevTools({
         bundleType: 0,
@@ -1560,13 +1561,13 @@ export default class Ink {
         ).isRaw ?? false
       }`,
     )
-    readableListeners.forEach((listener) => {
+    for (const listener of readableListeners) {
       this.stdinListeners.push({
         event: 'readable',
         listener: listener as (...args: unknown[]) => void,
       })
       stdin.removeListener('readable', listener as (...args: unknown[]) => void)
-    })
+    }
 
     // If raw mode is enabled, disable it temporarily
     const stdinWithRaw = stdin as NodeJS.ReadStream & {
@@ -1596,9 +1597,9 @@ export default class Ink {
     logForDebugging(
       `[stdin] resumeStdin: re-attaching ${this.stdinListeners.length} listener(s), wasRawMode=${this.wasRawMode}`,
     )
-    this.stdinListeners.forEach(({ event, listener }) => {
+    for (const { event, listener } of this.stdinListeners) {
       stdin.addListener(event, listener)
-    })
+    }
     this.stdinListeners = []
 
     // Re-enable raw mode if it was enabled before
@@ -1788,7 +1789,6 @@ export default class Ink {
     this.backFrame.screen.hyperlinkPool = this.hyperlinkPool
   }
   patchConsole(): () => void {
-    // biome-ignore lint/suspicious/noConsole: intentionally patching global console
     const con = console
     const originals: Partial<Record<keyof Console, Console[keyof Console]>> = {}
     const toDebug = (...args: unknown[]) => logForDebugging(`console.log: ${format(...args)}`)

--- a/packages/renderer/src/instances.ts
+++ b/packages/renderer/src/instances.ts
@@ -8,4 +8,3 @@ import type Ink from './ink'
 
 const instances = new Map<NodeJS.WriteStream, Ink>()
 export default instances
-

--- a/packages/renderer/src/layout/engine.ts
+++ b/packages/renderer/src/layout/engine.ts
@@ -4,4 +4,3 @@ import { createYogaLayoutNode } from './yoga'
 export function createLayoutNode(): LayoutNode {
   return createYogaLayoutNode()
 }
-

--- a/packages/renderer/src/layout/geometry.ts
+++ b/packages/renderer/src/layout/geometry.ts
@@ -21,12 +21,7 @@ export type Edges = {
 /** Create uniform edges */
 export function edges(all: number): Edges
 export function edges(vertical: number, horizontal: number): Edges
-export function edges(
-  top: number,
-  right: number,
-  bottom: number,
-  left: number,
-): Edges
+export function edges(top: number, right: number, bottom: number, left: number): Edges
 export function edges(a: number, b?: number, c?: number, d?: number): Edges {
   if (b === undefined) {
     return { top: a, right: a, bottom: a, left: a }
@@ -82,12 +77,7 @@ export function clampRect(rect: Rectangle, size: Size): Rectangle {
 }
 
 export function withinBounds(size: Size, point: Point): boolean {
-  return (
-    point.x >= 0 &&
-    point.y >= 0 &&
-    point.x < size.width &&
-    point.y < size.height
-  )
+  return point.x >= 0 && point.y >= 0 && point.x < size.width && point.y < size.height
 }
 
 export function clamp(value: number, min?: number, max?: number): number {
@@ -95,4 +85,3 @@ export function clamp(value: number, min?: number, max?: number): number {
   if (max !== undefined && value > max) return max
   return value
 }
-

--- a/packages/renderer/src/layout/node.ts
+++ b/packages/renderer/src/layout/node.ts
@@ -33,8 +33,7 @@ export const LayoutFlexDirection = {
   Column: 'column',
   ColumnReverse: 'column-reverse',
 } as const
-export type LayoutFlexDirection =
-  (typeof LayoutFlexDirection)[keyof typeof LayoutFlexDirection]
+export type LayoutFlexDirection = (typeof LayoutFlexDirection)[keyof typeof LayoutFlexDirection]
 
 export const LayoutAlign = {
   Auto: 'auto',
@@ -66,16 +65,14 @@ export const LayoutPositionType = {
   Relative: 'relative',
   Absolute: 'absolute',
 } as const
-export type LayoutPositionType =
-  (typeof LayoutPositionType)[keyof typeof LayoutPositionType]
+export type LayoutPositionType = (typeof LayoutPositionType)[keyof typeof LayoutPositionType]
 
 export const LayoutOverflow = {
   Visible: 'visible',
   Hidden: 'hidden',
   Scroll: 'scroll',
 } as const
-export type LayoutOverflow =
-  (typeof LayoutOverflow)[keyof typeof LayoutOverflow]
+export type LayoutOverflow = (typeof LayoutOverflow)[keyof typeof LayoutOverflow]
 
 export type LayoutMeasureFunc = (
   width: number,
@@ -87,8 +84,7 @@ export const LayoutMeasureMode = {
   Exactly: 'exactly',
   AtMost: 'at-most',
 } as const
-export type LayoutMeasureMode =
-  (typeof LayoutMeasureMode)[keyof typeof LayoutMeasureMode]
+export type LayoutMeasureMode = (typeof LayoutMeasureMode)[keyof typeof LayoutMeasureMode]
 
 export type LayoutNode = {
   // Tree
@@ -150,4 +146,3 @@ export type LayoutNode = {
   free(): void
   freeRecursive(): void
 }
-

--- a/packages/renderer/src/layout/yoga.ts
+++ b/packages/renderer/src/layout/yoga.ts
@@ -245,15 +245,11 @@ export class YogaLayoutNode implements LayoutNode {
   }
 
   getDisplay(): LayoutDisplay {
-    return this.yoga.getDisplay() === Display.None
-      ? LayoutDisplay.None
-      : LayoutDisplay.Flex
+    return this.yoga.getDisplay() === Display.None ? LayoutDisplay.None : LayoutDisplay.Flex
   }
 
   setPositionType(type: LayoutPositionType): void {
-    this.yoga.setPositionType(
-      type === 'absolute' ? PositionType.Absolute : PositionType.Relative,
-    )
+    this.yoga.setPositionType(type === 'absolute' ? PositionType.Absolute : PositionType.Relative)
   }
 
   setPosition(edge: LayoutEdge, value: number): void {
@@ -306,4 +302,3 @@ export class YogaLayoutNode implements LayoutNode {
 export function createYogaLayoutNode(): LayoutNode {
   return new YogaLayoutNode(Yoga.Node.create())
 }
-

--- a/packages/renderer/src/line-width-cache.ts
+++ b/packages/renderer/src/line-width-cache.ts
@@ -22,4 +22,3 @@ export function lineWidth(line: string): number {
   cache.set(line, width)
   return width
 }
-

--- a/packages/renderer/src/lodash-replacements.ts
+++ b/packages/renderer/src/lodash-replacements.ts
@@ -110,7 +110,7 @@ export function throttle<T extends (...args: unknown[]) => unknown>(
     return result
   } as ThrottledFunction<T>
 
-  throttled.cancel = function (): void {
+  throttled.cancel = (): void => {
     if (timerId !== undefined) {
       clearTimeout(timerId)
     }
@@ -120,7 +120,7 @@ export function throttle<T extends (...args: unknown[]) => unknown>(
     timerId = undefined
   }
 
-  throttled.flush = function (): ReturnType<T> | undefined {
+  throttled.flush = (): ReturnType<T> | undefined => {
     if (timerId === undefined) {
       return result
     }

--- a/packages/renderer/src/lodash-replacements.ts
+++ b/packages/renderer/src/lodash-replacements.ts
@@ -4,7 +4,6 @@
  * (CVE code injection via _.template, prototype pollution via _.unset/_.omit).
  */
 
-// biome-ignore lint/suspicious/noEmptyBlockStatements: intentional no-op
 export function noop(): void {}
 
 export interface ThrottledFunction<T extends (...args: unknown[]) => unknown> {

--- a/packages/renderer/src/lodash-replacements.ts
+++ b/packages/renderer/src/lodash-replacements.ts
@@ -8,14 +8,14 @@
 export function noop(): void {}
 
 export interface ThrottledFunction<T extends (...args: unknown[]) => unknown> {
-  (...args: Parameters<T>): ReturnType<T> | undefined;
-  cancel(): void;
-  flush(): ReturnType<T> | undefined;
+  (...args: Parameters<T>): ReturnType<T> | undefined
+  cancel(): void
+  flush(): ReturnType<T> | undefined
 }
 
 interface ThrottleOptions {
-  leading?: boolean;
-  trailing?: boolean;
+  leading?: boolean
+  trailing?: boolean
 }
 
 /**
@@ -27,106 +27,106 @@ export function throttle<T extends (...args: unknown[]) => unknown>(
   wait: number,
   options: ThrottleOptions = {},
 ): ThrottledFunction<T> {
-  let timerId: ReturnType<typeof setTimeout> | undefined;
-  let lastCallTime: number | undefined;
-  let lastInvokeTime = 0;
-  let lastArgs: Parameters<T> | undefined;
-  let result: ReturnType<T> | undefined;
+  let timerId: ReturnType<typeof setTimeout> | undefined
+  let lastCallTime: number | undefined
+  let lastInvokeTime = 0
+  let lastArgs: Parameters<T> | undefined
+  let result: ReturnType<T> | undefined
 
-  const leading = options.leading !== false;
-  const trailing = options.trailing !== false;
+  const leading = options.leading !== false
+  const trailing = options.trailing !== false
 
   function invokeFunc(time: number): ReturnType<T> {
-    lastInvokeTime = time;
-    const args = lastArgs!;
-    lastArgs = undefined;
-    result = func(...args) as ReturnType<T>;
-    return result;
+    lastInvokeTime = time
+    const args = lastArgs!
+    lastArgs = undefined
+    result = func(...args) as ReturnType<T>
+    return result
   }
 
   function startTimer(pendingFunc: () => void, remainingWait: number): void {
-    timerId = setTimeout(pendingFunc, remainingWait);
+    timerId = setTimeout(pendingFunc, remainingWait)
   }
 
   function shouldInvoke(time: number): boolean {
-    const timeSinceLastCall = lastCallTime === undefined ? wait : time - lastCallTime;
-    const timeSinceLastInvoke = time - lastInvokeTime;
+    const timeSinceLastCall = lastCallTime === undefined ? wait : time - lastCallTime
+    const timeSinceLastInvoke = time - lastInvokeTime
 
     return (
       lastCallTime === undefined ||
       timeSinceLastCall >= wait ||
       timeSinceLastCall < 0 ||
       timeSinceLastInvoke >= wait
-    );
+    )
   }
 
   function remainingWait(time: number): number {
-    const timeSinceLastCall = time - (lastCallTime ?? 0);
-    return Math.max(0, wait - timeSinceLastCall);
+    const timeSinceLastCall = time - (lastCallTime ?? 0)
+    return Math.max(0, wait - timeSinceLastCall)
   }
 
   function timerExpired(): void {
-    const time = Date.now();
+    const time = Date.now()
     if (shouldInvoke(time)) {
-      trailingEdge(time);
-      return;
+      trailingEdge(time)
+      return
     }
-    startTimer(timerExpired, remainingWait(time));
+    startTimer(timerExpired, remainingWait(time))
   }
 
   function trailingEdge(time: number): void {
-    timerId = undefined;
+    timerId = undefined
     if (trailing && lastArgs) {
-      invokeFunc(time);
+      invokeFunc(time)
     }
-    lastArgs = undefined;
+    lastArgs = undefined
   }
 
   function leadingEdge(time: number): void {
-    lastInvokeTime = time;
-    startTimer(timerExpired, wait);
+    lastInvokeTime = time
+    startTimer(timerExpired, wait)
     if (leading) {
-      invokeFunc(time);
+      invokeFunc(time)
     }
   }
 
   const throttled = function (this: unknown, ...args: Parameters<T>): ReturnType<T> | undefined {
-    const time = Date.now();
-    const isInvoking = shouldInvoke(time);
+    const time = Date.now()
+    const isInvoking = shouldInvoke(time)
 
-    lastArgs = args;
-    lastCallTime = time;
+    lastArgs = args
+    lastCallTime = time
 
     if (isInvoking) {
       if (timerId === undefined) {
-        leadingEdge(time);
-        return result;
+        leadingEdge(time)
+        return result
       }
       // Handle rapid calls during wait period (maxWait behavior)
     }
     if (timerId === undefined) {
-      startTimer(timerExpired, wait);
+      startTimer(timerExpired, wait)
     }
-    return result;
-  } as ThrottledFunction<T>;
+    return result
+  } as ThrottledFunction<T>
 
   throttled.cancel = function (): void {
     if (timerId !== undefined) {
-      clearTimeout(timerId);
+      clearTimeout(timerId)
     }
-    lastInvokeTime = 0;
-    lastArgs = undefined;
-    lastCallTime = undefined;
-    timerId = undefined;
-  };
+    lastInvokeTime = 0
+    lastArgs = undefined
+    lastCallTime = undefined
+    timerId = undefined
+  }
 
   throttled.flush = function (): ReturnType<T> | undefined {
     if (timerId === undefined) {
-      return result;
+      return result
     }
-    trailingEdge(Date.now());
-    return result;
-  };
+    trailingEdge(Date.now())
+    return result
+  }
 
-  return throttled;
+  return throttled
 }

--- a/packages/renderer/src/log-update.ts
+++ b/packages/renderer/src/log-update.ts
@@ -5,21 +5,21 @@ import type { Point } from './layout/geometry'
 import {
   type Cell,
   CellWidth,
+  type Hyperlink,
+  type Screen,
+  type StylePool,
   cellAt,
   charInCellAt,
   diffEach,
-  type Hyperlink,
   isEmptyCellAt,
-  type Screen,
-  type StylePool,
   shiftRows,
   visibleCellAtIndex,
 } from './screen'
 import {
   CURSOR_HOME,
+  RESET_SCROLL_REGION,
   scrollDown as csiScrollDown,
   scrollUp as csiScrollUp,
-  RESET_SCROLL_REGION,
   setScrollRegion,
 } from './termio/csi'
 import { LINK_END, link as oscLink } from './termio/osc'

--- a/packages/renderer/src/log-update.ts
+++ b/packages/renderer/src/log-update.ts
@@ -1,8 +1,4 @@
-import {
-  type AnsiCode,
-  ansiCodesToString,
-  diffAnsiCodes,
-} from '@alcalzone/ansi-tokenize'
+import { type AnsiCode, ansiCodesToString, diffAnsiCodes } from '@alcalzone/ansi-tokenize'
 import { logForDebugging } from '@yokai/shared'
 import type { Diff, FlickerReason, Frame } from './frame'
 import type { Point } from './layout/geometry'
@@ -120,12 +116,7 @@ export class LogUpdate {
     return []
   }
 
-  render(
-    prev: Frame,
-    next: Frame,
-    altScreen = false,
-    decstbmSafe = true,
-  ): Diff {
+  render(prev: Frame, next: Frame, altScreen = false, decstbmSafe = true): Diff {
     if (!this.options.isTTY) {
       return this.renderFullFrame(next)
     }
@@ -165,11 +156,7 @@ export class LogUpdate {
     let scrollPatch: Diff = []
     if (altScreen && next.scrollHint && decstbmSafe) {
       const { top, bottom, delta } = next.scrollHint
-      if (
-        top >= 0 &&
-        bottom < prev.screen.height &&
-        bottom < next.screen.height
-      ) {
+      if (top >= 0 && bottom < prev.screen.height && bottom < next.screen.height) {
         shiftRows(prev.screen, top, bottom, delta)
         scrollPatch = [
           {
@@ -201,8 +188,7 @@ export class LogUpdate {
     // When content fills the viewport exactly (height == viewport) and the
     // cursor is at the bottom, the cursor-restore LF at the end of the
     // previous frame scrolled 1 row into scrollback. Use >= to catch this.
-    const prevHadScrollback =
-      cursorAtBottom && prev.screen.height >= prev.viewport.height
+    const prevHadScrollback = cursorAtBottom && prev.screen.height >= prev.viewport.height
     const isShrinking = next.screen.height < prev.screen.height
     const nextFitsViewport = next.screen.height <= prev.viewport.height
 
@@ -250,8 +236,7 @@ export class LogUpdate {
     const screen = new VirtualScreen(prev.cursor, next.viewport.width)
 
     // Treat empty screen as height 1 to avoid spurious adjustments on first render
-    const heightDelta =
-      Math.max(next.screen.height, 1) - Math.max(prev.screen.height, 1)
+    const heightDelta = Math.max(next.screen.height, 1) - Math.max(prev.screen.height, 1)
     const shrinking = heightDelta < 0
     const growing = heightDelta > 0
 
@@ -263,17 +248,13 @@ export class LogUpdate {
       // If we need to clear more lines than fit in the viewport, some are in
       // scrollback, so we need a full reset.
       if (linesToClear > prev.viewport.height) {
-        return fullResetSequence_CAUSES_FLICKER(
-          next,
-          'offscreen',
-          this.options.stylePool,
-        )
+        return fullResetSequence_CAUSES_FLICKER(next, 'offscreen', this.options.stylePool)
       }
 
       // clear(N) moves cursor UP by N-1 lines and to column 0
       // This puts us at line prev.screen.height - N = next.screen.height
       // But we want to be at next.screen.height - 1 (bottom of new screen)
-      screen.txn(prev => [
+      screen.txn((prev) => [
         [
           { type: 'clear', count: linesToClear },
           { type: 'cursorMove', x: 0, y: -1 },
@@ -291,10 +272,7 @@ export class LogUpdate {
     // at viewport top, causing writes to land 1 row off and garbling the output.
     const cursorRestoreScroll = prevHadScrollback ? 1 : 0
     const viewportY = growing
-      ? Math.max(
-          0,
-          prev.screen.height - prev.viewport.height + cursorRestoreScroll,
-        )
+      ? Math.max(0, prev.screen.height - prev.viewport.height + cursorRestoreScroll)
       : Math.max(prev.screen.height, next.screen.height) -
         next.viewport.height +
         cursorRestoreScroll
@@ -315,18 +293,13 @@ export class LogUpdate {
       // advance 2 columns when we write the wide character itself.
       // SpacerTail: Second cell of a wide character
       // SpacerHead: Marks line-end position where wide char wraps to next line
-      if (
-        added &&
-        (added.width === CellWidth.SpacerTail ||
-          added.width === CellWidth.SpacerHead)
-      ) {
+      if (added && (added.width === CellWidth.SpacerTail || added.width === CellWidth.SpacerHead)) {
         return
       }
 
       if (
         removed &&
-        (removed.width === CellWidth.SpacerTail ||
-          removed.width === CellWidth.SpacerHead) &&
+        (removed.width === CellWidth.SpacerTail || removed.width === CellWidth.SpacerHead) &&
         !added
       ) {
         return
@@ -352,11 +325,7 @@ export class LogUpdate {
 
       if (added) {
         const targetHyperlink = added.hyperlink
-        currentHyperlink = transitionHyperlink(
-          screen.diff,
-          currentHyperlink,
-          targetHyperlink,
-        )
+        currentHyperlink = transitionHyperlink(screen.diff, currentHyperlink, targetHyperlink)
         const styleStr = stylePool.transition(currentStyleId, added.styleId)
         if (writeCellWithStyleStr(screen, added, styleStr)) {
           currentStyleId = added.styleId
@@ -388,27 +357,12 @@ export class LogUpdate {
     }
 
     // Reset styles before rendering new rows (they'll set their own styles)
-    currentStyleId = transitionStyle(
-      screen.diff,
-      stylePool,
-      currentStyleId,
-      stylePool.none,
-    )
-    currentHyperlink = transitionHyperlink(
-      screen.diff,
-      currentHyperlink,
-      undefined,
-    )
+    currentStyleId = transitionStyle(screen.diff, stylePool, currentStyleId, stylePool.none)
+    currentHyperlink = transitionHyperlink(screen.diff, currentHyperlink, undefined)
 
     // Handle growth: render new rows directly (they naturally scroll the terminal)
     if (growing) {
-      renderFrameSlice(
-        screen,
-        next,
-        prev.screen.height,
-        next.screen.height,
-        stylePool,
-      )
+      renderFrameSlice(screen, next, prev.screen.height, next.screen.height, stylePool)
     }
 
     // Restore cursor. Skipped in alt-screen: the cursor is hidden, its
@@ -424,7 +378,7 @@ export class LogUpdate {
       // no-op; next frame's CSI H anchors cursor
     } else if (next.cursor.y >= next.screen.height) {
       // Move to column 0 of current line, then emit newlines to reach target row
-      screen.txn(prev => {
+      screen.txn((prev) => {
         const rowsToCreate = next.cursor.y - prev.y
         if (rowsToCreate > 0) {
           // Use CR to resolve pending wrap (if any) without advancing
@@ -461,17 +415,11 @@ export class LogUpdate {
       )
     }
 
-    return scrollPatch.length > 0
-      ? [...scrollPatch, ...screen.diff]
-      : screen.diff
+    return scrollPatch.length > 0 ? [...scrollPatch, ...screen.diff] : screen.diff
   }
 }
 
-function transitionHyperlink(
-  diff: Diff,
-  current: Hyperlink,
-  target: Hyperlink,
-): Hyperlink {
+function transitionHyperlink(diff: Diff, current: Hyperlink, target: Hyperlink): Hyperlink {
   if (current !== target) {
     diff.push({ type: 'hyperlink', uri: target ?? '' })
     return target
@@ -512,11 +460,7 @@ function fullResetSequence_CAUSES_FLICKER(
   return [{ type: 'clearTerminal', reason, debug }, ...screen.diff]
 }
 
-function renderFrame(
-  screen: VirtualScreen,
-  frame: Frame,
-  stylePool: StylePool,
-): void {
+function renderFrame(screen: VirtualScreen, frame: Frame, stylePool: StylePool): void {
   renderFrameSlice(screen, frame, 0, frame.screen.height, stylePool)
 }
 
@@ -549,7 +493,7 @@ function renderFrameSlice(
     // between the virtual cursor and the real terminal cursor.
     if (screen.cursor.y < y) {
       const rowsToAdvance = y - screen.cursor.y
-      screen.txn(prev => {
+      screen.txn((prev) => {
         const patches: Diff = new Array<Diff[number]>(1 + rowsToAdvance)
         patches[0] = CARRIAGE_RETURN
         for (let i = 0; i < rowsToAdvance; i++) {
@@ -566,13 +510,7 @@ function renderFrameSlice(
       // match the last rendered style (since cursor-forward produces identical
       // visual result). visibleCellAtIndex handles the optimization internally
       // to avoid allocating Cell objects for skipped cells.
-      const cell = visibleCellAtIndex(
-        cells,
-        charPool,
-        hyperlinkPool,
-        index,
-        lastRenderedStyleId,
-      )
+      const cell = visibleCellAtIndex(cells, charPool, hyperlinkPool, index, lastRenderedStyleId)
       if (!cell) {
         continue
       }
@@ -581,11 +519,7 @@ function renderFrameSlice(
 
       // Handle hyperlink
       const targetHyperlink = cell.hyperlink
-      currentHyperlink = transitionHyperlink(
-        screen.diff,
-        currentHyperlink,
-        targetHyperlink,
-      )
+      currentHyperlink = transitionHyperlink(screen.diff, currentHyperlink, targetHyperlink)
 
       // Style transition — cached string, zero allocations after warmup
       const styleStr = stylePool.transition(currentStyleId, cell.styleId)
@@ -598,21 +532,12 @@ function renderFrameSlice(
     // bleed into the next line when the terminal scrolls. The old code
     // reset implicitly by writing trailing unstyled spaces; now that we
     // skip empty cells, we must reset explicitly.
-    currentStyleId = transitionStyle(
-      screen.diff,
-      stylePool,
-      currentStyleId,
-      stylePool.none,
-    )
-    currentHyperlink = transitionHyperlink(
-      screen.diff,
-      currentHyperlink,
-      undefined,
-    )
+    currentStyleId = transitionStyle(screen.diff, stylePool, currentStyleId, stylePool.none)
+    currentHyperlink = transitionHyperlink(screen.diff, currentHyperlink, undefined)
     // CR+LF at end of row — \r resets to column 0, \n moves to next line.
     // Without \r, the terminal cursor stays at whatever column content ended
     // (since we skip trailing spaces, this can be mid-row).
-    screen.txn(prev => [[CARRIAGE_RETURN, NEWLINE], { dx: -prev.x, dy: 1 }])
+    screen.txn((prev) => [[CARRIAGE_RETURN, NEWLINE], { dx: -prev.x, dy: 1 }])
   }
 
   // Reset any open style/hyperlink at end of slice
@@ -635,11 +560,7 @@ type Delta = { dx: number; dy: number }
  * unchanged. Updating the virtual tracker anyway desyncs it from the
  * terminal, and the next transition is computed from phantom state.
  */
-function writeCellWithStyleStr(
-  screen: VirtualScreen,
-  cell: Cell,
-  styleStr: string,
-): boolean {
+function writeCellWithStyleStr(screen: VirtualScreen, cell: Cell, styleStr: string): boolean {
   const cellWidth = cell.width === CellWidth.Wide ? 2 : 1
   const px = screen.cursor.x
   const vw = screen.viewportWidth
@@ -691,7 +612,7 @@ function writeCellWithStyleStr(
 }
 
 function moveCursorTo(screen: VirtualScreen, targetX: number, targetY: number) {
-  screen.txn(prev => {
+  screen.txn((prev) => {
     const dx = targetX - prev.x
     const dy = targetY - prev.y
     const inPendingWrap = prev.x >= screen.viewportWidth
@@ -700,19 +621,13 @@ function moveCursorTo(screen: VirtualScreen, targetX: number, targetY: number) {
     // to reset to column 0 on the current line without advancing
     // to the next line, then issue the cursor movement.
     if (inPendingWrap) {
-      return [
-        [CARRIAGE_RETURN, { type: 'cursorMove', x: targetX, y: dy }],
-        { dx, dy },
-      ]
+      return [[CARRIAGE_RETURN, { type: 'cursorMove', x: targetX, y: dy }], { dx, dy }]
     }
 
     // When moving to a different line, use carriage return (\r) to reset to
     // column 0 first, then cursor move.
     if (dy !== 0) {
-      return [
-        [CARRIAGE_RETURN, { type: 'cursorMove', x: targetX, y: dy }],
-        { dx, dy },
-      ]
+      return [[CARRIAGE_RETURN, { type: 'cursorMove', x: targetX, y: dy }], { dx, dy }]
     }
 
     // Standard same-line cursor move
@@ -771,4 +686,3 @@ class VirtualScreen {
     this.cursor.y += next.dy
   }
 }
-

--- a/packages/renderer/src/measure-element.ts
+++ b/packages/renderer/src/measure-element.ts
@@ -21,4 +21,3 @@ const measureElement = (node: DOMElement): Output => ({
 })
 
 export default measureElement
-

--- a/packages/renderer/src/measure-text.ts
+++ b/packages/renderer/src/measure-text.ts
@@ -45,4 +45,3 @@ function measureText(text: string, maxWidth: number): Output {
 }
 
 export default measureText
-

--- a/packages/renderer/src/node-cache.ts
+++ b/packages/renderer/src/node-cache.ts
@@ -31,11 +31,7 @@ export const pendingClears = new WeakMap<DOMElement, Rectangle[]>()
  */
 let absoluteNodeRemoved = false
 
-export function addPendingClear(
-  parent: DOMElement,
-  rect: Rectangle,
-  isAbsolute: boolean,
-): void {
+export function addPendingClear(parent: DOMElement, rect: Rectangle, isAbsolute: boolean): void {
   const existing = pendingClears.get(parent)
   if (existing) {
     existing.push(rect)
@@ -52,4 +48,3 @@ export function consumeAbsoluteRemovedFlag(): boolean {
   absoluteNodeRemoved = false
   return had
 }
-

--- a/packages/renderer/src/optimizer.ts
+++ b/packages/renderer/src/optimizer.ts
@@ -66,11 +66,7 @@ export function optimize(diff: Diff): Diff {
       }
 
       // Dedupe hyperlinks
-      if (
-        type === 'hyperlink' &&
-        lastType === 'hyperlink' &&
-        patch.uri === last.uri
-      ) {
+      if (type === 'hyperlink' && lastType === 'hyperlink' && patch.uri === last.uri) {
         continue
       }
 
@@ -91,4 +87,3 @@ export function optimize(diff: Diff): Diff {
 
   return result
 }
-

--- a/packages/renderer/src/output.ts
+++ b/packages/renderer/src/output.ts
@@ -109,19 +109,13 @@ function intersectClip(parent: Clip | undefined, child: Clip): Clip {
   }
 }
 
-function maxDefined(
-  a: number | undefined,
-  b: number | undefined,
-): number | undefined {
+function maxDefined(a: number | undefined, b: number | undefined): number | undefined {
   if (a === undefined) return b
   if (b === undefined) return a
   return Math.max(a, b)
 }
 
-function minDefined(
-  a: number | undefined,
-  b: number | undefined,
-): number | undefined {
+function minDefined(a: number | undefined, b: number | undefined): number | undefined {
   if (a === undefined) return b
   if (b === undefined) return a
   return Math.min(a, b)
@@ -350,12 +344,7 @@ export default class Output {
             src.height,
             clip?.y2 ?? Infinity,
           )
-          const maxX = Math.min(
-            regionX + regionWidth,
-            screenWidth,
-            src.width,
-            clip?.x2 ?? Infinity,
-          )
+          const maxX = Math.min(regionX + regionWidth, screenWidth, src.width, clip?.x2 ?? Infinity)
           if (startX >= maxX || startY >= maxY) continue
           // Skip rows covered by an absolute-positioned node's clear.
           // Absolute nodes overlay normal-flow siblings, so prevScreen in
@@ -371,11 +360,7 @@ export default class Output {
             const excluded =
               row < maxY &&
               absoluteClears.some(
-                r =>
-                  row >= r.y &&
-                  row < r.y + r.height &&
-                  startX >= r.x &&
-                  maxX <= r.x + r.width,
+                (r) => row >= r.y && row < r.y + r.height && startX >= r.x && maxX <= r.x + r.width,
               )
             if (excluded || row === maxY) {
               if (row > rowStart) {
@@ -403,11 +388,9 @@ export default class Output {
           const clip = getCurrentClip()
 
           if (clip) {
-            const clipHorizontally =
-              typeof clip?.x1 === 'number' && typeof clip?.x2 === 'number'
+            const clipHorizontally = typeof clip?.x1 === 'number' && typeof clip?.x2 === 'number'
 
-            const clipVertically =
-              typeof clip?.y1 === 'number' && typeof clip?.y2 === 'number'
+            const clipVertically = typeof clip?.y1 === 'number' && typeof clip?.y2 === 'number'
 
             // If text is positioned outside of clipping area altogether,
             // skip to the next operation to avoid unnecessary calculations
@@ -428,7 +411,7 @@ export default class Output {
             }
 
             if (clipHorizontally) {
-              lines = lines.map(line => {
+              lines = lines.map((line) => {
                 const from = x < clip.x1! ? clip.x1! - x : 0
                 const width = stringWidth(line)
                 const to = x + width > clip.x2! ? clip.x2! - x : width
@@ -599,13 +582,8 @@ function flushBuffer(
   const hyperlink = extractHyperlinkFromStyles(styles) ?? undefined
   const hasOsc8Styles =
     hyperlink !== undefined ||
-    styles.some(
-      s =>
-        s.code.length >= OSC8_PREFIX.length && s.code.startsWith(OSC8_PREFIX),
-    )
-  const filteredStyles = hasOsc8Styles
-    ? filterOutHyperlinkStyles(styles)
-    : styles
+    styles.some((s) => s.code.length >= OSC8_PREFIX.length && s.code.startsWith(OSC8_PREFIX))
+  const filteredStyles = hasOsc8Styles ? filterOutHyperlinkStyles(styles) : styles
   const styleId = stylePool.intern(filteredStyles)
 
   for (const { segment: grapheme } of getGraphemeSegmenter().segment(buffer)) {
@@ -641,10 +619,7 @@ function writeLineToScreen(
   let characters = charCache.get(line)
   if (!characters) {
     characters = reorderBidi(
-      styledCharsWithGraphemeClustering(
-        styledCharsFromTokens(tokenize(line)),
-        stylePool,
-      ),
+      styledCharsWithGraphemeClustering(styledCharsFromTokens(tokenize(line)), stylePool),
     )
     charCache.set(line, characters)
   }
@@ -681,12 +656,7 @@ function writeLineToScreen(
       else if (codePoint === 0x1b) {
         const nextChar = characters[charIdx + 1]?.value
         const nextCode = nextChar?.codePointAt(0)
-        if (
-          nextChar === '(' ||
-          nextChar === ')' ||
-          nextChar === '*' ||
-          nextChar === '+'
-        ) {
+        if (nextChar === '(' || nextChar === ')' || nextChar === '*' || nextChar === '+') {
           // Charset selection: ESC ( X, ESC ) X, etc.
           // Skip the intermediate char and the charset designator
           charIdx += 2
@@ -734,11 +704,7 @@ function writeLineToScreen(
               }
             }
           }
-        } else if (
-          nextCode !== undefined &&
-          nextCode >= 0x30 &&
-          nextCode <= 0x7e
-        ) {
+        } else if (nextCode !== undefined && nextCode >= 0x30 && nextCode <= 0x7e) {
           // Single-character escape sequences: ESC followed by 0x30-0x7E
           // (excluding the multi-char introducers already handled above)
           // - Fp range (0x30-0x3F): ESC 7 (save cursor), ESC 8 (restore)

--- a/packages/renderer/src/output.ts
+++ b/packages/renderer/src/output.ts
@@ -4,19 +4,19 @@ import {
   styledCharsFromTokens,
   tokenize,
 } from '@alcalzone/ansi-tokenize'
-import { logForDebugging, getGraphemeSegmenter, sliceAnsi } from '@yokai/shared'
+import { getGraphemeSegmenter, logForDebugging, sliceAnsi } from '@yokai/shared'
 import { reorderBidi } from './bidi'
 import { type Rectangle, unionRect } from './layout/geometry'
 import {
-  blitRegion,
   CellWidth,
+  OSC8_PREFIX,
+  type Screen,
+  type StylePool,
+  blitRegion,
   extractHyperlinkFromStyles,
   filterOutHyperlinkStyles,
   markNoSelectRegion,
-  OSC8_PREFIX,
   resetScreen,
-  type Screen,
-  type StylePool,
   setCellAt,
   shiftRows,
 } from './screen'
@@ -342,9 +342,14 @@ export default class Output {
             regionY + regionHeight,
             screenHeight,
             src.height,
-            clip?.y2 ?? Infinity,
+            clip?.y2 ?? Number.POSITIVE_INFINITY,
           )
-          const maxX = Math.min(regionX + regionWidth, screenWidth, src.width, clip?.x2 ?? Infinity)
+          const maxX = Math.min(
+            regionX + regionWidth,
+            screenWidth,
+            src.width,
+            clip?.x2 ?? Number.POSITIVE_INFINITY,
+          )
           if (startX >= maxX || startY >= maxY) continue
           // Skip rows covered by an absolute-positioned node's clear.
           // Absolute nodes overlay normal-flow siblings, so prevScreen in

--- a/packages/renderer/src/parse-keypress.ts
+++ b/packages/renderer/src/parse-keypress.ts
@@ -6,7 +6,7 @@
  */
 import { Buffer } from 'buffer'
 import { PASTE_END, PASTE_START } from './termio/csi'
-import { createTokenizer, type Tokenizer } from './termio/tokenize'
+import { type Tokenizer, createTokenizer } from './termio/tokenize'
 
 // eslint-disable-next-line no-control-regex
 const META_KEY_CODE_RE = /^(?:\x1b)([a-zA-Z0-9])$/
@@ -127,8 +127,8 @@ function parseTerminalResponse(s: string): TerminalResponse | null {
     if ((m = DECRPM_RE.exec(s))) {
       return {
         type: 'decrpm',
-        mode: parseInt(m[1]!, 10),
-        status: parseInt(m[2]!, 10),
+        mode: Number.parseInt(m[1]!, 10),
+        status: Number.parseInt(m[2]!, 10),
       }
     }
 
@@ -141,14 +141,14 @@ function parseTerminalResponse(s: string): TerminalResponse | null {
     }
 
     if ((m = KITTY_FLAGS_RE.exec(s))) {
-      return { type: 'kittyKeyboard', flags: parseInt(m[1]!, 10) }
+      return { type: 'kittyKeyboard', flags: Number.parseInt(m[1]!, 10) }
     }
 
     if ((m = CURSOR_POSITION_RE.exec(s))) {
       return {
         type: 'cursorPosition',
-        row: parseInt(m[1]!, 10),
-        col: parseInt(m[2]!, 10),
+        row: Number.parseInt(m[1]!, 10),
+        col: Number.parseInt(m[2]!, 10),
       }
     }
 
@@ -159,7 +159,7 @@ function parseTerminalResponse(s: string): TerminalResponse | null {
   if (s.startsWith('\x1b]')) {
     const m = OSC_RESPONSE_RE.exec(s)
     if (m) {
-      return { type: 'osc', code: parseInt(m[1]!, 10), data: m[2]! }
+      return { type: 'osc', code: Number.parseInt(m[1]!, 10), data: m[2]! }
     }
   }
 
@@ -176,7 +176,7 @@ function parseTerminalResponse(s: string): TerminalResponse | null {
 
 function splitNumericParams(params: string): number[] {
   if (!params) return []
-  return params.split(';').map((p) => parseInt(p, 10))
+  return params.split(';').map((p) => Number.parseInt(p, 10))
 }
 
 export type KeyParseState = {
@@ -571,7 +571,7 @@ export type ParsedInput = ParsedKey | ParsedMouse | ParsedResponse
 function parseMouseEvent(s: string): ParsedMouse | null {
   const match = SGR_MOUSE_RE.exec(s)
   if (!match) return null
-  const button = parseInt(match[1]!, 10)
+  const button = Number.parseInt(match[1]!, 10)
   // Wheel events (bit 6 set, low bits 0/1 for up/down) stay as ParsedKey
   // so the keybinding system can route them to scroll handlers.
   if ((button & 0x40) !== 0) return null
@@ -579,13 +579,13 @@ function parseMouseEvent(s: string): ParsedMouse | null {
     kind: 'mouse',
     button,
     action: match[4] === 'M' ? 'press' : 'release',
-    col: parseInt(match[2]!, 10),
-    row: parseInt(match[3]!, 10),
+    col: Number.parseInt(match[2]!, 10),
+    row: Number.parseInt(match[3]!, 10),
     sequence: s,
   }
 }
 
-function parseKeypress(s: string = ''): ParsedKey {
+function parseKeypress(s = ''): ParsedKey {
   let parts
 
   const key: ParsedKey = {
@@ -608,9 +608,9 @@ function parseKeypress(s: string = ''): ParsedKey {
   // Example: ESC[13;2u = Shift+Enter, ESC[27u = Escape (no modifiers)
   let match: RegExpExecArray | null
   if ((match = CSI_U_RE.exec(s))) {
-    const codepoint = parseInt(match[1]!, 10)
+    const codepoint = Number.parseInt(match[1]!, 10)
     // Modifier defaults to 1 (no modifiers) when not present
-    const modifier = match[2] ? parseInt(match[2], 10) : 1
+    const modifier = match[2] ? Number.parseInt(match[2], 10) : 1
     const mods = decodeModifier(modifier)
     const name = keycodeToName(codepoint)
     return {
@@ -632,8 +632,8 @@ function parseKeypress(s: string = ''): ParsedKey {
   // Must run before FN_KEY_RE — FN_KEY_RE only allows 2 params before ~ and
   // would leave the tail as garbage if it partially matched.
   if ((match = MODIFY_OTHER_KEYS_RE.exec(s))) {
-    const mods = decodeModifier(parseInt(match[1]!, 10))
-    const name = keycodeToName(parseInt(match[2]!, 10))
+    const mods = decodeModifier(Number.parseInt(match[1]!, 10))
+    const name = keycodeToName(Number.parseInt(match[2]!, 10))
     return {
       kind: 'key',
       name,
@@ -656,7 +656,7 @@ function parseKeypress(s: string = ''): ParsedKey {
   // Ctrl=0x10) — modified wheel events (e.g. Ctrl+scroll, button=80)
   // should still be recognized as wheelup/wheeldown.
   if ((match = SGR_MOUSE_RE.exec(s))) {
-    const button = parseInt(match[1]!, 10)
+    const button = Number.parseInt(match[1]!, 10)
     if ((button & 0x43) === 0x40) return createNavKey(s, 'wheelup', false)
     if ((button & 0x43) === 0x41) return createNavKey(s, 'wheeldown', false)
     // Shouldn't reach here (parseMouseEvent catches non-wheel) but be safe

--- a/packages/renderer/src/parse-keypress.ts
+++ b/packages/renderer/src/parse-keypress.ts
@@ -586,7 +586,7 @@ function parseMouseEvent(s: string): ParsedMouse | null {
 }
 
 function parseKeypress(s = ''): ParsedKey {
-  let parts
+  let parts: RegExpExecArray | null
 
   const key: ParsedKey = {
     kind: 'key',

--- a/packages/renderer/src/parse-keypress.ts
+++ b/packages/renderer/src/parse-keypress.ts
@@ -4,7 +4,7 @@
  * Uses the termio tokenizer for escape sequence boundary detection,
  * then interprets sequences as keypresses.
  */
-import { Buffer } from 'buffer'
+import { Buffer } from 'node:buffer'
 import { PASTE_END, PASTE_START } from './termio/csi'
 import { type Tokenizer, createTokenizer } from './termio/tokenize'
 
@@ -197,17 +197,17 @@ function inputToString(input: Buffer | string): string {
   if (Buffer.isBuffer(input)) {
     if (input[0]! > 127 && input[1] === undefined) {
       ;(input[0] as unknown as number) -= 128
-      return '\x1b' + String(input)
-    } else {
-      return String(input)
+      return `\x1b${String(input)}`
     }
-  } else if (input !== undefined && typeof input !== 'string') {
     return String(input)
-  } else if (!input) {
-    return ''
-  } else {
-    return input
   }
+  if (input !== undefined && typeof input !== 'string') {
+    return String(input)
+  }
+  if (!input) {
+    return ''
+  }
+  return input
 }
 
 export function parseMultipleKeypresses(
@@ -274,7 +274,7 @@ export function parseMultipleKeypresses(
         // range would match typed input like `[MAX]` batched into one read
         // and silently drop it as a phantom click. Click/drag orphans leak
         // as visible garbage instead; deletable garbage beats silent loss.
-        const resynthesized = '\x1b' + token.value
+        const resynthesized = `\x1b${token.value}`
         const mouse = parseMouseEvent(resynthesized)
         keys.push(mouse ?? parseKeypress(resynthesized))
       } else {

--- a/packages/renderer/src/parse-keypress.ts
+++ b/packages/renderer/src/parse-keypress.ts
@@ -176,7 +176,7 @@ function parseTerminalResponse(s: string): TerminalResponse | null {
 
 function splitNumericParams(params: string): number[] {
   if (!params) return []
-  return params.split(';').map(p => parseInt(p, 10))
+  return params.split(';').map((p) => parseInt(p, 10))
 }
 
 export type KeyParseState = {
@@ -408,7 +408,7 @@ const keyName: Record<string, string> = {
 export const nonAlphanumericKeys = [
   // Filter out single-character values (digits, operators from numpad) since
   // those are printable characters that should produce input
-  ...Object.values(keyName).filter(v => v.length > 1),
+  ...Object.values(keyName).filter((v) => v.length > 1),
   // escape and backspace are assigned directly in parseKeypress (not via the
   // keyName map), so the spread above misses them. Without these, ctrl+escape
   // via Kitty/modifyOtherKeys leaks the literal word "escape" as input text
@@ -421,36 +421,13 @@ export const nonAlphanumericKeys = [
 ]
 
 const isShiftKey = (code: string): boolean => {
-  return [
-    '[a',
-    '[b',
-    '[c',
-    '[d',
-    '[e',
-    '[2$',
-    '[3$',
-    '[5$',
-    '[6$',
-    '[7$',
-    '[8$',
-    '[Z',
-  ].includes(code)
+  return ['[a', '[b', '[c', '[d', '[e', '[2$', '[3$', '[5$', '[6$', '[7$', '[8$', '[Z'].includes(
+    code,
+  )
 }
 
 const isCtrlKey = (code: string): boolean => {
-  return [
-    'Oa',
-    'Ob',
-    'Oc',
-    'Od',
-    'Oe',
-    '[2^',
-    '[3^',
-    '[5^',
-    '[6^',
-    '[7^',
-    '[8^',
-  ].includes(code)
+  return ['Oa', 'Ob', 'Oc', 'Od', 'Oe', '[2^', '[3^', '[5^', '[6^', '[7^', '[8^'].includes(code)
 }
 
 /**
@@ -740,9 +717,7 @@ function parseKeypress(s: string = ''): ParsedKey {
       key.option = true
     }
 
-    const code = [parts[1], parts[2], parts[4], parts[6]]
-      .filter(Boolean)
-      .join('')
+    const code = [parts[1], parts[2], parts[4], parts[6]].filter(Boolean).join('')
 
     const modifier = ((parts[3] || parts[5] || 1) as number) - 1
 
@@ -799,4 +774,3 @@ function createNavKey(s: string, name: string, ctrl: boolean): ParsedKey {
     isPasted: false,
   }
 }
-

--- a/packages/renderer/src/reconciler.ts
+++ b/packages/renderer/src/reconciler.ts
@@ -46,9 +46,7 @@ const diff = (before: AnyObject, after: AnyObject): AnyObject | undefined => {
   let isChanged = false
 
   for (const key of Object.keys(before)) {
-    const isDeleted = after
-      ? !Object.prototype.hasOwnProperty.call(after, key)
-      : true
+    const isDeleted = after ? !Object.prototype.hasOwnProperty.call(after, key) : true
 
     if (isDeleted) {
       changed[key] = undefined
@@ -282,20 +280,13 @@ const reconciler = createReconciler<
       const renderMs = performance.now() - _tr
       if (renderMs > 10) {
         // eslint-disable-next-line custom-rules/no-sync-fs -- debug instrumentation
-        appendFileSync(
-          COMMIT_LOG,
-          `${_tr.toFixed(1)} SLOW_PAINT ${renderMs.toFixed(1)}ms\n`,
-        )
+        appendFileSync(COMMIT_LOG, `${_tr.toFixed(1)} SLOW_PAINT ${renderMs.toFixed(1)}ms\n`)
       }
     }
   },
-  getChildHostContext(
-    parentHostContext: HostContext,
-    type: ElementNames,
-  ): HostContext {
+  getChildHostContext(parentHostContext: HostContext, type: ElementNames): HostContext {
     const previousIsInsideText = parentHostContext.isInsideText
-    const isInsideText =
-      type === 'ink-text' || type === 'ink-virtual-text' || type === 'ink-link'
+    const isInsideText = type === 'ink-text' || type === 'ink-virtual-text' || type === 'ink-link'
 
     if (previousIsInsideText === isInsideText) {
       return parentHostContext
@@ -316,9 +307,7 @@ const reconciler = createReconciler<
     }
 
     const type =
-      originalType === 'ink-text' && hostContext.isInsideText
-        ? 'ink-virtual-text'
-        : originalType
+      originalType === 'ink-text' && hostContext.isInsideText ? 'ink-virtual-text' : originalType
 
     const node = createNode(type)
     if (COMMIT_LOG) _createCount++
@@ -333,15 +322,9 @@ const reconciler = createReconciler<
 
     return node
   },
-  createTextInstance(
-    text: string,
-    _root: DOMElement,
-    hostContext: HostContext,
-  ): TextNode {
+  createTextInstance(text: string, _root: DOMElement, hostContext: HostContext): TextNode {
     if (!hostContext.isInsideText) {
-      throw new Error(
-        `Text string "${text}" must be rendered inside <Text> component`,
-      )
+      throw new Error(`Text string "${text}" must be rendered inside <Text> component`)
     }
 
     return createTextNode(text)
@@ -367,11 +350,7 @@ const reconciler = createReconciler<
   appendInitialChild: appendChildNode,
   appendChild: appendChildNode,
   insertBefore: insertBeforeNode,
-  finalizeInitialChildren(
-    _node: DOMElement,
-    _type: ElementNames,
-    props: Props,
-  ): boolean {
+  finalizeInitialChildren(_node: DOMElement, _type: ElementNames, props: Props): boolean {
     return props['autoFocus'] === true
   },
   commitMount(node: DOMElement): void {
@@ -399,12 +378,7 @@ const reconciler = createReconciler<
     getFocusManager(node).handleNodeRemoved(removeNode, node)
   },
   // React 19 commitUpdate receives old and new props directly instead of an updatePayload
-  commitUpdate(
-    node: DOMElement,
-    _type: ElementNames,
-    oldProps: Props,
-    newProps: Props,
-  ): void {
+  commitUpdate(node: DOMElement, _type: ElementNames, oldProps: Props, newProps: Props): void {
     const props = diff(oldProps, newProps)
     const style = diff(oldProps['style'] as Styles, newProps['style'] as Styles)
 

--- a/packages/renderer/src/reconciler.ts
+++ b/packages/renderer/src/reconciler.ts
@@ -1,6 +1,6 @@
 /* eslint-disable custom-rules/no-top-level-side-effects */
 
-import { appendFileSync } from 'fs'
+import { appendFileSync } from 'node:fs'
 import { isEnvTruthy } from '@yokai/shared'
 import { getYogaCounters } from '@yokai/shared/yoga-layout'
 import createReconciler from 'react-reconciler'
@@ -351,7 +351,7 @@ const reconciler = createReconciler<
   appendChild: appendChildNode,
   insertBefore: insertBeforeNode,
   finalizeInitialChildren(_node: DOMElement, _type: ElementNames, props: Props): boolean {
-    return props['autoFocus'] === true
+    return props.autoFocus === true
   },
   commitMount(node: DOMElement): void {
     getFocusManager(node).handleAutoFocus(node)
@@ -380,7 +380,7 @@ const reconciler = createReconciler<
   // React 19 commitUpdate receives old and new props directly instead of an updatePayload
   commitUpdate(node: DOMElement, _type: ElementNames, oldProps: Props, newProps: Props): void {
     const props = diff(oldProps, newProps)
-    const style = diff(oldProps['style'] as Styles, newProps['style'] as Styles)
+    const style = diff(oldProps.style as Styles, newProps.style as Styles)
 
     if (props) {
       for (const [key, value] of Object.entries(props)) {
@@ -404,7 +404,7 @@ const reconciler = createReconciler<
     }
 
     if (style && node.yogaNode) {
-      applyStyles(node.yogaNode, style, newProps['style'] as Styles)
+      applyStyles(node.yogaNode, style, newProps.style as Styles)
     }
   },
   commitTextUpdate(node: TextNode, _oldText: string, newText: string): void {

--- a/packages/renderer/src/reconciler.ts
+++ b/packages/renderer/src/reconciler.ts
@@ -1,17 +1,18 @@
 /* eslint-disable custom-rules/no-top-level-side-effects */
 
 import { appendFileSync } from 'fs'
-import createReconciler from 'react-reconciler'
-import { getYogaCounters } from '@yokai/shared/yoga-layout'
 import { isEnvTruthy } from '@yokai/shared'
+import { getYogaCounters } from '@yokai/shared/yoga-layout'
+import createReconciler from 'react-reconciler'
 import {
+  type DOMElement,
+  type DOMNodeAttribute,
+  type ElementNames,
+  type TextNode,
   appendChildNode,
   clearYogaNodeReferences,
   createNode,
   createTextNode,
-  type DOMElement,
-  type DOMNodeAttribute,
-  type ElementNames,
   insertBeforeNode,
   markDirty,
   removeChildNode,
@@ -19,7 +20,6 @@ import {
   setStyle,
   setTextNodeValue,
   setTextStyles,
-  type TextNode,
 } from './dom'
 import { Dispatcher } from './events/dispatcher'
 import { EVENT_HANDLER_PROPS } from './events/event-handlers'

--- a/packages/renderer/src/render-border.ts
+++ b/packages/renderer/src/render-border.ts
@@ -27,10 +27,7 @@ export const CUSTOM_BORDER_STYLES = {
   },
 } as const
 
-export type BorderStyle =
-  | keyof Boxes
-  | keyof typeof CUSTOM_BORDER_STYLES
-  | BoxStyle
+export type BorderStyle = keyof Boxes | keyof typeof CUSTOM_BORDER_STYLES | BoxStyle
 
 function embedTextInBorder(
   borderLine: string,
@@ -67,11 +64,7 @@ function embedTextInBorder(
   return [before, text, after]
 }
 
-function styleBorderLine(
-  line: string,
-  color: Color | undefined,
-  dim: boolean | undefined,
-): string {
+function styleBorderLine(line: string, color: Color | undefined, dim: boolean | undefined): string {
   let styled = applyColor(line, color)
   if (dim) {
     styled = chalk.dim(styled)
@@ -79,50 +72,35 @@ function styleBorderLine(
   return styled
 }
 
-const renderBorder = (
-  x: number,
-  y: number,
-  node: DOMNode,
-  output: Output,
-): void => {
+const renderBorder = (x: number, y: number, node: DOMNode, output: Output): void => {
   if (node.style.borderStyle) {
     const width = Math.floor(node.yogaNode!.getComputedWidth())
     const height = Math.floor(node.yogaNode!.getComputedHeight())
     const box =
       typeof node.style.borderStyle === 'string'
-        ? (CUSTOM_BORDER_STYLES[
-            node.style.borderStyle as keyof typeof CUSTOM_BORDER_STYLES
-          ] ?? cliBoxes[node.style.borderStyle as keyof Boxes])
+        ? (CUSTOM_BORDER_STYLES[node.style.borderStyle as keyof typeof CUSTOM_BORDER_STYLES] ??
+          cliBoxes[node.style.borderStyle as keyof Boxes])
         : node.style.borderStyle
 
     const topBorderColor = node.style.borderTopColor ?? node.style.borderColor
-    const bottomBorderColor =
-      node.style.borderBottomColor ?? node.style.borderColor
+    const bottomBorderColor = node.style.borderBottomColor ?? node.style.borderColor
     const leftBorderColor = node.style.borderLeftColor ?? node.style.borderColor
-    const rightBorderColor =
-      node.style.borderRightColor ?? node.style.borderColor
+    const rightBorderColor = node.style.borderRightColor ?? node.style.borderColor
 
-    const dimTopBorderColor =
-      node.style.borderTopDimColor ?? node.style.borderDimColor
+    const dimTopBorderColor = node.style.borderTopDimColor ?? node.style.borderDimColor
 
-    const dimBottomBorderColor =
-      node.style.borderBottomDimColor ?? node.style.borderDimColor
+    const dimBottomBorderColor = node.style.borderBottomDimColor ?? node.style.borderDimColor
 
-    const dimLeftBorderColor =
-      node.style.borderLeftDimColor ?? node.style.borderDimColor
+    const dimLeftBorderColor = node.style.borderLeftDimColor ?? node.style.borderDimColor
 
-    const dimRightBorderColor =
-      node.style.borderRightDimColor ?? node.style.borderDimColor
+    const dimRightBorderColor = node.style.borderRightDimColor ?? node.style.borderDimColor
 
     const showTopBorder = node.style.borderTop !== false
     const showBottomBorder = node.style.borderBottom !== false
     const showLeftBorder = node.style.borderLeft !== false
     const showRightBorder = node.style.borderRight !== false
 
-    const contentWidth = Math.max(
-      0,
-      width - (showLeftBorder ? 1 : 0) - (showRightBorder ? 1 : 0),
-    )
+    const contentWidth = Math.max(0, width - (showLeftBorder ? 1 : 0) - (showRightBorder ? 1 : 0))
 
     const topBorderLine = showTopBorder
       ? (showLeftBorder ? box.topLeft : '') +
@@ -145,11 +123,7 @@ const renderBorder = (
         text +
         styleBorderLine(after, topBorderColor, dimTopBorderColor)
     } else if (showTopBorder) {
-      topBorder = styleBorderLine(
-        topBorderLine,
-        topBorderColor,
-        dimTopBorderColor,
-      )
+      topBorder = styleBorderLine(topBorderLine, topBorderColor, dimTopBorderColor)
     }
 
     let verticalBorderHeight = height
@@ -164,17 +138,13 @@ const renderBorder = (
 
     verticalBorderHeight = Math.max(0, verticalBorderHeight)
 
-    let leftBorder = (applyColor(box.left, leftBorderColor) + '\n').repeat(
-      verticalBorderHeight,
-    )
+    let leftBorder = (applyColor(box.left, leftBorderColor) + '\n').repeat(verticalBorderHeight)
 
     if (dimLeftBorderColor) {
       leftBorder = chalk.dim(leftBorder)
     }
 
-    let rightBorder = (applyColor(box.right, rightBorderColor) + '\n').repeat(
-      verticalBorderHeight,
-    )
+    let rightBorder = (applyColor(box.right, rightBorderColor) + '\n').repeat(verticalBorderHeight)
 
     if (dimRightBorderColor) {
       rightBorder = chalk.dim(rightBorder)
@@ -201,11 +171,7 @@ const renderBorder = (
         text +
         styleBorderLine(after, bottomBorderColor, dimBottomBorderColor)
     } else if (showBottomBorder) {
-      bottomBorder = styleBorderLine(
-        bottomBorderLine,
-        bottomBorderColor,
-        dimBottomBorderColor,
-      )
+      bottomBorder = styleBorderLine(bottomBorderLine, bottomBorderColor, dimBottomBorderColor)
     }
 
     const offsetY = showTopBorder ? 1 : 0
@@ -229,4 +195,3 @@ const renderBorder = (
 }
 
 export default renderBorder
-

--- a/packages/renderer/src/render-border.ts
+++ b/packages/renderer/src/render-border.ts
@@ -33,8 +33,8 @@ function embedTextInBorder(
   borderLine: string,
   text: string,
   align: 'start' | 'end' | 'center',
-  offset = 0,
   borderChar: string,
+  offset = 0,
 ): [before: string, text: string, after: string] {
   const textLength = stringWidth(text)
   const borderLength = borderLine.length
@@ -115,8 +115,8 @@ const renderBorder = (x: number, y: number, node: DOMNode, output: Output): void
         topBorderLine,
         node.style.borderText.content,
         node.style.borderText.align,
-        node.style.borderText.offset,
         box.top,
+        node.style.borderText.offset,
       )
       topBorder =
         styleBorderLine(before, topBorderColor, dimTopBorderColor) +
@@ -138,13 +138,13 @@ const renderBorder = (x: number, y: number, node: DOMNode, output: Output): void
 
     verticalBorderHeight = Math.max(0, verticalBorderHeight)
 
-    let leftBorder = (applyColor(box.left, leftBorderColor) + '\n').repeat(verticalBorderHeight)
+    let leftBorder = `${applyColor(box.left, leftBorderColor)}\n`.repeat(verticalBorderHeight)
 
     if (dimLeftBorderColor) {
       leftBorder = chalk.dim(leftBorder)
     }
 
-    let rightBorder = (applyColor(box.right, rightBorderColor) + '\n').repeat(verticalBorderHeight)
+    let rightBorder = `${applyColor(box.right, rightBorderColor)}\n`.repeat(verticalBorderHeight)
 
     if (dimRightBorderColor) {
       rightBorder = chalk.dim(rightBorder)
@@ -163,8 +163,8 @@ const renderBorder = (x: number, y: number, node: DOMNode, output: Output): void
         bottomBorderLine,
         node.style.borderText.content,
         node.style.borderText.align,
-        node.style.borderText.offset,
         box.bottom,
+        node.style.borderText.offset,
       )
       bottomBorder =
         styleBorderLine(before, bottomBorderColor, dimBottomBorderColor) +

--- a/packages/renderer/src/render-border.ts
+++ b/packages/renderer/src/render-border.ts
@@ -33,7 +33,7 @@ function embedTextInBorder(
   borderLine: string,
   text: string,
   align: 'start' | 'end' | 'center',
-  offset: number = 0,
+  offset = 0,
   borderChar: string,
 ): [before: string, text: string, after: string] {
   const textLength = stringWidth(text)

--- a/packages/renderer/src/render-node-to-output.ts
+++ b/packages/renderer/src/render-node-to-output.ts
@@ -344,19 +344,16 @@ function wrapWithSoftWrap(
 // so their coordinates will be relative to the first node anyway
 function applyPaddingToText(node: DOMElement, text: string, softWrap?: boolean[]): string {
   const yogaNode = node.childNodes[0]?.yogaNode
+  if (!yogaNode) return text
 
-  if (yogaNode) {
-    const offsetX = yogaNode.getComputedLeft()
-    const offsetY = yogaNode.getComputedTop()
-    text = '\n'.repeat(offsetY) + indentString(text, offsetX)
-    if (softWrap && offsetY > 0) {
-      // Prepend `false` for each padding line so indices stay aligned
-      // with text.split('\n'). Mutate in place — caller owns the array.
-      softWrap.unshift(...Array<boolean>(offsetY).fill(false))
-    }
+  const offsetX = yogaNode.getComputedLeft()
+  const offsetY = yogaNode.getComputedTop()
+  if (softWrap && offsetY > 0) {
+    // Prepend `false` for each padding line so indices stay aligned
+    // with text.split('\n'). Mutate in place — caller owns the array.
+    softWrap.unshift(...Array<boolean>(offsetY).fill(false))
   }
-
-  return text
+  return '\n'.repeat(offsetY) + indentString(text, offsetX)
 }
 
 // After nodes are laid out, render each to output object, which later gets rendered to terminal

--- a/packages/renderer/src/render-node-to-output.ts
+++ b/packages/renderer/src/render-node-to-output.ts
@@ -202,7 +202,7 @@ function applyStylesToWrappedText(
   segments: StyledSegment[],
   charToSegment: number[],
   originalPlain: string,
-  trimEnabled: boolean = false,
+  trimEnabled = false,
 ): string {
   const lines = wrappedPlain.split('\n')
   const resultLines: string[] = []

--- a/packages/renderer/src/render-node-to-output.ts
+++ b/packages/renderer/src/render-node-to-output.ts
@@ -515,7 +515,7 @@ function renderNodeToOutput(
       // Pre-rendered ANSI content. The producer already wrapped to width and
       // emitted terminal-ready escape codes. Skip squash, measure, wrap, and
       // style re-application — output.write() parses ANSI directly into cells.
-      const text = node.attributes['rawText'] as string
+      const text = node.attributes.rawText as string
       if (text) {
         output.write(x, y, text)
       }
@@ -713,7 +713,7 @@ function renderNodeToOutput(
         // active text selection by the same delta (native terminal behavior:
         // view keeps scrolling, highlight walks up with the text).
         const scrollTopBeforeFollow = node.scrollTop ?? 0
-        const sticky = node.stickyScroll ?? Boolean(node.attributes['stickyScroll'])
+        const sticky = node.stickyScroll ?? Boolean(node.attributes.stickyScroll)
         const prevMaxScroll = Math.max(0, prevScrollHeight - prevInnerHeight)
         // Positional check only valid when content grew — virtualization can
         // transiently SHRINK scrollHeight (tail unmount + stale heightCache

--- a/packages/renderer/src/render-node-to-output.ts
+++ b/packages/renderer/src/render-node-to-output.ts
@@ -8,10 +8,7 @@ import { nodeCache, pendingClears } from './node-cache'
 import type Output from './output'
 import renderBorder from './render-border'
 import type { Screen } from './screen'
-import {
-  type StyledSegment,
-  squashTextNodesToSegments,
-} from './squash-text-nodes'
+import { type StyledSegment, squashTextNodesToSegments } from './squash-text-nodes'
 import type { Color } from './styles'
 import { isXtermJs } from './terminal'
 import { widestLine } from './widest-line'
@@ -121,11 +118,7 @@ const SCROLL_STEP_HIGH = 3 // pending ≥ HIGH: fast flick
 const SCROLL_MAX_PENDING = 30 // snap excess beyond this
 
 // xterm.js adaptive drain. Returns rows applied; mutates pendingScrollDelta.
-function drainAdaptive(
-  node: DOMElement,
-  pending: number,
-  innerHeight: number,
-): number {
+function drainAdaptive(node: DOMElement, pending: number, innerHeight: number): number {
   const sign = pending > 0 ? 1 : -1
   let abs = Math.abs(pending)
   let applied = 0
@@ -158,11 +151,7 @@ function drainAdaptive(
 
 // Native proportional drain. step = max(MIN, floor(abs*3/4)), capped at
 // innerHeight-1 so DECSTBM + blit+shift fast path fire.
-function drainProportional(
-  node: DOMElement,
-  pending: number,
-  innerHeight: number,
-): number {
+function drainProportional(node: DOMElement, pending: number, innerHeight: number): number {
   const abs = Math.abs(pending)
   const cap = Math.max(1, innerHeight - 1)
   const step = Math.min(cap, Math.max(SCROLL_MIN_PER_FRAME, (abs * 3) >> 2))
@@ -233,10 +222,7 @@ function applyStylesToWrappedText(
 
       // Only skip if original has whitespace but line doesn't
       if (originalHasWhitespace && !lineStartsWithWhitespace) {
-        while (
-          charIndex < originalPlain.length &&
-          /\s/.test(originalPlain[charIndex]!)
-        ) {
+        while (charIndex < originalPlain.length && /\s/.test(originalPlain[charIndex]!)) {
           charIndex++
         }
       }
@@ -303,15 +289,9 @@ function applyStylesToWrappedText(
       const nextLineFirstChar = nextLine.length > 0 ? nextLine[0] : null
 
       // Skip whitespace until we hit a char that matches the next line's first char
-      while (
-        charIndex < originalPlain.length &&
-        /\s/.test(originalPlain[charIndex]!)
-      ) {
+      while (charIndex < originalPlain.length && /\s/.test(originalPlain[charIndex]!)) {
         // Stop if we found the character that starts the next line
-        if (
-          nextLineFirstChar !== null &&
-          originalPlain[charIndex] === nextLineFirstChar
-        ) {
+        if (nextLineFirstChar !== null && originalPlain[charIndex] === nextLineFirstChar) {
           break
         }
         charIndex++
@@ -362,11 +342,7 @@ function wrapWithSoftWrap(
 // and use it as offset for the rest of the nodes
 // Only first node is taken into account, because other text nodes can't have margin or padding,
 // so their coordinates will be relative to the first node anyway
-function applyPaddingToText(
-  node: DOMElement,
-  text: string,
-  softWrap?: boolean[],
-): string {
+function applyPaddingToText(node: DOMElement, text: string, softWrap?: boolean[]): string {
   const yogaNode = node.childNodes[0]?.yogaNode
 
   if (yogaNode) {
@@ -486,10 +462,7 @@ function renderNodeToOutput(
     // above changed height), old cells still on the terminal.
     const positionChanged =
       cached !== undefined &&
-      (cached.x !== x ||
-        cached.y !== y ||
-        cached.width !== width ||
-        cached.height !== height)
+      (cached.x !== x || cached.y !== y || cached.width !== width || cached.height !== height)
     if (positionChanged) {
       layoutShifted = true
     }
@@ -549,13 +522,11 @@ function renderNodeToOutput(
     } else if (node.nodeName === 'ink-text') {
       const segments = squashTextNodesToSegments(
         node,
-        inheritedBackgroundColor
-          ? { backgroundColor: inheritedBackgroundColor }
-          : undefined,
+        inheritedBackgroundColor ? { backgroundColor: inheritedBackgroundColor } : undefined,
       )
 
       // First, get plain text to check if wrapping is needed
-      const plainText = segments.map(s => s.text).join('')
+      const plainText = segments.map((s) => s.text).join('')
 
       if (plainText.length > 0) {
         // Upstream Ink uses getMaxWidth(yogaNode) unclamped here. That
@@ -580,7 +551,7 @@ function renderNodeToOutput(
           softWrap = w.softWrap
           text = w.wrapped
             .split('\n')
-            .map(line => {
+            .map((line) => {
               let styled = applyTextStyles(line, segment.styles)
               // Apply OSC 8 hyperlink per-line so each line is independently
               // clickable. output.ts splits on newlines and tokenizes each
@@ -611,7 +582,7 @@ function renderNodeToOutput(
         } else {
           // No wrapping needed: apply styles directly
           text = segments
-            .map(segment => {
+            .map((segment) => {
               let styledText = applyTextStyles(segment.text, segment.styles)
               if (segment.hyperlink) {
                 styledText = wrapWithOsc8Link(styledText, segment.hyperlink)
@@ -626,8 +597,7 @@ function renderNodeToOutput(
         output.write(x, y, text, softWrap)
       }
     } else if (node.nodeName === 'ink-box') {
-      const boxBackgroundColor =
-        node.style.backgroundColor ?? inheritedBackgroundColor
+      const boxBackgroundColor = node.style.backgroundColor ?? inheritedBackgroundColor
 
       // Mark this box's region as non-selectable (fullscreen text
       // selection). noSelect ops are applied AFTER blits/writes in
@@ -662,24 +632,16 @@ function renderNodeToOutput(
       let y1: number | undefined
       let y2: number | undefined
       if (needsClip) {
-        const x1 = clipHorizontally
-          ? x + yogaNode.getComputedBorder(LayoutEdge.Left)
-          : undefined
+        const x1 = clipHorizontally ? x + yogaNode.getComputedBorder(LayoutEdge.Left) : undefined
 
         const x2 = clipHorizontally
-          ? x +
-            yogaNode.getComputedWidth() -
-            yogaNode.getComputedBorder(LayoutEdge.Right)
+          ? x + yogaNode.getComputedWidth() - yogaNode.getComputedBorder(LayoutEdge.Right)
           : undefined
 
-        y1 = clipVertically
-          ? y + yogaNode.getComputedBorder(LayoutEdge.Top)
-          : undefined
+        y1 = clipVertically ? y + yogaNode.getComputedBorder(LayoutEdge.Top) : undefined
 
         y2 = clipVertically
-          ? y +
-            yogaNode.getComputedHeight() -
-            yogaNode.getComputedBorder(LayoutEdge.Bottom)
+          ? y + yogaNode.getComputedHeight() - yogaNode.getComputedBorder(LayoutEdge.Bottom)
           : undefined
 
         output.clip({ x1, x2, y1, y2 })
@@ -695,13 +657,10 @@ function renderNodeToOutput(
         const padTop = yogaNode.getComputedPadding(LayoutEdge.Top)
         const innerHeight = Math.max(
           0,
-          (y2 ?? y + height) -
-            (y1 ?? y) -
-            padTop -
-            yogaNode.getComputedPadding(LayoutEdge.Bottom),
+          (y2 ?? y + height) - (y1 ?? y) - padTop - yogaNode.getComputedPadding(LayoutEdge.Bottom),
         )
 
-        const content = node.childNodes.find(c => (c as DOMElement).yogaNode) as
+        const content = node.childNodes.find((c) => (c as DOMElement).yogaNode) as
           | DOMElement
           | undefined
         const contentYoga = content?.yogaNode
@@ -754,16 +713,14 @@ function renderNodeToOutput(
         // active text selection by the same delta (native terminal behavior:
         // view keeps scrolling, highlight walks up with the text).
         const scrollTopBeforeFollow = node.scrollTop ?? 0
-        const sticky =
-          node.stickyScroll ?? Boolean(node.attributes['stickyScroll'])
+        const sticky = node.stickyScroll ?? Boolean(node.attributes['stickyScroll'])
         const prevMaxScroll = Math.max(0, prevScrollHeight - prevInnerHeight)
         // Positional check only valid when content grew — virtualization can
         // transiently SHRINK scrollHeight (tail unmount + stale heightCache
         // spacer) making scrollTop >= prevMaxScroll true by artifact, not
         // because the user was at bottom.
         const grew = scrollHeight >= prevScrollHeight
-        const atBottom =
-          sticky || (grew && scrollTopBeforeFollow >= prevMaxScroll)
+        const atBottom = sticky || (grew && scrollTopBeforeFollow >= prevMaxScroll)
         if (atBottom && (node.pendingScrollDelta ?? 0) >= 0) {
           node.scrollTop = maxScroll
           node.pendingScrollDelta = undefined
@@ -777,10 +734,7 @@ function renderNodeToOutput(
           // undefined (never set by user action) leave it alone — setting it
           // would make the sticky flag sticky-by-default and lock out
           // direct scrollTop writes (e.g. the alt-screen-perf test).
-          if (
-            node.stickyScroll === false &&
-            scrollTopBeforeFollow >= prevMaxScroll
-          ) {
+          if (node.stickyScroll === false && scrollTopBeforeFollow >= prevMaxScroll) {
             node.stickyScroll = true
           }
         }
@@ -819,8 +773,7 @@ function renderNodeToOutput(
           // frame, roughly matching React's slide rate so the gap stays
           // bounded and catch-up is quick once input stops.
           const pastClamp =
-            haveClamp &&
-            ((pending < 0 && cur < cMin) || (pending > 0 && cur > cMax))
+            haveClamp && ((pending < 0 && cur < cMin) || (pending > 0 && cur > cMax))
           const eff = pastClamp ? Math.min(4, innerHeight >> 3) : innerHeight
           cur += isXtermJsHost()
             ? drainAdaptive(node, pending, eff)
@@ -839,9 +792,7 @@ function renderNodeToOutput(
         // the right range. Not scheduling scrollDrainNode here keeps the
         // clamp passive — React's commit → resetAfterCommit → onRender will
         // paint again with fresh bounds.
-        const clamped = haveClamp
-          ? Math.max(cMin, Math.min(scrollTop, cMax))
-          : scrollTop
+        const clamped = haveClamp ? Math.max(cMin, Math.min(scrollTop, cMax)) : scrollTop
         node.scrollTop = scrollTop
         // Clamp hitting top/bottom consumes any remainder. Set drainPending
         // only after clamp so a wasted no-op frame isn't scheduled.
@@ -906,9 +857,7 @@ function renderNodeToOutput(
           const prevHeight = contentCached?.height ?? scrollHeight
           const heightDelta = scrollHeight - prevHeight
           const safeForFastPath =
-            !hint ||
-            heightDelta === 0 ||
-            (hint.delta > 0 && heightDelta === hint.delta)
+            !hint || heightDelta === 0 || (hint.delta > 0 && heightDelta === hint.delta)
           // scrollHint is set above when hint is captured. If safeForFastPath
           // is false the full path renders a next.screen that doesn't match
           // the DECSTBM shift — emitting DECSTBM leaves stale rows (seen as
@@ -938,7 +887,7 @@ function renderNodeToOutput(
             // pass clears dirty flags, and edge-spanning children would be
             // missed by the second pass without this snapshot.
             const dirtyChildren = content.dirty
-              ? new Set(content.childNodes.filter(c => (c as DOMElement).dirty))
+              ? new Set(content.childNodes.filter((c) => (c as DOMElement).dirty))
               : null
             renderScrolledChildren(
               content,
@@ -1007,14 +956,9 @@ function renderNodeToOutput(
                   cumHeightShift += childH - (prev ? prev.height : 0)
                 }
                 // Skip culled children (outside viewport)
-                if (
-                  childBottom <= scrollTop ||
-                  childTop >= scrollTop + innerHeight
-                )
-                  continue
+                if (childBottom <= scrollTop || childTop >= scrollTop + innerHeight) continue
                 // Skip children entirely within edge rows (already rendered)
-                if (childTop >= edgeTopLocal && childBottom <= edgeBottomLocal)
-                  continue
+                if (childTop >= edgeTopLocal && childBottom <= edgeBottomLocal) continue
                 const screenY = Math.floor(contentY + childTop)
                 // Clean children reaching here have cumHeightShift ≠ 0 OR
                 // no cache. Re-check precisely: cached.y − delta is where
@@ -1024,10 +968,7 @@ function renderNodeToOutput(
                 // painted it → render.
                 if (!isDirty) {
                   const childCached = nodeCache.get(childElem)
-                  if (
-                    childCached &&
-                    Math.floor(childCached.y) - delta === screenY
-                  ) {
+                  if (childCached && Math.floor(childCached.y) - delta === screenY) {
                     continue
                   }
                 }
@@ -1071,13 +1012,9 @@ function renderNodeToOutput(
             for (const r of absoluteRectsPrev) {
               if (r.y >= bottom + 1 || r.y + r.height <= top) continue
               const shiftedTop = Math.max(top, Math.floor(r.y) - delta)
-              const shiftedBottom = Math.min(
-                bottom + 1,
-                Math.floor(r.y + r.height) - delta,
-              )
+              const shiftedBottom = Math.min(bottom + 1, Math.floor(r.y + r.height) - delta)
               // Skip if entirely within edge rows (already rendered).
-              if (shiftedTop >= edgeTop && shiftedBottom <= edgeBottom + 1)
-                continue
+              if (shiftedTop >= edgeTop && shiftedBottom <= edgeBottom + 1) continue
               if (shiftedTop >= shiftedBottom) continue
               const fill = Array(shiftedBottom - shiftedTop)
                 .fill(spaces)
@@ -1205,15 +1142,7 @@ function renderNodeToOutput(
       // which may overlap with where the parent's border now is.
       renderBorder(x, y, node, output)
     } else if (node.nodeName === 'ink-root') {
-      renderChildren(
-        node,
-        output,
-        x,
-        y,
-        hasRemovedChild,
-        prevScreen,
-        inheritedBackgroundColor,
-      )
+      renderChildren(node, output, x, y, hasRemovedChild, prevScreen, inheritedBackgroundColor)
     }
 
     // Cache layout bounds for dirty tracking
@@ -1296,9 +1225,7 @@ function renderChildren(
 function clipsBothAxes(node: DOMElement): boolean {
   const ox = node.style.overflowX ?? node.style.overflow
   const oy = node.style.overflowY ?? node.style.overflow
-  return (
-    (ox === 'hidden' || ox === 'scroll') && (oy === 'hidden' || oy === 'scroll')
-  )
+  return (ox === 'hidden' || ox === 'scroll') && (oy === 'hidden' || oy === 'scroll')
 }
 
 // When Yoga squeezes a box to h=0, the ghost only happens if a sibling
@@ -1405,11 +1332,7 @@ function renderScrolledChildren(
       const cached = nodeCache.get(childElem)
       let top: number
       let height: number
-      if (
-        cached?.top !== undefined &&
-        !childElem.dirty &&
-        cumHeightShift === 0
-      ) {
+      if (cached?.top !== undefined && !childElem.dirty && cumHeightShift === 0) {
         top = cached.top
         height = cached.height
       } else {
@@ -1460,4 +1383,3 @@ function dropSubtreeCache(node: DOMElement): void {
 export { buildCharToSegmentMap, applyStylesToWrappedText }
 
 export default renderNodeToOutput
-

--- a/packages/renderer/src/render-to-screen.ts
+++ b/packages/renderer/src/render-to-screen.ts
@@ -6,9 +6,7 @@ import { createNode, type DOMElement } from './dom'
 import { FocusManager } from './focus'
 import Output from './output'
 import reconciler from './reconciler'
-import renderNodeToOutput, {
-  resetLayoutShifted,
-} from './render-node-to-output'
+import renderNodeToOutput, { resetLayoutShifted } from './render-node-to-output'
 import {
   CellWidth,
   CharPool,

--- a/packages/renderer/src/render-to-screen.ts
+++ b/packages/renderer/src/render-to-screen.ts
@@ -1,20 +1,20 @@
-import { noop } from './lodash-replacements'
+import { logForDebugging } from '@yokai/shared'
 import type { ReactElement } from 'react'
 import { LegacyRoot } from 'react-reconciler/constants.js'
-import { logForDebugging } from '@yokai/shared'
-import { createNode, type DOMElement } from './dom'
+import { type DOMElement, createNode } from './dom'
 import { FocusManager } from './focus'
+import { noop } from './lodash-replacements'
 import Output from './output'
 import reconciler from './reconciler'
 import renderNodeToOutput, { resetLayoutShifted } from './render-node-to-output'
 import {
   CellWidth,
   CharPool,
-  cellAtIndex,
-  createScreen,
   HyperlinkPool,
   type Screen,
   StylePool,
+  cellAtIndex,
+  createScreen,
   setCellStyleId,
 } from './screen'
 

--- a/packages/renderer/src/renderer.ts
+++ b/packages/renderer/src/renderer.ts
@@ -10,7 +10,7 @@ import renderNodeToOutput, {
   resetScrollDrainNode,
   resetScrollHint,
 } from './render-node-to-output'
-import { createScreen, type StylePool } from './screen'
+import { type StylePool, createScreen } from './screen'
 
 export type RenderOptions = {
   frontFrame: Frame

--- a/packages/renderer/src/renderer.ts
+++ b/packages/renderer/src/renderer.ts
@@ -83,8 +83,7 @@ export default function createRenderer(node: DOMElement, stylePool: StylePool): 
     const height = options.altScreen ? terminalRows : yogaHeight
     if (options.altScreen && yogaHeight > terminalRows) {
       logForDebugging(
-        `alt-screen: yoga height ${yogaHeight} > terminalRows ${terminalRows} — ` +
-          `something is rendering outside <AlternateScreen>. Overflow clipped.`,
+        `alt-screen: yoga height ${yogaHeight} > terminalRows ${terminalRows} — something is rendering outside <AlternateScreen>. Overflow clipped.`,
         { level: 'warn' },
       )
     }

--- a/packages/renderer/src/renderer.ts
+++ b/packages/renderer/src/renderer.ts
@@ -28,16 +28,12 @@ export type RenderOptions = {
 
 export type Renderer = (options: RenderOptions) => Frame
 
-export default function createRenderer(
-  node: DOMElement,
-  stylePool: StylePool,
-): Renderer {
+export default function createRenderer(node: DOMElement, stylePool: StylePool): Renderer {
   // Reuse Output across frames so charCache (tokenize + grapheme clustering)
   // persists — most lines don't change between renders.
   let output: Output | undefined
-  return options => {
-    const { frontFrame, backFrame, isTTY, terminalWidth, terminalRows } =
-      options
+  return (options) => {
+    const { frontFrame, backFrame, isTTY, terminalWidth, terminalRows } = options
     const prevScreen = frontFrame.screen
     const backScreen = backFrame.screen
     // Read pools from the back buffer's screen — pools may be replaced
@@ -52,13 +48,9 @@ export default function createRenderer(
     const computedHeight = node.yogaNode?.getComputedHeight()
     const computedWidth = node.yogaNode?.getComputedWidth()
     const hasInvalidHeight =
-      computedHeight === undefined ||
-      !Number.isFinite(computedHeight) ||
-      computedHeight < 0
+      computedHeight === undefined || !Number.isFinite(computedHeight) || computedHeight < 0
     const hasInvalidWidth =
-      computedWidth === undefined ||
-      !Number.isFinite(computedWidth) ||
-      computedWidth < 0
+      computedWidth === undefined || !Number.isFinite(computedWidth) || computedWidth < 0
 
     if (!node.yogaNode || hasInvalidHeight || hasInvalidWidth) {
       // Log to help diagnose root cause (visible with --debug flag)
@@ -69,13 +61,7 @@ export default function createRenderer(
         )
       }
       return {
-        screen: createScreen(
-          terminalWidth,
-          0,
-          stylePool,
-          charPool,
-          hyperlinkPool,
-        ),
+        screen: createScreen(terminalWidth, 0, stylePool, charPool, hyperlinkPool),
         viewport: { width: terminalWidth, height: terminalRows },
         cursor: { x: 0, y: 0, visible: true },
       }
@@ -102,9 +88,7 @@ export default function createRenderer(
         { level: 'warn' },
       )
     }
-    const screen =
-      backScreen ??
-      createScreen(width, height, stylePool, charPool, hyperlinkPool)
+    const screen = backScreen ?? createScreen(width, height, stylePool, charPool, hyperlinkPool)
     if (output) {
       output.reset(width, height, screen)
     } else {
@@ -128,10 +112,7 @@ export default function createRenderer(
     // Normal-flow removals don't paint cross-subtree and are fine.
     const absoluteRemoved = consumeAbsoluteRemovedFlag()
     renderNodeToOutput(node, output, {
-      prevScreen:
-        absoluteRemoved || options.prevFrameContaminated
-          ? undefined
-          : prevScreen,
+      prevScreen: absoluteRemoved || options.prevFrameContaminated ? undefined : prevScreen,
     })
 
     const renderedScreen = output.get()
@@ -176,4 +157,3 @@ export default function createRenderer(
     }
   }
 }
-

--- a/packages/renderer/src/root.ts
+++ b/packages/renderer/src/root.ts
@@ -87,10 +87,7 @@ export const renderSync = (
     ...opts,
   }
 
-  const instance: Ink = getInstance(
-    inkOptions.stdout,
-    () => new Ink(inkOptions),
-  )
+  const instance: Ink = getInstance(inkOptions.stdout, () => new Ink(inkOptions))
 
   instance.render(node)
 
@@ -150,15 +147,13 @@ export async function createRoot({
   instances.set(stdout, instance)
 
   return {
-    render: node => instance.render(node),
+    render: (node) => instance.render(node),
     unmount: () => instance.unmount(),
     waitUntilExit: () => instance.waitUntilExit(),
   }
 }
 
-const getOptions = (
-  stdout: NodeJS.WriteStream | RenderOptions | undefined = {},
-): RenderOptions => {
+const getOptions = (stdout: NodeJS.WriteStream | RenderOptions | undefined = {}): RenderOptions => {
   if (stdout instanceof Stream) {
     return {
       stdout,
@@ -169,10 +164,7 @@ const getOptions = (
   return stdout
 }
 
-const getInstance = (
-  stdout: NodeJS.WriteStream,
-  createInstance: () => Ink,
-): Ink => {
+const getInstance = (stdout: NodeJS.WriteStream, createInstance: () => Ink): Ink => {
   let instance = instances.get(stdout)
 
   if (!instance) {
@@ -182,4 +174,3 @@ const getInstance = (
 
   return instance
 }
-

--- a/packages/renderer/src/root.ts
+++ b/packages/renderer/src/root.ts
@@ -1,6 +1,6 @@
-import type { ReactNode } from 'react'
-import { logForDebugging } from '@yokai/shared'
 import { Stream } from 'stream'
+import { logForDebugging } from '@yokai/shared'
+import type { ReactNode } from 'react'
 import type { FrameEvent } from './frame'
 import Ink, { type Options as InkOptions } from './ink'
 import instances from './instances'

--- a/packages/renderer/src/root.ts
+++ b/packages/renderer/src/root.ts
@@ -1,4 +1,4 @@
-import { Stream } from 'stream'
+import { Stream } from 'node:stream'
 import { logForDebugging } from '@yokai/shared'
 import type { ReactNode } from 'react'
 import type { FrameEvent } from './frame'

--- a/packages/renderer/src/screen.ts
+++ b/packages/renderer/src/screen.ts
@@ -1066,7 +1066,7 @@ type DiffCallback = (
   y: number,
   removed: Cell | undefined,
   added: Cell | undefined,
-) => boolean | void
+) => boolean | undefined
 
 /**
  * Like diff(), but calls a callback for each change instead of building an array.

--- a/packages/renderer/src/screen.ts
+++ b/packages/renderer/src/screen.ts
@@ -271,7 +271,7 @@ function hasVisibleSpaceEffect(styles: AnsiCode[]): boolean {
  * @see https://mitchellh.com/writing/grapheme-clusters-in-terminals
  */
 // const enum is inlined at compile time - no runtime object, no property access
-export const enum CellWidth {
+export enum CellWidth {
   // Not a wide character, cell width 1
   Narrow = 0,
   // Wide character, cell width 2. This cell contains the actual character.

--- a/packages/renderer/src/screen.ts
+++ b/packages/renderer/src/screen.ts
@@ -444,8 +444,7 @@ export function createScreen(
   // negatives in degenerate layouts; passing those into typed-array
   // allocation crashes. Locals instead of param reassign for clarity.
   const w = Number.isInteger(width) && width >= 0 ? width : Math.max(0, Math.floor(width) || 0)
-  const h =
-    Number.isInteger(height) && height >= 0 ? height : Math.max(0, Math.floor(height) || 0)
+  const h = Number.isInteger(height) && height >= 0 ? height : Math.max(0, Math.floor(height) || 0)
 
   const size = w * h
 
@@ -485,8 +484,7 @@ export function resetScreen(screen: Screen, width: number, height: number): void
 
   // Sanitize: clamp to non-negative integers (see createScreen for rationale).
   const w = Number.isInteger(width) && width >= 0 ? width : Math.max(0, Math.floor(width) || 0)
-  const h =
-    Number.isInteger(height) && height >= 0 ? height : Math.max(0, Math.floor(height) || 0)
+  const h = Number.isInteger(height) && height >= 0 ? height : Math.max(0, Math.floor(height) || 0)
 
   const size = w * h
 

--- a/packages/renderer/src/screen.ts
+++ b/packages/renderer/src/screen.ts
@@ -1,14 +1,5 @@
-import {
-  type AnsiCode,
-  ansiCodesToString,
-  diffAnsiCodes,
-} from '@alcalzone/ansi-tokenize'
-import {
-  type Point,
-  type Rectangle,
-  type Size,
-  unionRect,
-} from './layout/geometry.js'
+import { type AnsiCode, ansiCodesToString, diffAnsiCodes } from '@alcalzone/ansi-tokenize'
+import { type Point, type Rectangle, type Size, unionRect } from './layout/geometry.js'
 import { BEL, ESC, SEP } from './termio/ansi.js'
 import * as warn from './warn.js'
 
@@ -127,14 +118,12 @@ export class StylePool {
    * with a single bitmask check on the packed word.
    */
   intern(styles: AnsiCode[]): number {
-    const key = styles.length === 0 ? '' : styles.map(s => s.code).join('\0')
+    const key = styles.length === 0 ? '' : styles.map((s) => s.code).join('\0')
     let id = this.ids.get(key)
     if (id === undefined) {
       const rawId = this.styles.length
       this.styles.push(styles.length === 0 ? [] : styles)
-      id =
-        (rawId << 1) |
-        (styles.length > 0 && hasVisibleSpaceEffect(styles) ? 1 : 0)
+      id = (rawId << 1) | (styles.length > 0 && hasVisibleSpaceEffect(styles) ? 1 : 0)
       this.ids.set(key, id)
     }
     return id
@@ -172,7 +161,7 @@ export class StylePool {
     if (id === undefined) {
       const baseCodes = this.get(baseId)
       // If already inverted, use as-is (avoids SGR 7 stacking)
-      const hasInverse = baseCodes.some(c => c.endCode === '\x1b[27m')
+      const hasInverse = baseCodes.some((c) => c.endCode === '\x1b[27m')
       id = hasInverse ? baseId : this.intern([...baseCodes, INVERSE_CODE])
       this.inverseCache.set(baseId, id)
     }
@@ -198,21 +187,17 @@ export class StylePool {
       // when both colors are explicit). Filtering both gives clean
       // yellow-bg + terminal-default-fg everywhere. Bold/dim/italic
       // coexist — keep those.
-      const codes = baseCodes.filter(
-        c => c.endCode !== '\x1b[39m' && c.endCode !== '\x1b[49m',
-      )
+      const codes = baseCodes.filter((c) => c.endCode !== '\x1b[39m' && c.endCode !== '\x1b[49m')
       // fg-yellow FIRST so inverse swaps it to bg. Bold after inverse is
       // fine — SGR 1 is fg-attribute-only, order-independent vs 7.
       codes.push(YELLOW_FG_CODE)
-      if (!baseCodes.some(c => c.endCode === '\x1b[27m'))
-        codes.push(INVERSE_CODE)
-      if (!baseCodes.some(c => c.endCode === '\x1b[22m')) codes.push(BOLD_CODE)
+      if (!baseCodes.some((c) => c.endCode === '\x1b[27m')) codes.push(INVERSE_CODE)
+      if (!baseCodes.some((c) => c.endCode === '\x1b[22m')) codes.push(BOLD_CODE)
       // Underline as the unambiguous marker — yellow-bg can clash with
       // existing bg styling (user-prompt bg, syntax bg). If you see
       // underline but no yellow on a match, the overlay IS finding it;
       // the yellow is just losing a styling fight.
-      if (!baseCodes.some(c => c.endCode === '\x1b[24m'))
-        codes.push(UNDERLINE_CODE)
+      if (!baseCodes.some((c) => c.endCode === '\x1b[24m')) codes.push(UNDERLINE_CODE)
       id = this.intern(codes)
       this.currentMatchCache.set(baseId, id)
     }
@@ -249,7 +234,7 @@ export class StylePool {
       // Keep everything except bg (49m) and inverse (27m). Fg, bold, dim,
       // italic, underline, strikethrough all preserved.
       const kept = this.get(baseId).filter(
-        c => c.endCode !== '\x1b[49m' && c.endCode !== '\x1b[27m',
+        (c) => c.endCode !== '\x1b[49m' && c.endCode !== '\x1b[27m',
       )
       kept.push(bg)
       id = this.intern(kept)
@@ -339,11 +324,7 @@ const HYPERLINK_MASK = 0x7fff // 15 bits
 const WIDTH_MASK = 3 // 2 bits
 
 // Pack styleId, hyperlinkId, and width into a single Int32
-function packWord1(
-  styleId: number,
-  hyperlinkId: number,
-  width: number,
-): number {
+function packWord1(styleId: number, hyperlinkId: number, width: number): number {
   return (styleId << STYLE_SHIFT) | (hyperlinkId << HYPERLINK_SHIFT) | width
 }
 
@@ -498,11 +479,7 @@ export function createScreen(
  * For double-buffering, this allows swapping between front and back buffers
  * without allocating new Screen objects each frame.
  */
-export function resetScreen(
-  screen: Screen,
-  width: number,
-  height: number,
-): void {
+export function resetScreen(screen: Screen, width: number, height: number): void {
   // Warn if dimensions are not valid integers
   warn.ifNotInteger(width, 'resetScreen width')
   warn.ifNotInteger(height, 'resetScreen height')
@@ -591,8 +568,7 @@ export function migrateScreenPools(
  * this is intentional as cells are stored packed, not as objects.
  */
 export function cellAt(screen: Screen, x: number, y: number): Cell | undefined {
-  if (x < 0 || y < 0 || x >= screen.width || y >= screen.height)
-    return undefined
+  if (x < 0 || y < 0 || x >= screen.width || y >= screen.height) return undefined
   return cellAtIndex(screen, y * screen.width + x)
 }
 /**
@@ -663,13 +639,8 @@ function cellAtCI(screen: Screen, ci: number, out: Cell): void {
   out.hyperlink = hid === 0 ? undefined : screen.hyperlinkPool.get(hid)
 }
 
-export function charInCellAt(
-  screen: Screen,
-  x: number,
-  y: number,
-): string | undefined {
-  if (x < 0 || y < 0 || x >= screen.width || y >= screen.height)
-    return undefined
+export function charInCellAt(screen: Screen, x: number, y: number): string | undefined {
+  if (x < 0 || y < 0 || x >= screen.width || y >= screen.height) return undefined
   const ci = (y * screen.width + x) << 1
   return screen.charPool.get(screen.cells[ci]!)
 }
@@ -690,12 +661,7 @@ export function charInCellAt(
  * wrap to the next line. This function doesn't need to handle SpacerHead
  * automatically - it will be set directly by the wrapping code.
  */
-export function setCellAt(
-  screen: Screen,
-  x: number,
-  y: number,
-  cell: Cell,
-): void {
+export function setCellAt(screen: Screen, x: number, y: number, cell: Cell): void {
   if (x < 0 || y < 0 || x >= screen.width || y >= screen.height) return
   const ci = (y * screen.width + x) << 1
   const cells = screen.cells
@@ -710,20 +676,13 @@ export function setCellAt(
       const spacerCI = ci + 2
       if ((cells[spacerCI + 1]! & WIDTH_MASK) === CellWidth.SpacerTail) {
         cells[spacerCI] = EMPTY_CHAR_INDEX
-        cells[spacerCI + 1] = packWord1(
-          screen.emptyStyleId,
-          0,
-          CellWidth.Narrow,
-        )
+        cells[spacerCI + 1] = packWord1(screen.emptyStyleId, 0, CellWidth.Narrow)
       }
     }
   }
   // Track cleared Wide position for damage expansion below
   let clearedWideX = -1
-  if (
-    prevWidth === CellWidth.SpacerTail &&
-    cell.width !== CellWidth.SpacerTail
-  ) {
+  if (prevWidth === CellWidth.SpacerTail && cell.width !== CellWidth.SpacerTail) {
     // Overwriting a SpacerTail: clear the orphaned Wide char at (x-1).
     // Keeping the wide character with Narrow width would cause the terminal
     // to still render it with width 2, desyncing the cursor model.
@@ -739,11 +698,7 @@ export function setCellAt(
 
   // Pack cell data into cells array
   cells[ci] = internCharString(screen, cell.char)
-  cells[ci + 1] = packWord1(
-    cell.styleId,
-    internHyperlink(screen, cell.hyperlink),
-    cell.width,
-  )
+  cells[ci + 1] = packWord1(cell.styleId, internHyperlink(screen, cell.hyperlink), cell.width)
 
   // Track damage - expand bounds in place instead of allocating new objects
   // Include the main cell position and any cleared orphan cells
@@ -786,19 +741,11 @@ export function setCellAt(
           (cells[orphanCI + 1]! & WIDTH_MASK) === CellWidth.SpacerTail
         ) {
           cells[orphanCI] = EMPTY_CHAR_INDEX
-          cells[orphanCI + 1] = packWord1(
-            screen.emptyStyleId,
-            0,
-            CellWidth.Narrow,
-          )
+          cells[orphanCI + 1] = packWord1(screen.emptyStyleId, 0, CellWidth.Narrow)
         }
       }
       cells[spacerCI] = SPACER_CHAR_INDEX
-      cells[spacerCI + 1] = packWord1(
-        screen.emptyStyleId,
-        0,
-        CellWidth.SpacerTail,
-      )
+      cells[spacerCI + 1] = packWord1(screen.emptyStyleId, 0, CellWidth.SpacerTail)
 
       // Expand damage to include SpacerTail so diff() scans it
       const d = screen.damage
@@ -814,12 +761,7 @@ export function setCellAt(
  * or hyperlink. Preserves empty cells as-is (char stays ' '). Tracks damage
  * for the cell so diffEach picks up the change.
  */
-export function setCellStyleId(
-  screen: Screen,
-  x: number,
-  y: number,
-  styleId: number,
-): void {
+export function setCellStyleId(screen: Screen, x: number, y: number, styleId: number): void {
   if (x < 0 || y < 0 || x >= screen.width || y >= screen.height) return
   const ci = (y * screen.width + x) << 1
   const cells = screen.cells
@@ -931,11 +873,7 @@ export function blitRegion(
     for (let y = regionY; y < maxY; y++) {
       if ((srcCells[srcLastCI + 1]! & WIDTH_MASK) === CellWidth.Wide) {
         dstCells[dstSpacerCI] = SPACER_CHAR_INDEX
-        dstCells[dstSpacerCI + 1] = packWord1(
-          dst.emptyStyleId,
-          0,
-          CellWidth.SpacerTail,
-        )
+        dstCells[dstSpacerCI + 1] = packWord1(dst.emptyStyleId, 0, CellWidth.SpacerTail)
         wroteSpacerOutsideRegion = true
       }
       srcLastCI += srcStride
@@ -980,11 +918,7 @@ export function clearRegion(
   // word0=EMPTY_CHAR_INDEX(0), word1=packWord1(0,0,0)=0
   if (startX === 0 && maxX === screenWidth) {
     // Full-width: single fill, no boundary checks needed
-    cells64.fill(
-      EMPTY_CELL_VALUE,
-      rowBase,
-      rowBase + (maxY - startY) * screenWidth,
-    )
+    cells64.fill(EMPTY_CELL_VALUE, rowBase, rowBase + (maxY - startY) * screenWidth)
   } else {
     // Partial-width: single loop handles boundary cleanup and fill per row.
     const stride = screenWidth << 1 // 2 Int32s per cell
@@ -1054,12 +988,7 @@ export function clearRegion(
  * noSelect bitmap are shifted so text-selection markers stay aligned when
  * this is applied to next.screen during scroll fast path.
  */
-export function shiftRows(
-  screen: Screen,
-  top: number,
-  bottom: number,
-  n: number,
-): void {
+export function shiftRows(screen: Screen, top: number, bottom: number, n: number): void {
   if (n === 0 || top < 0 || bottom >= screen.height || top > bottom) return
   const w = screen.width
   const cells64 = screen.cells64
@@ -1096,9 +1025,7 @@ const OSC8_REGEX = new RegExp(`^${ESC}\\]8${SEP}${SEP}([^${BEL}]*)${BEL}$`)
 // OSC8 prefix: ESC ] 8 ; — cheap check to skip regex for the vast majority of styles (SGR = ESC [)
 export const OSC8_PREFIX = `${ESC}]8${SEP}`
 
-export function extractHyperlinkFromStyles(
-  styles: AnsiCode[],
-): Hyperlink | null {
+export function extractHyperlinkFromStyles(styles: AnsiCode[]): Hyperlink | null {
   for (const style of styles) {
     const code = style.code
     if (code.length < 5 || !code.startsWith(OSC8_PREFIX)) continue
@@ -1112,8 +1039,7 @@ export function extractHyperlinkFromStyles(
 
 export function filterOutHyperlinkStyles(styles: AnsiCode[]): AnsiCode[] {
   return styles.filter(
-    style =>
-      !style.code.startsWith(OSC8_PREFIX) || !OSC8_REGEX.test(style.code),
+    (style) => !style.code.startsWith(OSC8_PREFIX) || !OSC8_REGEX.test(style.code),
   )
 }
 
@@ -1130,11 +1056,7 @@ export function diff(
   const output: [Point, Cell | undefined, Cell | undefined][] = []
   diffEach(prev, next, (x, y, removed, added) => {
     // Copy cells since diffEach reuses the objects
-    output.push([
-      { x, y },
-      removed ? { ...removed } : undefined,
-      added ? { ...added } : undefined,
-    ])
+    output.push([{ x, y }, removed ? { ...removed } : undefined, added ? { ...added } : undefined])
   })
   return output
 }
@@ -1153,11 +1075,7 @@ type DiffCallback = (
  *
  * Returns true if the callback ever returned true (early exit signal).
  */
-export function diffEach(
-  prev: Screen,
-  next: Screen,
-  cb: DiffCallback,
-): boolean {
+export function diffEach(prev: Screen, next: Screen, cb: DiffCallback): boolean {
   const prevWidth = prev.width
   const nextWidth = next.width
   const prevHeight = prev.height
@@ -1210,12 +1128,7 @@ export function diffEach(
  * Returns the number of matching cells before the first difference,
  * or `count` if all cells match. Tiny and pure for JIT inlining.
  */
-function findNextDiff(
-  a: Int32Array,
-  b: Int32Array,
-  w0: number,
-  count: number,
-): number {
+function findNextDiff(a: Int32Array, b: Int32Array, w0: number, count: number): number {
   for (let i = 0; i < count; i++, w0 += 2) {
     const w1 = w0 | 1
     if (a[w0] !== b[w0] || a[w1] !== b[w1]) return i
@@ -1356,13 +1269,9 @@ function diffSameWidth(
       )
         return true
     } else if (prevIn) {
-      if (diffRowRemoved(prev, rowCI, y, startX, rowEndX, prevCell, cb))
-        return true
+      if (diffRowRemoved(prev, rowCI, y, startX, rowEndX, prevCell, cb)) return true
     } else if (nextIn) {
-      if (
-        diffRowAdded(nextCells, next, rowCI, y, startX, rowEndX, nextCell, cb)
-      )
-        return true
+      if (diffRowAdded(nextCells, next, rowCI, y, startX, rowEndX, nextCell, cb)) return true
     }
 
     rowCI += stride

--- a/packages/renderer/src/screen.ts
+++ b/packages/renderer/src/screen.ts
@@ -440,15 +440,14 @@ export function createScreen(
   warn.ifNotInteger(width, 'createScreen width')
   warn.ifNotInteger(height, 'createScreen height')
 
-  // Ensure width and height are valid integers to prevent crashes
-  if (!Number.isInteger(width) || width < 0) {
-    width = Math.max(0, Math.floor(width) || 0)
-  }
-  if (!Number.isInteger(height) || height < 0) {
-    height = Math.max(0, Math.floor(height) || 0)
-  }
+  // Sanitize: clamp to non-negative integers. Yoga can hand us NaN or
+  // negatives in degenerate layouts; passing those into typed-array
+  // allocation crashes. Locals instead of param reassign for clarity.
+  const w = Number.isInteger(width) && width >= 0 ? width : Math.max(0, Math.floor(width) || 0)
+  const h =
+    Number.isInteger(height) && height >= 0 ? height : Math.max(0, Math.floor(height) || 0)
 
-  const size = width * height
+  const size = w * h
 
   // Allocate one buffer, two views: Int32Array for per-word access,
   // BigInt64Array for bulk fill in resetScreen/clearRegion.
@@ -459,8 +458,8 @@ export function createScreen(
   const cells64 = new BigInt64Array(buf)
 
   return {
-    width,
-    height,
+    width: w,
+    height: h,
     cells,
     cells64,
     charPool,
@@ -468,7 +467,7 @@ export function createScreen(
     emptyStyleId: styles.none,
     damage: undefined,
     noSelect: new Uint8Array(size),
-    softWrap: new Int32Array(height),
+    softWrap: new Int32Array(h),
   }
 }
 
@@ -484,15 +483,12 @@ export function resetScreen(screen: Screen, width: number, height: number): void
   warn.ifNotInteger(width, 'resetScreen width')
   warn.ifNotInteger(height, 'resetScreen height')
 
-  // Ensure width and height are valid integers to prevent crashes
-  if (!Number.isInteger(width) || width < 0) {
-    width = Math.max(0, Math.floor(width) || 0)
-  }
-  if (!Number.isInteger(height) || height < 0) {
-    height = Math.max(0, Math.floor(height) || 0)
-  }
+  // Sanitize: clamp to non-negative integers (see createScreen for rationale).
+  const w = Number.isInteger(width) && width >= 0 ? width : Math.max(0, Math.floor(width) || 0)
+  const h =
+    Number.isInteger(height) && height >= 0 ? height : Math.max(0, Math.floor(height) || 0)
 
-  const size = width * height
+  const size = w * h
 
   // Resize if needed (only grow, to avoid reallocations)
   if (screen.cells64.length < size) {
@@ -501,18 +497,18 @@ export function resetScreen(screen: Screen, width: number, height: number): void
     screen.cells64 = new BigInt64Array(buf)
     screen.noSelect = new Uint8Array(size)
   }
-  if (screen.softWrap.length < height) {
-    screen.softWrap = new Int32Array(height)
+  if (screen.softWrap.length < h) {
+    screen.softWrap = new Int32Array(h)
   }
 
   // Reset all cells — single fill call, no loop
   screen.cells64.fill(EMPTY_CELL_VALUE, 0, size)
   screen.noSelect.fill(0, 0, size)
-  screen.softWrap.fill(0, 0, height)
+  screen.softWrap.fill(0, 0, h)
 
   // Update dimensions
-  screen.width = width
-  screen.height = height
+  screen.width = w
+  screen.height = h
 
   // Shared pools accumulate — no clearing needed. Unique char/hyperlink sets are bounded.
 

--- a/packages/renderer/src/searchHighlight.ts
+++ b/packages/renderer/src/searchHighlight.ts
@@ -1,10 +1,4 @@
-import {
-  CellWidth,
-  cellAtIndex,
-  type Screen,
-  type StylePool,
-  setCellStyleId,
-} from './screen'
+import { CellWidth, cellAtIndex, type Screen, type StylePool, setCellStyleId } from './screen'
 
 /**
  * Highlight all visible occurrences of `query` in the screen buffer by
@@ -24,11 +18,7 @@ import {
  * Returns true if any match was highlighted (damage gate — caller forces
  * full-frame damage when true).
  */
-export function applySearchHighlight(
-  screen: Screen,
-  query: string,
-  stylePool: StylePool,
-): boolean {
+export function applySearchHighlight(screen: Screen, query: string, stylePool: StylePool): boolean {
   if (!query) return false
   const lq = query.toLowerCase()
   const qlen = lq.length
@@ -91,4 +81,3 @@ export function applySearchHighlight(
 
   return applied
 }
-

--- a/packages/renderer/src/searchHighlight.ts
+++ b/packages/renderer/src/searchHighlight.ts
@@ -1,4 +1,4 @@
-import { CellWidth, cellAtIndex, type Screen, type StylePool, setCellStyleId } from './screen'
+import { CellWidth, type Screen, type StylePool, cellAtIndex, setCellStyleId } from './screen'
 
 /**
  * Highlight all visible occurrences of `query` in the screen buffer by

--- a/packages/renderer/src/selection.ts
+++ b/packages/renderer/src/selection.ts
@@ -301,7 +301,9 @@ export function findPlainTextUrlAt(screen: Screen, col: number, row: number): st
   const schemeRe = /(?:https?|file):\/\//g
   let urlStart = -1
   let urlEnd = token.length
-  for (let m; (m = schemeRe.exec(token)); ) {
+  while (true) {
+    const m = schemeRe.exec(token)
+    if (!m) break
     if (m.index > clickIdx) {
       urlEnd = m.index
       break

--- a/packages/renderer/src/selection.ts
+++ b/packages/renderer/src/selection.ts
@@ -76,11 +76,7 @@ export function createSelectionState(): SelectionState {
   }
 }
 
-export function startSelection(
-  s: SelectionState,
-  col: number,
-  row: number,
-): void {
+export function startSelection(s: SelectionState, col: number, row: number): void {
   s.anchor = { col, row }
   // Focus is not set until the first drag motion. A click-release with no
   // drag leaves focus null → hasSelection/selectionBounds return false/null
@@ -97,19 +93,14 @@ export function startSelection(
   s.lastPressHadAlt = false
 }
 
-export function updateSelection(
-  s: SelectionState,
-  col: number,
-  row: number,
-): void {
+export function updateSelection(s: SelectionState, col: number, row: number): void {
   if (!s.isDragging) return
   // First motion at the same cell as anchor is a no-op. Terminals in mode
   // 1002 can fire a drag event at the anchor cell (sub-pixel tremor, or a
   // motion-release pair). Setting focus here would turn a bare click into
   // a 1-cell selection and clobber the clipboard via useCopyOnSelect. Once
   // focus is set (real drag), we track normally including back to anchor.
-  if (!s.focus && s.anchor && s.anchor.col === col && s.anchor.row === row)
-    return
+  if (!s.focus && s.anchor && s.anchor.col === col && s.anchor.row === row) return
   s.focus = { col, row }
   // User moved the mouse to a new screen position — any accumulated
   // text-relative tracking from drag-to-scroll frames no longer applies.
@@ -162,11 +153,7 @@ function charClass(c: string): 0 | 1 | 2 {
  * null if the click is out of bounds or lands on a noSelect cell. Used by
  * selectWordAt (initial double-click) and extendWordSelection (drag).
  */
-function wordBoundsAt(
-  screen: Screen,
-  col: number,
-  row: number,
-): { lo: number; hi: number } | null {
+function wordBoundsAt(screen: Screen, col: number, row: number): { lo: number; hi: number } | null {
   if (row < 0 || row >= screen.height) return null
   const width = screen.width
   const noSelect = screen.noSelect
@@ -240,12 +227,7 @@ function comparePoints(a: Point, b: Point): number {
  * Sets isDragging=true and anchorSpan so a subsequent drag extends the
  * selection word-by-word (native macOS behavior).
  */
-export function selectWordAt(
-  s: SelectionState,
-  screen: Screen,
-  col: number,
-  row: number,
-): void {
+export function selectWordAt(s: SelectionState, screen: Screen, col: number, row: number): void {
   const b = wordBoundsAt(screen, col, row)
   if (!b) return
   const lo = { col: b.lo, row }
@@ -272,11 +254,7 @@ function isUrlChar(c: string): boolean {
  * tracking intercepts. Called from getHyperlinkAt as a fallback when the
  * cell has no OSC 8 hyperlink.
  */
-export function findPlainTextUrlAt(
-  screen: Screen,
-  col: number,
-  row: number,
-): string | undefined {
+export function findPlainTextUrlAt(screen: Screen, col: number, row: number): string | undefined {
   if (row < 0 || row >= screen.height) return undefined
   const width = screen.width
   const noSelect = screen.noSelect
@@ -368,11 +346,7 @@ export function findPlainTextUrlAt(
  * and trailing-whitespace trimming so the copied text is just the visible
  * line content.
  */
-export function selectLineAt(
-  s: SelectionState,
-  screen: Screen,
-  row: number,
-): void {
+export function selectLineAt(s: SelectionState, screen: Screen, row: number): void {
   if (row < 0 || row >= screen.height) return
   const lo = { col: 0, row }
   const hi = { col: screen.width - 1, row }
@@ -389,12 +363,7 @@ export function selectLineAt(
  * position. Word mode falls back to the raw cell when the mouse is over a
  * noSelect cell or out of bounds, so dragging into gutters still extends.
  */
-export function extendSelection(
-  s: SelectionState,
-  screen: Screen,
-  col: number,
-  row: number,
-): void {
+export function extendSelection(s: SelectionState, screen: Screen, col: number, row: number): void {
   if (!s.isDragging || !s.anchorSpan) return
   const span = s.anchorSpan
   let mLo: Point
@@ -425,13 +394,7 @@ export function extendSelection(
 
 /** Semantic keyboard focus moves. See moveSelectionFocus in ink.tsx for
  *  how screen bounds + row-wrap are applied. */
-export type FocusMove =
-  | 'left'
-  | 'right'
-  | 'up'
-  | 'down'
-  | 'lineStart'
-  | 'lineEnd'
+export type FocusMove = 'left' | 'right' | 'up' | 'down' | 'lineStart' | 'lineEnd'
 
 /**
  * Set focus to (col, row) for keyboard selection extension (shift+arrow).
@@ -483,24 +446,15 @@ export function shiftSelection(
   // and scrolledOffAbove stays stale (highlight ≠ copy).
   const vAnchor = (s.virtualAnchorRow ?? s.anchor.row) + dRow
   const vFocus = (s.virtualFocusRow ?? s.focus.row) + dRow
-  if (
-    (vAnchor < minRow && vFocus < minRow) ||
-    (vAnchor > maxRow && vFocus > maxRow)
-  ) {
+  if ((vAnchor < minRow && vFocus < minRow) || (vAnchor > maxRow && vFocus > maxRow)) {
     clearSelection(s)
     return
   }
   // Debt = how far the nearer endpoint overshoots each edge. When debt
   // shrinks (reverse scroll), those rows are back on-screen — pop from
   // the accumulator so getSelectedText doesn't double-count them.
-  const oldMin = Math.min(
-    s.virtualAnchorRow ?? s.anchor.row,
-    s.virtualFocusRow ?? s.focus.row,
-  )
-  const oldMax = Math.max(
-    s.virtualAnchorRow ?? s.anchor.row,
-    s.virtualFocusRow ?? s.focus.row,
-  )
+  const oldMin = Math.min(s.virtualAnchorRow ?? s.anchor.row, s.virtualFocusRow ?? s.focus.row)
+  const oldMax = Math.max(s.virtualAnchorRow ?? s.anchor.row, s.virtualFocusRow ?? s.focus.row)
   const oldAboveDebt = Math.max(0, minRow - oldMin)
   const oldBelowDebt = Math.max(0, oldMax - maxRow)
   const newAboveDebt = Math.max(0, minRow - Math.min(vAnchor, vFocus))
@@ -527,10 +481,8 @@ export function shiftSelection(
   // that's the normal establish-debt path, not stale.
   if (s.scrolledOffAbove.length > newAboveDebt) {
     // Above pushes newest at END → keep END.
-    s.scrolledOffAbove =
-      newAboveDebt > 0 ? s.scrolledOffAbove.slice(-newAboveDebt) : []
-    s.scrolledOffAboveSW =
-      newAboveDebt > 0 ? s.scrolledOffAboveSW.slice(-newAboveDebt) : []
+    s.scrolledOffAbove = newAboveDebt > 0 ? s.scrolledOffAbove.slice(-newAboveDebt) : []
+    s.scrolledOffAboveSW = newAboveDebt > 0 ? s.scrolledOffAboveSW.slice(-newAboveDebt) : []
   }
   if (s.scrolledOffBelow.length > newBelowDebt) {
     // Below unshifts newest at FRONT → keep FRONT.
@@ -547,8 +499,7 @@ export function shiftSelection(
   }
   s.anchor = shift(s.anchor, vAnchor)
   s.focus = shift(s.focus, vFocus)
-  s.virtualAnchorRow =
-    vAnchor < minRow || vAnchor > maxRow ? vAnchor : undefined
+  s.virtualAnchorRow = vAnchor < minRow || vAnchor > maxRow ? vAnchor : undefined
   s.virtualFocusRow = vFocus < minRow || vFocus > maxRow ? vFocus : undefined
   // anchorSpan not virtual-tracked: it's for word/line extend-on-drag,
   // irrelevant to the keyboard-scroll round-trip case.
@@ -573,12 +524,7 @@ export function shiftSelection(
  * was under the anchor is now at a different viewport row, so the anchor
  * must follow it. Focus is left unchanged (it stays at the mouse position).
  */
-export function shiftAnchor(
-  s: SelectionState,
-  dRow: number,
-  minRow: number,
-  maxRow: number,
-): void {
+export function shiftAnchor(s: SelectionState, dRow: number, minRow: number, maxRow: number): void {
   if (!s.anchor) return
   // Same virtual-row tracking as shiftSelection/shiftSelectionForFollow: the
   // drag→follow transition hands off to shiftSelectionForFollow, which reads
@@ -641,9 +587,7 @@ export function shiftSelectionForFollow(
   // clamped row instead of the true pre-clamp row and never pops the
   // accumulator — getSelectedText double-counts the off-screen rows.
   const rawAnchor = (s.virtualAnchorRow ?? s.anchor.row) + dRow
-  const rawFocus = s.focus
-    ? (s.virtualFocusRow ?? s.focus.row) + dRow
-    : undefined
+  const rawFocus = s.focus ? (s.virtualFocusRow ?? s.focus.row) + dRow : undefined
   if (rawAnchor < minRow && rawFocus !== undefined && rawFocus < minRow) {
     clearSelection(s)
     return true
@@ -654,12 +598,9 @@ export function shiftSelectionForFollow(
   if (s.focus && rawFocus !== undefined) {
     s.focus = { col: s.focus.col, row: clamp(rawFocus, minRow, maxRow) }
   }
-  s.virtualAnchorRow =
-    rawAnchor < minRow || rawAnchor > maxRow ? rawAnchor : undefined
+  s.virtualAnchorRow = rawAnchor < minRow || rawAnchor > maxRow ? rawAnchor : undefined
   s.virtualFocusRow =
-    rawFocus !== undefined && (rawFocus < minRow || rawFocus > maxRow)
-      ? rawFocus
-      : undefined
+    rawFocus !== undefined && (rawFocus < minRow || rawFocus > maxRow) ? rawFocus : undefined
   // anchorSpan not virtual-tracked (word/line extend, irrelevant to
   // keyboard-scroll round-trip) — plain clamp from current row.
   if (s.anchorSpan) {
@@ -698,11 +639,7 @@ export function selectionBounds(s: SelectionState): {
  * Check if a cell at (col, row) is within the current selection range.
  * Used by the renderer to apply inverse style.
  */
-export function isCellSelected(
-  s: SelectionState,
-  col: number,
-  row: number,
-): boolean {
+export function isCellSelected(s: SelectionState, col: number, row: number): boolean {
   const b = selectionBounds(s)
   if (!b) return false
   const { start, end } = b
@@ -716,12 +653,7 @@ export function isCellSelected(
  *  continuation (screen.softWrap[row+1]>0), clamp to that content-end
  *  column and skip the trailing trim so the word-separator space survives
  *  the join. See Screen.softWrap for why the clamp is necessary. */
-function extractRowText(
-  screen: Screen,
-  row: number,
-  colStart: number,
-  colEnd: number,
-): string {
+function extractRowText(screen: Screen, row: number, colStart: number, colEnd: number): string {
   const noSelect = screen.noSelect
   const rowOff = row * screen.width
   const contentEnd = row + 1 < screen.height ? screen.softWrap[row + 1]! : 0
@@ -735,10 +667,7 @@ function extractRowText(
     if (!cell) continue
     // Skip spacer tails (second half of wide chars) — the head already
     // contains the full grapheme. SpacerHead is a blank at line-end.
-    if (
-      cell.width === CellWidth.SpacerTail ||
-      cell.width === CellWidth.SpacerHead
-    ) {
+    if (cell.width === CellWidth.SpacerTail || cell.width === CellWidth.SpacerHead) {
       continue
     }
     line += cell.char
@@ -750,11 +679,7 @@ function extractRowText(
  *  into logical lines. push(text, sw) appends a newline before text
  *  only when sw=false (i.e. the row starts a new logical line). Rows
  *  with sw=true are concatenated onto the previous row. */
-function joinRows(
-  lines: string[],
-  text: string,
-  sw: boolean | undefined,
-): void {
+function joinRows(lines: string[], text: string, sw: boolean | undefined): void {
   if (sw && lines.length > 0) {
     lines[lines.length - 1] += text
   } else {

--- a/packages/renderer/src/squash-text-nodes.ts
+++ b/packages/renderer/src/squash-text-nodes.ts
@@ -38,24 +38,11 @@ export function squashTextNodesToSegments(
           hyperlink: inheritedHyperlink,
         })
       }
-    } else if (
-      childNode.nodeName === 'ink-text' ||
-      childNode.nodeName === 'ink-virtual-text'
-    ) {
-      squashTextNodesToSegments(
-        childNode,
-        mergedStyles,
-        inheritedHyperlink,
-        out,
-      )
+    } else if (childNode.nodeName === 'ink-text' || childNode.nodeName === 'ink-virtual-text') {
+      squashTextNodesToSegments(childNode, mergedStyles, inheritedHyperlink, out)
     } else if (childNode.nodeName === 'ink-link') {
       const href = childNode.attributes['href'] as string | undefined
-      squashTextNodesToSegments(
-        childNode,
-        mergedStyles,
-        href || inheritedHyperlink,
-        out,
-      )
+      squashTextNodesToSegments(childNode, mergedStyles, href || inheritedHyperlink, out)
     }
   }
 
@@ -76,10 +63,7 @@ function squashTextNodes(node: DOMElement): string {
 
     if (childNode.nodeName === '#text') {
       text += childNode.nodeValue
-    } else if (
-      childNode.nodeName === 'ink-text' ||
-      childNode.nodeName === 'ink-virtual-text'
-    ) {
+    } else if (childNode.nodeName === 'ink-text' || childNode.nodeName === 'ink-virtual-text') {
       text += squashTextNodes(childNode)
     } else if (childNode.nodeName === 'ink-link') {
       text += squashTextNodes(childNode)
@@ -90,4 +74,3 @@ function squashTextNodes(node: DOMElement): string {
 }
 
 export default squashTextNodes
-

--- a/packages/renderer/src/squash-text-nodes.ts
+++ b/packages/renderer/src/squash-text-nodes.ts
@@ -41,7 +41,7 @@ export function squashTextNodesToSegments(
     } else if (childNode.nodeName === 'ink-text' || childNode.nodeName === 'ink-virtual-text') {
       squashTextNodesToSegments(childNode, mergedStyles, inheritedHyperlink, out)
     } else if (childNode.nodeName === 'ink-link') {
-      const href = childNode.attributes['href'] as string | undefined
+      const href = childNode.attributes.href as string | undefined
       squashTextNodesToSegments(childNode, mergedStyles, href || inheritedHyperlink, out)
     }
   }

--- a/packages/renderer/src/stringWidth.ts
+++ b/packages/renderer/src/stringWidth.ts
@@ -203,4 +203,3 @@ function isZeroWidth(codePoint: number): boolean {
 }
 
 export const stringWidth: (str: string) => number = stringWidthJavaScript
-

--- a/packages/renderer/src/stringWidth.ts
+++ b/packages/renderer/src/stringWidth.ts
@@ -1,7 +1,7 @@
+import { getGraphemeSegmenter } from '@yokai/shared'
 import emojiRegex from 'emoji-regex'
 import { eastAsianWidth } from 'get-east-asian-width'
 import stripAnsi from 'strip-ansi'
-import { getGraphemeSegmenter } from '@yokai/shared'
 
 const EMOJI_REGEX = emojiRegex()
 

--- a/packages/renderer/src/stringWidth.ts
+++ b/packages/renderer/src/stringWidth.ts
@@ -17,10 +17,14 @@ const EMOJI_REGEX = emojiRegex()
  * which correctly treats ambiguous-width characters as narrow (width 1) as
  * recommended by the Unicode standard for Western contexts.
  */
-function stringWidthJavaScript(str: string): number {
-  if (typeof str !== 'string' || str.length === 0) {
+function stringWidthJavaScript(input: string): number {
+  if (typeof input !== 'string' || input.length === 0) {
     return 0
   }
+  // Local mutable copy: the ANSI-strip branch below reassigns. Avoiding
+  // parameter reassignment keeps the signature's intent clear (input is
+  // never observably mutated for callers) and satisfies noParameterAssign.
+  let str = input
 
   // Fast path: pure ASCII string (no ANSI codes, no wide chars)
   let isPureAscii = true

--- a/packages/renderer/src/styles.ts
+++ b/packages/renderer/src/styles.ts
@@ -408,9 +408,7 @@ export type Styles = {
 const applyPositionStyles = (node: LayoutNode, style: Styles): void => {
   if ('position' in style) {
     node.setPositionType(
-      style.position === 'absolute'
-        ? LayoutPositionType.Absolute
-        : LayoutPositionType.Relative,
+      style.position === 'absolute' ? LayoutPositionType.Absolute : LayoutPositionType.Relative,
     )
   }
   if ('top' in style) applyPositionEdge(node, 'top', style.top)
@@ -444,11 +442,7 @@ const applyOverflowStyles = (node: LayoutNode, style: Styles): void => {
     node.setOverflow(LayoutOverflow.Scroll)
   } else if (y === 'hidden' || x === 'hidden') {
     node.setOverflow(LayoutOverflow.Hidden)
-  } else if (
-    'overflow' in style ||
-    'overflowX' in style ||
-    'overflowY' in style
-  ) {
+  } else if ('overflow' in style || 'overflowX' in style || 'overflowY' in style) {
     node.setOverflow(LayoutOverflow.Visible)
   }
 }
@@ -519,9 +513,7 @@ const applyFlexStyles = (node: LayoutNode, style: Styles): void => {
   }
 
   if ('flexShrink' in style) {
-    node.setFlexShrink(
-      typeof style.flexShrink === 'number' ? style.flexShrink : 1,
-    )
+    node.setFlexShrink(typeof style.flexShrink === 'number' ? style.flexShrink : 1)
   }
 
   if ('flexWrap' in style) {
@@ -685,17 +677,11 @@ const applyDimensionStyles = (node: LayoutNode, style: Styles): void => {
 
 const applyDisplayStyles = (node: LayoutNode, style: Styles): void => {
   if ('display' in style) {
-    node.setDisplay(
-      style.display === 'flex' ? LayoutDisplay.Flex : LayoutDisplay.None,
-    )
+    node.setDisplay(style.display === 'flex' ? LayoutDisplay.Flex : LayoutDisplay.None)
   }
 }
 
-const applyBorderStyles = (
-  node: LayoutNode,
-  style: Styles,
-  resolvedStyle?: Styles,
-): void => {
+const applyBorderStyles = (node: LayoutNode, style: Styles, resolvedStyle?: Styles): void => {
   // resolvedStyle is the full current style (already set on the DOM node).
   // style may be a diff with only changed properties. For border side props,
   // we need the resolved value because `borderStyle` in a diff may not include
@@ -705,22 +691,10 @@ const applyBorderStyles = (
   if ('borderStyle' in style) {
     const borderWidth = style.borderStyle ? 1 : 0
 
-    node.setBorder(
-      LayoutEdge.Top,
-      resolved.borderTop !== false ? borderWidth : 0,
-    )
-    node.setBorder(
-      LayoutEdge.Bottom,
-      resolved.borderBottom !== false ? borderWidth : 0,
-    )
-    node.setBorder(
-      LayoutEdge.Left,
-      resolved.borderLeft !== false ? borderWidth : 0,
-    )
-    node.setBorder(
-      LayoutEdge.Right,
-      resolved.borderRight !== false ? borderWidth : 0,
-    )
+    node.setBorder(LayoutEdge.Top, resolved.borderTop !== false ? borderWidth : 0)
+    node.setBorder(LayoutEdge.Bottom, resolved.borderBottom !== false ? borderWidth : 0)
+    node.setBorder(LayoutEdge.Left, resolved.borderLeft !== false ? borderWidth : 0)
+    node.setBorder(LayoutEdge.Right, resolved.borderRight !== false ? borderWidth : 0)
   } else {
     // Handle individual border property changes (when only borderX changes without borderStyle).
     // Skip undefined values — they mean the prop was removed or never set,
@@ -754,11 +728,7 @@ const applyGapStyles = (node: LayoutNode, style: Styles): void => {
   }
 }
 
-const styles = (
-  node: LayoutNode,
-  style: Styles = {},
-  resolvedStyle?: Styles,
-): void => {
+const styles = (node: LayoutNode, style: Styles = {}, resolvedStyle?: Styles): void => {
   applyPositionStyles(node, style)
   applyOverflowStyles(node, style)
   applyMarginStyles(node, style)
@@ -771,4 +741,3 @@ const styles = (
 }
 
 export default styles
-

--- a/packages/renderer/src/supports-hyperlinks.ts
+++ b/packages/renderer/src/supports-hyperlinks.ts
@@ -32,20 +32,20 @@ export function supportsHyperlinks(options?: SupportsHyperlinksOptions): boolean
   const env = options?.env ?? process.env
 
   // Check for additional terminals not detected by supports-hyperlinks
-  const termProgram = env['TERM_PROGRAM']
+  const termProgram = env.TERM_PROGRAM
   if (termProgram && ADDITIONAL_HYPERLINK_TERMINALS.includes(termProgram)) {
     return true
   }
 
   // LC_TERMINAL is set by some terminals (e.g. iTerm2) and preserved inside tmux,
   // where TERM_PROGRAM is overwritten to 'tmux'.
-  const lcTerminal = env['LC_TERMINAL']
+  const lcTerminal = env.LC_TERMINAL
   if (lcTerminal && ADDITIONAL_HYPERLINK_TERMINALS.includes(lcTerminal)) {
     return true
   }
 
   // Kitty sets TERM=xterm-kitty
-  const term = env['TERM']
+  const term = env.TERM
   if (term?.includes('kitty')) {
     return true
   }

--- a/packages/renderer/src/supports-hyperlinks.ts
+++ b/packages/renderer/src/supports-hyperlinks.ts
@@ -23,11 +23,8 @@ type SupportsHyperlinksOptions = {
  * Extends the supports-hyperlinks library with additional terminal detection.
  * @param options Optional overrides for testing (env, stdoutSupported)
  */
-export function supportsHyperlinks(
-  options?: SupportsHyperlinksOptions,
-): boolean {
-  const stdoutSupported =
-    options?.stdoutSupported ?? supportsHyperlinksLib.stdout
+export function supportsHyperlinks(options?: SupportsHyperlinksOptions): boolean {
+  const stdoutSupported = options?.stdoutSupported ?? supportsHyperlinksLib.stdout
   if (stdoutSupported) {
     return true
   }
@@ -55,4 +52,3 @@ export function supportsHyperlinks(
 
   return false
 }
-

--- a/packages/renderer/src/tabstops.ts
+++ b/packages/renderer/src/tabstops.ts
@@ -6,10 +6,7 @@ import { createTokenizer } from './termio/tokenize'
 
 const DEFAULT_TAB_INTERVAL = 8
 
-export function expandTabs(
-  text: string,
-  interval = DEFAULT_TAB_INTERVAL,
-): string {
+export function expandTabs(text: string, interval = DEFAULT_TAB_INTERVAL): string {
   if (!text.includes('\t')) {
     return text
   }
@@ -44,4 +41,3 @@ export function expandTabs(
 
   return result
 }
-

--- a/packages/renderer/src/terminal-focus-state.ts
+++ b/packages/renderer/src/terminal-focus-state.ts
@@ -45,4 +45,3 @@ export function resetTerminalFocusState(): void {
     cb()
   }
 }
-

--- a/packages/renderer/src/terminal-querier.ts
+++ b/packages/renderer/src/terminal-querier.ts
@@ -145,14 +145,12 @@ export class TerminalQuerier {
    * Never rejects; never times out on its own. If you never call flush()
    * and the terminal doesn't respond, the promise remains pending.
    */
-  send<T extends TerminalResponse>(
-    query: TerminalQuery<T>,
-  ): Promise<T | undefined> {
-    return new Promise(resolve => {
+  send<T extends TerminalResponse>(query: TerminalQuery<T>): Promise<T | undefined> {
+    return new Promise((resolve) => {
       this.queue.push({
         kind: 'query',
         match: query.match,
-        resolve: r => resolve(r as T | undefined),
+        resolve: (r) => resolve(r as T | undefined),
       })
       this.stdout.write(query.request)
     })
@@ -168,7 +166,7 @@ export class TerminalQuerier {
    * Safe to call with no pending queries — still waits for a round-trip.
    */
   flush(): Promise<void> {
-    return new Promise(resolve => {
+    return new Promise((resolve) => {
       this.queue.push({ kind: 'sentinel', resolve })
       this.stdout.write(SENTINEL)
     })
@@ -193,7 +191,7 @@ export class TerminalQuerier {
    * - Unsolicited responses (no match, no sentinel) are silently dropped.
    */
   onResponse(r: TerminalResponse): void {
-    const idx = this.queue.findIndex(p => p.kind === 'query' && p.match(r))
+    const idx = this.queue.findIndex((p) => p.kind === 'query' && p.match(r))
     if (idx !== -1) {
       const [q] = this.queue.splice(idx, 1)
       if (q?.kind === 'query') q.resolve(r)
@@ -201,7 +199,7 @@ export class TerminalQuerier {
     }
 
     if (r.type === 'da1') {
-      const s = this.queue.findIndex(p => p.kind === 'sentinel')
+      const s = this.queue.findIndex((p) => p.kind === 'sentinel')
       if (s === -1) return
       for (const p of this.queue.splice(0, s + 1)) {
         if (p.kind === 'query') p.resolve(undefined)
@@ -210,4 +208,3 @@ export class TerminalQuerier {
     }
   }
 }
-

--- a/packages/renderer/src/terminal.ts
+++ b/packages/renderer/src/terminal.ts
@@ -1,6 +1,6 @@
-import { coerce } from 'semver'
 import type { Writable } from 'stream'
 import { env, gte } from '@yokai/shared'
+import { coerce } from 'semver'
 import { getClearTerminalSequence } from './clearTerminal'
 import type { Diff } from './frame'
 import { cursorMove, cursorTo, eraseLines } from './termio/csi'
@@ -105,7 +105,7 @@ export function isSynchronizedOutputSupported(): boolean {
   // VTE-based terminals (GNOME Terminal, Tilix, etc.) since VTE 0.68
   const vteVersion = process.env.VTE_VERSION
   if (vteVersion) {
-    const version = parseInt(vteVersion, 10)
+    const version = Number.parseInt(vteVersion, 10)
     if (version >= 6800) return true
   }
 

--- a/packages/renderer/src/terminal.ts
+++ b/packages/renderer/src/terminal.ts
@@ -1,4 +1,4 @@
-import type { Writable } from 'stream'
+import type { Writable } from 'node:stream'
 import { env, gte } from '@yokai/shared'
 import { coerce } from 'semver'
 import { getClearTerminalSequence } from './clearTerminal'

--- a/packages/renderer/src/terminal.ts
+++ b/packages/renderer/src/terminal.ts
@@ -34,11 +34,7 @@ export function isProgressReportingAvailable(): boolean {
   }
 
   // ConEmu supports OSC 9;4 for progress (all versions)
-  if (
-    process.env.ConEmuANSI ||
-    process.env.ConEmuPID ||
-    process.env.ConEmuTask
-  ) {
+  if (process.env.ConEmuANSI || process.env.ConEmuPID || process.env.ConEmuTask) {
     return true
   }
 
@@ -186,11 +182,7 @@ export type Terminal = {
   stderr: Writable
 }
 
-export function writeDiffToTerminal(
-  terminal: Terminal,
-  diff: Diff,
-  skipSyncMarkers = false,
-): void {
+export function writeDiffToTerminal(terminal: Terminal, diff: Diff, skipSyncMarkers = false): void {
   // No output if there are no patches
   if (diff.length === 0) {
     return

--- a/packages/renderer/src/termio.ts
+++ b/packages/renderer/src/termio.ts
@@ -40,4 +40,3 @@ export type {
   UnderlineStyle,
 } from './termio/types'
 export { colorsEqual, defaultStyle, stylesEqual } from './termio/types'
-

--- a/packages/renderer/src/termio/ansi.ts
+++ b/packages/renderer/src/termio/ansi.ts
@@ -73,4 +73,3 @@ export function isC0(byte: number): boolean {
 export function isEscFinal(byte: number): boolean {
   return byte >= 0x30 && byte <= 0x7e
 }
-

--- a/packages/renderer/src/termio/csi.ts
+++ b/packages/renderer/src/termio/csi.ts
@@ -27,9 +27,7 @@ export function isCSIParam(byte: number): boolean {
 
 /** Check if a byte is a CSI intermediate byte */
 export function isCSIIntermediate(byte: number): boolean {
-  return (
-    byte >= CSI_RANGE.INTERMEDIATE_START && byte <= CSI_RANGE.INTERMEDIATE_END
-  )
+  return byte >= CSI_RANGE.INTERMEDIATE_START && byte <= CSI_RANGE.INTERMEDIATE_END
 }
 
 /** Check if a byte is a CSI final byte (@ through ~) */
@@ -317,4 +315,3 @@ export const ENABLE_MODIFY_OTHER_KEYS = csi('>4;2m')
  * Disable xterm modifyOtherKeys (reset to default).
  */
 export const DISABLE_MODIFY_OTHER_KEYS = csi('>4m')
-

--- a/packages/renderer/src/termio/dec.ts
+++ b/packages/renderer/src/termio/dec.ts
@@ -58,4 +58,3 @@ export const DISABLE_MOUSE_TRACKING =
   decreset(DEC.MOUSE_ANY) +
   decreset(DEC.MOUSE_BUTTON) +
   decreset(DEC.MOUSE_NORMAL)
-

--- a/packages/renderer/src/termio/esc.ts
+++ b/packages/renderer/src/termio/esc.ts
@@ -65,4 +65,3 @@ export function parseEsc(chars: string): Action | null {
   // Unknown
   return { type: 'unknown', sequence: `\x1b${chars}` }
 }
-

--- a/packages/renderer/src/termio/osc.ts
+++ b/packages/renderer/src/termio/osc.ts
@@ -248,7 +248,7 @@ export function parseOSC(content: string): Action | null {
   const command = semicolonIdx >= 0 ? content.slice(0, semicolonIdx) : content
   const data = semicolonIdx >= 0 ? content.slice(semicolonIdx + 1) : ''
 
-  const commandNum = parseInt(command, 10)
+  const commandNum = Number.parseInt(command, 10)
 
   // Window/icon title
   if (commandNum === OSC.SET_TITLE_AND_ICON) {
@@ -309,15 +309,15 @@ export function parseOscColor(spec: string): Color | null {
   if (hex) {
     return {
       type: 'rgb',
-      r: parseInt(hex[1]!, 16),
-      g: parseInt(hex[2]!, 16),
-      b: parseInt(hex[3]!, 16),
+      r: Number.parseInt(hex[1]!, 16),
+      g: Number.parseInt(hex[2]!, 16),
+      b: Number.parseInt(hex[3]!, 16),
     }
   }
   const rgb = spec.match(/^rgb:([0-9a-f]{1,4})\/([0-9a-f]{1,4})\/([0-9a-f]{1,4})$/i)
   if (rgb) {
     // XParseColor: N hex digits → value / (16^N - 1), scale to 0-255
-    const scale = (s: string) => Math.round((parseInt(s, 16) / (16 ** s.length - 1)) * 255)
+    const scale = (s: string) => Math.round((Number.parseInt(s, 16) / (16 ** s.length - 1)) * 255)
     return {
       type: 'rgb',
       r: scale(rgb[1]!),

--- a/packages/renderer/src/termio/osc.ts
+++ b/packages/renderer/src/termio/osc.ts
@@ -61,8 +61,7 @@ export function wrapForMultiplexer(sequence: string): string {
 export type ClipboardPath = 'native' | 'tmux-buffer' | 'osc52'
 
 export function getClipboardPath(): ClipboardPath {
-  const nativeAvailable =
-    process.platform === 'darwin' && !process.env['SSH_CONNECTION']
+  const nativeAvailable = process.platform === 'darwin' && !process.env['SSH_CONNECTION']
   if (nativeAvailable) return 'native'
   if (process.env['TMUX']) return 'tmux-buffer'
   return 'osc52'
@@ -89,9 +88,7 @@ function tmuxPassthrough(payload: string): string {
 export async function tmuxLoadBuffer(text: string): Promise<boolean> {
   if (!process.env['TMUX']) return false
   const args =
-    process.env['LC_TERMINAL'] === 'iTerm2'
-      ? ['load-buffer', '-']
-      : ['load-buffer', '-w', '-']
+    process.env['LC_TERMINAL'] === 'iTerm2' ? ['load-buffer', '-'] : ['load-buffer', '-w', '-']
   const { code } = await execFileNoThrow('tmux', args, {
     input: text,
     useCwd: false,
@@ -186,24 +183,20 @@ function copyNative(text: string): void {
         return
       }
       // First call: probe wl-copy (Wayland) then xclip/xsel (X11), cache winner.
-      void execFileNoThrow('wl-copy', [], opts).then(r => {
+      void execFileNoThrow('wl-copy', [], opts).then((r) => {
         if (r.code === 0) {
           linuxCopy = 'wl-copy'
           return
         }
-        void execFileNoThrow('xclip', ['-selection', 'clipboard'], opts).then(
-          r2 => {
-            if (r2.code === 0) {
-              linuxCopy = 'xclip'
-              return
-            }
-            void execFileNoThrow('xsel', ['--clipboard', '--input'], opts).then(
-              r3 => {
-                linuxCopy = r3.code === 0 ? 'xsel' : null
-              },
-            )
-          },
-        )
+        void execFileNoThrow('xclip', ['-selection', 'clipboard'], opts).then((r2) => {
+          if (r2.code === 0) {
+            linuxCopy = 'xclip'
+            return
+          }
+          void execFileNoThrow('xsel', ['--clipboard', '--input'], opts).then((r3) => {
+            linuxCopy = r3.code === 0 ? 'xsel' : null
+          })
+        })
       })
       return
     }
@@ -321,13 +314,10 @@ export function parseOscColor(spec: string): Color | null {
       b: parseInt(hex[3]!, 16),
     }
   }
-  const rgb = spec.match(
-    /^rgb:([0-9a-f]{1,4})\/([0-9a-f]{1,4})\/([0-9a-f]{1,4})$/i,
-  )
+  const rgb = spec.match(/^rgb:([0-9a-f]{1,4})\/([0-9a-f]{1,4})\/([0-9a-f]{1,4})$/i)
   if (rgb) {
     // XParseColor: N hex digits → value / (16^N - 1), scale to 0-255
-    const scale = (s: string) =>
-      Math.round((parseInt(s, 16) / (16 ** s.length - 1)) * 255)
+    const scale = (s: string) => Math.round((parseInt(s, 16) / (16 ** s.length - 1)) * 255)
     return {
       type: 'rgb',
       r: scale(rgb[1]!),
@@ -408,8 +398,7 @@ export function link(url: string, params?: Record<string, string>): string {
 
 function osc8Id(url: string): string {
   let h = 0
-  for (let i = 0; i < url.length; i++)
-    h = ((h << 5) - h + url.charCodeAt(i)) | 0
+  for (let i = 0; i < url.length; i++) h = ((h << 5) - h + url.charCodeAt(i)) | 0
   return (h >>> 0).toString(36)
 }
 
@@ -447,10 +436,7 @@ export const CLEAR_ITERM2_PROGRESS = `${OSC_PREFIX}${OSC.ITERM2};${ITERM2.PROGRE
 export const CLEAR_TERMINAL_TITLE = `${OSC_PREFIX}${OSC.SET_TITLE_AND_ICON};${BEL}`
 
 /** Clear all three OSC 21337 tab-status fields. Used on exit. */
-export const CLEAR_TAB_STATUS = osc(
-  OSC.TAB_STATUS,
-  'indicator=;status=;status-color=',
-)
+export const CLEAR_TAB_STATUS = osc(OSC.TAB_STATUS, 'indicator=;status=;status-color=')
 
 /**
  * Gate for emitting OSC 21337 (tab-status indicator). Ant-only while the
@@ -474,19 +460,15 @@ export function tabStatus(fields: TabStatusAction): string {
   const parts: string[] = []
   const rgb = (c: Color) =>
     c.type === 'rgb'
-      ? `#${[c.r, c.g, c.b].map(n => n.toString(16).padStart(2, '0')).join('')}`
+      ? `#${[c.r, c.g, c.b].map((n) => n.toString(16).padStart(2, '0')).join('')}`
       : ''
   const escapeStatusValue = (value: string): string =>
     value.split('\\').join('\\\\').split(';').join('\\;')
   if ('indicator' in fields)
     parts.push(`indicator=${fields.indicator ? rgb(fields.indicator) : ''}`)
   if ('status' in fields)
-    parts.push(
-      `status=${fields.status ? escapeStatusValue(fields.status) : ''}`,
-    )
+    parts.push(`status=${fields.status ? escapeStatusValue(fields.status) : ''}`)
   if ('statusColor' in fields)
-    parts.push(
-      `status-color=${fields.statusColor ? rgb(fields.statusColor) : ''}`,
-    )
+    parts.push(`status-color=${fields.statusColor ? rgb(fields.statusColor) : ''}`)
   return osc(OSC.TAB_STATUS, parts.join(';'))
 }

--- a/packages/renderer/src/termio/osc.ts
+++ b/packages/renderer/src/termio/osc.ts
@@ -2,7 +2,7 @@
  * OSC (Operating System Command) Types and Parser
  */
 
-import { Buffer } from 'buffer'
+import { Buffer } from 'node:buffer'
 import { env, execFileNoThrow } from '@yokai/shared'
 import { BEL, ESC, ESC_TYPE, SEP } from './ansi'
 import type { Action, Color, TabStatusAction } from './types'
@@ -10,7 +10,7 @@ import type { Action, Color, TabStatusAction } from './types'
 export const OSC_PREFIX = ESC + String.fromCharCode(ESC_TYPE.OSC)
 
 /** String Terminator (ESC \) - alternative to BEL for terminating OSC */
-export const ST = ESC + '\\'
+export const ST = `${ESC}\\`
 
 /** Generate an OSC sequence: ESC ] p1;p2;...;pN <terminator>
  * Uses ST terminator for Kitty (avoids beeps), BEL for others */
@@ -32,11 +32,11 @@ export function osc(...parts: (string | number)[]): string {
  * wrapped \x07 is opaque DCS payload and tmux never sees the bell.
  */
 export function wrapForMultiplexer(sequence: string): string {
-  if (process.env['TMUX']) {
+  if (process.env.TMUX) {
     const escaped = sequence.split('\x1b').join('\x1b\x1b')
     return `\x1bPtmux;${escaped}\x1b\\`
   }
-  if (process.env['STY']) {
+  if (process.env.STY) {
     return `\x1bP${sequence}\x1b\\`
   }
   return sequence
@@ -61,9 +61,9 @@ export function wrapForMultiplexer(sequence: string): string {
 export type ClipboardPath = 'native' | 'tmux-buffer' | 'osc52'
 
 export function getClipboardPath(): ClipboardPath {
-  const nativeAvailable = process.platform === 'darwin' && !process.env['SSH_CONNECTION']
+  const nativeAvailable = process.platform === 'darwin' && !process.env.SSH_CONNECTION
   if (nativeAvailable) return 'native'
-  if (process.env['TMUX']) return 'tmux-buffer'
+  if (process.env.TMUX) return 'tmux-buffer'
   return 'osc52'
 }
 
@@ -86,9 +86,9 @@ function tmuxPassthrough(payload: string): string {
  * Returns true if the buffer was loaded successfully.
  */
 export async function tmuxLoadBuffer(text: string): Promise<boolean> {
-  if (!process.env['TMUX']) return false
+  if (!process.env.TMUX) return false
   const args =
-    process.env['LC_TERMINAL'] === 'iTerm2' ? ['load-buffer', '-'] : ['load-buffer', '-w', '-']
+    process.env.LC_TERMINAL === 'iTerm2' ? ['load-buffer', '-'] : ['load-buffer', '-w', '-']
   const { code } = await execFileNoThrow('tmux', args, {
     input: text,
     useCwd: false,
@@ -141,7 +141,7 @@ export async function setClipboard(text: string): Promise<string> {
   // Gated on SSH_CONNECTION (not SSH_TTY) since tmux panes inherit SSH_TTY
   // forever but SSH_CONNECTION is in tmux's default update-environment and
   // clears on local attach. Fire-and-forget.
-  if (!process.env['SSH_CONNECTION']) copyNative(text)
+  if (!process.env.SSH_CONNECTION) copyNative(text)
 
   const tmuxBufferLoaded = await tmuxLoadBuffer(text)
 

--- a/packages/renderer/src/termio/parser.ts
+++ b/packages/renderer/src/termio/parser.ts
@@ -18,7 +18,7 @@ import { DEC } from './dec'
 import { parseEsc } from './esc'
 import { parseOSC } from './osc'
 import { applySGR } from './sgr'
-import { createTokenizer, type Token, type Tokenizer } from './tokenize'
+import { type Token, type Tokenizer, createTokenizer } from './tokenize'
 import type { Action, Grapheme, TextStyle } from './types'
 import { defaultStyle } from './types'
 
@@ -80,7 +80,7 @@ function* segmentGraphemes(str: string): Generator<Grapheme> {
 
 function parseCSIParams(paramStr: string): number[] {
   if (paramStr === '') return []
-  return paramStr.split(/[;:]/).map((s) => (s === '' ? 0 : parseInt(s, 10)))
+  return paramStr.split(/[;:]/).map((s) => (s === '' ? 0 : Number.parseInt(s, 10)))
 }
 
 /** Parse a raw CSI sequence (e.g., "\x1b[31m") into an action */

--- a/packages/renderer/src/termio/parser.ts
+++ b/packages/renderer/src/termio/parser.ts
@@ -80,7 +80,7 @@ function* segmentGraphemes(str: string): Generator<Grapheme> {
 
 function parseCSIParams(paramStr: string): number[] {
   if (paramStr === '') return []
-  return paramStr.split(/[;:]/).map(s => (s === '' ? 0 : parseInt(s, 10)))
+  return paramStr.split(/[;:]/).map((s) => (s === '' ? 0 : parseInt(s, 10)))
 }
 
 /** Parse a raw CSI sequence (e.g., "\x1b[31m") into an action */
@@ -242,9 +242,7 @@ function parseCSI(rawSequence: string): Action | null {
 /**
  * Identify the type of escape sequence from its raw form.
  */
-function identifySequence(
-  seq: string,
-): 'csi' | 'osc' | 'esc' | 'ss3' | 'unknown' {
+function identifySequence(seq: string): 'csi' | 'osc' | 'esc' | 'ss3' | 'unknown' {
   if (seq.length < 2) return 'unknown'
   if (seq.charCodeAt(0) !== C0.ESC) return 'unknown'
 
@@ -392,4 +390,3 @@ export class Parser {
     }
   }
 }
-

--- a/packages/renderer/src/termio/sgr.ts
+++ b/packages/renderer/src/termio/sgr.ts
@@ -42,7 +42,7 @@ function parseParams(str: string): Param[] {
   for (let i = 0; i <= str.length; i++) {
     const c = str[i]
     if (c === ';' || c === undefined) {
-      const n = num === '' ? null : parseInt(num, 10)
+      const n = num === '' ? null : Number.parseInt(num, 10)
       if (inSub) {
         if (n !== null) current.subparams.push(n)
       } else {
@@ -53,7 +53,7 @@ function parseParams(str: string): Param[] {
       num = ''
       inSub = false
     } else if (c === ':') {
-      const n = num === '' ? null : parseInt(num, 10)
+      const n = num === '' ? null : Number.parseInt(num, 10)
       if (!inSub) {
         current.value = n
         current.colon = true

--- a/packages/renderer/src/termio/sgr.ts
+++ b/packages/renderer/src/termio/sgr.ts
@@ -27,14 +27,7 @@ const NAMED_COLORS: NamedColor[] = [
   'brightWhite',
 ]
 
-const UNDERLINE_STYLES: UnderlineStyle[] = [
-  'none',
-  'single',
-  'double',
-  'curly',
-  'dotted',
-  'dashed',
-]
+const UNDERLINE_STYLES: UnderlineStyle[] = ['none', 'single', 'double', 'curly', 'dotted', 'dashed']
 
 type Param = { value: number | null; subparams: number[]; colon: boolean }
 
@@ -99,11 +92,7 @@ function parseExtendedColor(
 
   const next = params[idx + 1]
   if (!next) return null
-  if (
-    next.value === 5 &&
-    params[idx + 2]?.value !== null &&
-    params[idx + 2]?.value !== undefined
-  ) {
+  if (next.value === 5 && params[idx + 2]?.value !== null && params[idx + 2]?.value !== undefined) {
     return { index: params[idx + 2]!.value! }
   }
   if (next.value === 2) {
@@ -154,9 +143,7 @@ export function applySGR(paramStr: string, style: TextStyle): TextStyle {
       continue
     }
     if (code === 4) {
-      s.underline = p.colon
-        ? (UNDERLINE_STYLES[p.subparams[0]!] ?? 'single')
-        : 'single'
+      s.underline = p.colon ? (UNDERLINE_STYLES[p.subparams[0]!] ?? 'single') : 'single'
       i++
       continue
     }
@@ -266,10 +253,7 @@ export function applySGR(paramStr: string, style: TextStyle): TextStyle {
     if (code === 38) {
       const c = parseExtendedColor(params, i)
       if (c) {
-        s.fg =
-          'index' in c
-            ? { type: 'indexed', index: c.index }
-            : { type: 'rgb', ...c }
+        s.fg = 'index' in c ? { type: 'indexed', index: c.index } : { type: 'rgb', ...c }
         i += p.colon ? 1 : 'index' in c ? 3 : 5
         continue
       }
@@ -277,10 +261,7 @@ export function applySGR(paramStr: string, style: TextStyle): TextStyle {
     if (code === 48) {
       const c = parseExtendedColor(params, i)
       if (c) {
-        s.bg =
-          'index' in c
-            ? { type: 'indexed', index: c.index }
-            : { type: 'rgb', ...c }
+        s.bg = 'index' in c ? { type: 'indexed', index: c.index } : { type: 'rgb', ...c }
         i += p.colon ? 1 : 'index' in c ? 3 : 5
         continue
       }
@@ -289,9 +270,7 @@ export function applySGR(paramStr: string, style: TextStyle): TextStyle {
       const c = parseExtendedColor(params, i)
       if (c) {
         s.underlineColor =
-          'index' in c
-            ? { type: 'indexed', index: c.index }
-            : { type: 'rgb', ...c }
+          'index' in c ? { type: 'indexed', index: c.index } : { type: 'rgb', ...c }
         i += p.colon ? 1 : 'index' in c ? 3 : 5
         continue
       }
@@ -306,4 +285,3 @@ export function applySGR(paramStr: string, style: TextStyle): TextStyle {
   }
   return s
 }
-

--- a/packages/renderer/src/termio/tokenize.ts
+++ b/packages/renderer/src/termio/tokenize.ts
@@ -9,19 +9,9 @@
 import { C0, ESC_TYPE, isEscFinal } from './ansi'
 import { isCSIFinal, isCSIIntermediate, isCSIParam } from './csi'
 
-export type Token =
-  | { type: 'text'; value: string }
-  | { type: 'sequence'; value: string }
+export type Token = { type: 'text'; value: string } | { type: 'sequence'; value: string }
 
-type State =
-  | 'ground'
-  | 'escape'
-  | 'escapeIntermediate'
-  | 'csi'
-  | 'ss3'
-  | 'osc'
-  | 'dcs'
-  | 'apc'
+type State = 'ground' | 'escape' | 'escapeIntermediate' | 'csi' | 'ss3' | 'osc' | 'dcs' | 'apc'
 
 export type Tokenizer = {
   /** Feed input and get resulting tokens */
@@ -61,13 +51,7 @@ export function createTokenizer(options?: TokenizerOptions): Tokenizer {
 
   return {
     feed(input: string): Token[] {
-      const result = tokenize(
-        input,
-        currentState,
-        currentBuffer,
-        false,
-        x10Mouse,
-      )
+      const result = tokenize(input, currentState, currentBuffer, false, x10Mouse)
       currentState = result.state.state
       currentBuffer = result.state.buffer
       return result.tokens
@@ -317,4 +301,3 @@ function tokenize(
 
   return { tokens, state: result }
 }
-

--- a/packages/renderer/src/termio/types.ts
+++ b/packages/renderer/src/termio/types.ts
@@ -40,13 +40,7 @@ export type Color =
 // =============================================================================
 
 /** Underline style variants */
-export type UnderlineStyle =
-  | 'none'
-  | 'single'
-  | 'double'
-  | 'curly'
-  | 'dotted'
-  | 'dashed'
+export type UnderlineStyle = 'none' | 'single' | 'double' | 'curly' | 'dotted' | 'dashed'
 
 /** Text style attributes - represents current styling state */
 export type TextStyle = {
@@ -109,11 +103,7 @@ export function colorsEqual(a: Color, b: Color): boolean {
     case 'indexed':
       return a.index === (b as typeof a).index
     case 'rgb':
-      return (
-        a.r === (b as typeof a).r &&
-        a.g === (b as typeof a).g &&
-        a.b === (b as typeof a).b
-      )
+      return a.r === (b as typeof a).r && a.g === (b as typeof a).g && a.b === (b as typeof a).b
     case 'default':
       return true
   }
@@ -234,4 +224,3 @@ export type Action =
   | { type: 'bell' }
   | { type: 'reset' } // Full terminal reset (ESC c)
   | { type: 'unknown'; sequence: string } // Unrecognized sequence
-

--- a/packages/renderer/src/useTerminalNotification.ts
+++ b/packages/renderer/src/useTerminalNotification.ts
@@ -1,7 +1,7 @@
 import { createContext, useCallback, useContext, useMemo } from 'react'
-import { isProgressReportingAvailable, type Progress } from './terminal'
+import { type Progress, isProgressReportingAvailable } from './terminal'
 import { BEL } from './termio/ansi'
-import { ITERM2, OSC, osc, PROGRESS, wrapForMultiplexer } from './termio/osc'
+import { ITERM2, OSC, PROGRESS, osc, wrapForMultiplexer } from './termio/osc'
 
 type WriteRaw = (data: string) => void
 

--- a/packages/renderer/src/useTerminalNotification.ts
+++ b/packages/renderer/src/useTerminalNotification.ts
@@ -25,9 +25,7 @@ export type TerminalNotification = {
 export function useTerminalNotification(): TerminalNotification {
   const writeRaw = useContext(TerminalWriteContext)
   if (!writeRaw) {
-    throw new Error(
-      'useTerminalNotification must be used within TerminalWriteProvider',
-    )
+    throw new Error('useTerminalNotification must be used within TerminalWriteProvider')
   }
 
   const notifyITerm2 = useCallback(
@@ -74,42 +72,22 @@ export function useTerminalNotification(): TerminalNotification {
         return
       }
       if (!state) {
-        writeRaw(
-          wrapForMultiplexer(
-            osc(OSC.ITERM2, ITERM2.PROGRESS, PROGRESS.CLEAR, ''),
-          ),
-        )
+        writeRaw(wrapForMultiplexer(osc(OSC.ITERM2, ITERM2.PROGRESS, PROGRESS.CLEAR, '')))
         return
       }
       const pct = Math.max(0, Math.min(100, Math.round(percentage ?? 0)))
       switch (state) {
         case 'completed':
-          writeRaw(
-            wrapForMultiplexer(
-              osc(OSC.ITERM2, ITERM2.PROGRESS, PROGRESS.CLEAR, ''),
-            ),
-          )
+          writeRaw(wrapForMultiplexer(osc(OSC.ITERM2, ITERM2.PROGRESS, PROGRESS.CLEAR, '')))
           break
         case 'error':
-          writeRaw(
-            wrapForMultiplexer(
-              osc(OSC.ITERM2, ITERM2.PROGRESS, PROGRESS.ERROR, pct),
-            ),
-          )
+          writeRaw(wrapForMultiplexer(osc(OSC.ITERM2, ITERM2.PROGRESS, PROGRESS.ERROR, pct)))
           break
         case 'indeterminate':
-          writeRaw(
-            wrapForMultiplexer(
-              osc(OSC.ITERM2, ITERM2.PROGRESS, PROGRESS.INDETERMINATE, ''),
-            ),
-          )
+          writeRaw(wrapForMultiplexer(osc(OSC.ITERM2, ITERM2.PROGRESS, PROGRESS.INDETERMINATE, '')))
           break
         case 'running':
-          writeRaw(
-            wrapForMultiplexer(
-              osc(OSC.ITERM2, ITERM2.PROGRESS, PROGRESS.SET, pct),
-            ),
-          )
+          writeRaw(wrapForMultiplexer(osc(OSC.ITERM2, ITERM2.PROGRESS, PROGRESS.SET, pct)))
           break
         case null:
           // Handled by the if guard above
@@ -124,4 +102,3 @@ export function useTerminalNotification(): TerminalNotification {
     [notifyITerm2, notifyKitty, notifyGhostty, notifyBell, progress],
   )
 }
-

--- a/packages/renderer/src/warn.ts
+++ b/packages/renderer/src/warn.ts
@@ -7,4 +7,3 @@ export function ifNotInteger(value: number | undefined, name: string): void {
     level: 'warn',
   })
 }
-

--- a/packages/renderer/src/widest-line.ts
+++ b/packages/renderer/src/widest-line.ts
@@ -6,8 +6,7 @@ export function widestLine(string: string): number {
 
   while (start <= string.length) {
     const end = string.indexOf('\n', start)
-    const line =
-      end === -1 ? string.substring(start) : string.substring(start, end)
+    const line = end === -1 ? string.substring(start) : string.substring(start, end)
 
     maxWidth = Math.max(maxWidth, lineWidth(line))
 
@@ -17,4 +16,3 @@ export function widestLine(string: string): number {
 
   return maxWidth
 }
-

--- a/packages/renderer/src/wrap-text.ts
+++ b/packages/renderer/src/wrap-text.ts
@@ -12,11 +12,7 @@ function sliceFit(text: string, start: number, end: number): string {
   return stringWidth(s) > end - start ? sliceAnsi(text, start, end - 1) : s
 }
 
-function truncate(
-  text: string,
-  columns: number,
-  position: 'start' | 'middle' | 'end',
-): string {
+function truncate(text: string, columns: number, position: 'start' | 'middle' | 'end'): string {
   if (columns < 1) return ''
   if (columns === 1) return ELLIPSIS
 
@@ -29,9 +25,7 @@ function truncate(
   if (position === 'middle') {
     const half = Math.floor(columns / 2)
     return (
-      sliceFit(text, 0, half) +
-      ELLIPSIS +
-      sliceFit(text, length - (columns - half) + 1, length)
+      sliceFit(text, 0, half) + ELLIPSIS + sliceFit(text, length - (columns - half) + 1, length)
     )
   }
   return sliceFit(text, 0, columns - 1) + ELLIPSIS
@@ -72,4 +66,3 @@ export default function wrapText(
 
   return text
 }
-

--- a/packages/renderer/src/wrapAnsi.ts
+++ b/packages/renderer/src/wrapAnsi.ts
@@ -6,10 +6,6 @@ type WrapAnsiOptions = {
   trim?: boolean
 }
 
-const wrapAnsi: (
-  input: string,
-  columns: number,
-  options?: WrapAnsiOptions,
-) => string = wrapAnsiNpm
+const wrapAnsi: (input: string, columns: number, options?: WrapAnsiOptions) => string = wrapAnsiNpm
 
 export { wrapAnsi }

--- a/packages/shared/src/debug.ts
+++ b/packages/shared/src/debug.ts
@@ -5,9 +5,7 @@
 export type DebugLogLevel = 'verbose' | 'debug' | 'info' | 'warn' | 'error'
 
 let debugEnabled =
-  process.env.DEBUG === '1' ||
-  process.env.DEBUG === 'true' ||
-  process.argv.includes('--debug')
+  process.env.DEBUG === '1' || process.env.DEBUG === 'true' || process.argv.includes('--debug')
 
 export function enableDebugLogging(): void {
   debugEnabled = true

--- a/packages/shared/src/env.ts
+++ b/packages/shared/src/env.ts
@@ -7,11 +7,7 @@ import { isEnvTruthy } from './envUtils'
 type Platform = 'win32' | 'darwin' | 'linux'
 
 function isSSHSession(): boolean {
-  return !!(
-    process.env.SSH_CONNECTION ||
-    process.env.SSH_CLIENT ||
-    process.env.SSH_TTY
-  )
+  return !!(process.env.SSH_CONNECTION || process.env.SSH_CLIENT || process.env.SSH_TTY)
 }
 
 function detectTerminal(): string | null {

--- a/packages/shared/src/envUtils.ts
+++ b/packages/shared/src/envUtils.ts
@@ -9,9 +9,7 @@ export function isEnvTruthy(envVar: string | boolean | undefined): boolean {
   return ['1', 'true', 'yes', 'on'].includes(normalizedValue)
 }
 
-export function isEnvDefinedFalsy(
-  envVar: string | boolean | undefined,
-): boolean {
+export function isEnvDefinedFalsy(envVar: string | boolean | undefined): boolean {
   if (envVar === undefined) return false
   if (typeof envVar === 'boolean') return !envVar
   if (!envVar) return false

--- a/packages/shared/src/execFileNoThrow.ts
+++ b/packages/shared/src/execFileNoThrow.ts
@@ -22,7 +22,7 @@ export function execFileNoThrow(
     useCwd?: boolean
   } = {},
 ): Promise<ExecResult> {
-  return new Promise(resolve => {
+  return new Promise((resolve) => {
     const opts: ExecFileOptions & { encoding: 'utf8' } = {
       timeout: options.timeout ?? 600000,
       env: options.env,

--- a/packages/shared/src/execFileNoThrow.ts
+++ b/packages/shared/src/execFileNoThrow.ts
@@ -3,7 +3,7 @@
  * Simplified version using Node.js child_process directly.
  */
 
-import { execFile as cpExecFile, type ExecFileOptions } from 'child_process'
+import { execFile as cpExecFile, type ExecFileOptions } from 'node:child_process'
 
 type ExecResult = {
   stdout: string

--- a/packages/shared/src/execFileNoThrow.ts
+++ b/packages/shared/src/execFileNoThrow.ts
@@ -3,7 +3,7 @@
  * Simplified version using Node.js child_process directly.
  */
 
-import { execFile as cpExecFile, type ExecFileOptions } from 'node:child_process'
+import { type ExecFileOptions, execFile as cpExecFile } from 'node:child_process'
 
 type ExecResult = {
   stdout: string

--- a/packages/shared/src/logger.ts
+++ b/packages/shared/src/logger.ts
@@ -3,8 +3,12 @@ type LogFn = (...args: unknown[]) => void
 let debugLogger: LogFn = () => {}
 let errorLogger: LogFn = console.error
 
-export function logForDebugging(...args: unknown[]) { debugLogger(...args) }
-export function logError(...args: unknown[]) { errorLogger(...args) }
+export function logForDebugging(...args: unknown[]) {
+  debugLogger(...args)
+}
+export function logError(...args: unknown[]) {
+  errorLogger(...args)
+}
 
 export function configureLogger(opts: { debug?: LogFn; error?: LogFn }) {
   if (opts.debug) debugLogger = opts.debug

--- a/packages/shared/src/sliceAnsi.ts
+++ b/packages/shared/src/sliceAnsi.ts
@@ -26,17 +26,13 @@ function isEndCode(code: AnsiCode): boolean {
 }
 
 function filterStartCodes(codes: AnsiCode[]): AnsiCode[] {
-  return codes.filter(c => !isEndCode(c))
+  return codes.filter((c) => !isEndCode(c))
 }
 
 /**
  * Slice a string containing ANSI escape codes by display width.
  */
-export default function sliceAnsi(
-  str: string,
-  start: number,
-  end?: number,
-): string {
+export default function sliceAnsi(str: string, start: number, end?: number): string {
   const tokens = tokenize(str)
   let activeCodes: AnsiCode[] = []
   let position = 0

--- a/packages/shared/src/stringWidth.ts
+++ b/packages/shared/src/stringWidth.ts
@@ -5,10 +5,14 @@ import { getGraphemeSegmenter } from './intl.js'
 
 const EMOJI_REGEX = emojiRegex()
 
-function stringWidthJavaScript(str: string): number {
-  if (typeof str !== 'string' || str.length === 0) {
+function stringWidthJavaScript(input: string): number {
+  if (typeof input !== 'string' || input.length === 0) {
     return 0
   }
+  // Local mutable copy: the ANSI-strip branch below reassigns. Avoiding
+  // parameter reassignment keeps the signature's intent clear (input is
+  // never observably mutated for callers) and satisfies noParameterAssign.
+  let str = input
 
   let isPureAscii = true
   for (let i = 0; i < str.length; i++) {

--- a/packages/shared/src/yoga-layout/enums.ts
+++ b/packages/shared/src/yoga-layout/enums.ts
@@ -69,8 +69,7 @@ export type Errata = (typeof Errata)[keyof typeof Errata]
 export const ExperimentalFeature = {
   WebFlexBasis: 0,
 } as const
-export type ExperimentalFeature =
-  (typeof ExperimentalFeature)[keyof typeof ExperimentalFeature]
+export type ExperimentalFeature = (typeof ExperimentalFeature)[keyof typeof ExperimentalFeature]
 
 export const FlexDirection = {
   Column: 0,
@@ -132,4 +131,3 @@ export const Wrap = {
   WrapReverse: 2,
 } as const
 export type Wrap = (typeof Wrap)[keyof typeof Wrap]
-

--- a/packages/shared/src/yoga-layout/index.ts
+++ b/packages/shared/src/yoga-layout/index.ts
@@ -2370,16 +2370,21 @@ function boundAxis(
   const owner = isWidth ? ownerWidth : ownerHeight
   let v = value
   // Inlined resolveValue: Unit.Point=1, Unit.Percent=2. `m === m` is !isNaN.
+  // Self-compare instead of Number.isNaN to keep this branchy hot loop tight —
+  // the comment above explains the perf rationale (32k calls/layout). Biome's
+  // noSelfCompare flag is suppressed per-site to keep the override visible.
   if (maxU === 1) {
     if (v > maxV.value) v = maxV.value
   } else if (maxU === 2) {
     const m = (maxV.value * owner) / 100
+    // biome-ignore lint/suspicious/noSelfCompare: NaN check, see comment above
     if (m === m && v > m) v = m
   }
   if (minU === 1) {
     if (v < minV.value) v = minV.value
   } else if (minU === 2) {
     const m = (minV.value * owner) / 100
+    // biome-ignore lint/suspicious/noSelfCompare: NaN check, see comment above
     if (m === m && v < m) v = m
   }
   return v

--- a/packages/shared/src/yoga-layout/index.ts
+++ b/packages/shared/src/yoga-layout/index.ts
@@ -84,8 +84,8 @@ export type Value = {
   value: number
 }
 
-const UNDEFINED_VALUE: Value = { unit: Unit.Undefined, value: NaN }
-const AUTO_VALUE: Value = { unit: Unit.Auto, value: NaN }
+const UNDEFINED_VALUE: Value = { unit: Unit.Undefined, value: Number.NaN }
+const AUTO_VALUE: Value = { unit: Unit.Auto, value: Number.NaN }
 
 function pointValue(v: number): Value {
   return { unit: Unit.Point, value: v }

--- a/packages/shared/src/yoga-layout/index.ts
+++ b/packages/shared/src/yoga-layout/index.ts
@@ -821,8 +821,7 @@ export class Node {
     this.style.margin[edge] = val
     if (val.unit === Unit.Auto) this._hasAutoMargin = true
     else this._hasAutoMargin = hasAnyAutoEdge(this.style.margin)
-    this._hasMargin =
-      this._hasAutoMargin || hasAnyDefinedEdge(this.style.margin)
+    this._hasMargin = this._hasAutoMargin || hasAnyDefinedEdge(this.style.margin)
     this.markDirty()
   }
   setMarginPercent(edge: Edge, v: number): void {
@@ -951,14 +950,8 @@ export class Node {
     // to the root even without a parent container; this matters for rounding
     // since the root's abs top/left seeds the pixel-grid walk).
     const mar = this.layout.margin
-    const posL = resolveValue(
-      resolveEdgeRaw(this.style.position, EDGE_LEFT),
-      isDefined(w) ? w : 0,
-    )
-    const posT = resolveValue(
-      resolveEdgeRaw(this.style.position, EDGE_TOP),
-      isDefined(w) ? w : 0,
-    )
+    const posL = resolveValue(resolveEdgeRaw(this.style.position, EDGE_LEFT), isDefined(w) ? w : 0)
+    const posT = resolveValue(resolveEdgeRaw(this.style.position, EDGE_TOP), isDefined(w) ? w : 0)
     this.layout.left = mar[EDGE_LEFT] + (isDefined(posL) ? posL : 0)
     this.layout.top = mar[EDGE_TOP] + (isDefined(posT) ? posT : 0)
     roundLayout(this, this.config.pointScaleFactor, 0, 0)
@@ -1215,9 +1208,7 @@ function layoutNode(
 
   // Resolve style dimensions
   const styleWidth = forceWidth ? NaN : resolveValue(style.width, ownerWidth)
-  const styleHeight = forceHeight
-    ? NaN
-    : resolveValue(style.height, ownerHeight)
+  const styleHeight = forceHeight ? NaN : resolveValue(style.height, ownerHeight)
 
   // If style dimension is defined, it overrides the available size
   let width = availableWidth
@@ -1239,14 +1230,8 @@ function layoutNode(
 
   // Measure-func leaf node
   if (node.measureFunc && node.children.length === 0) {
-    const innerW =
-      wMode === MeasureMode.Undefined
-        ? NaN
-        : Math.max(0, width - paddingBorderWidth)
-    const innerH =
-      hMode === MeasureMode.Undefined
-        ? NaN
-        : Math.max(0, height - paddingBorderHeight)
+    const innerW = wMode === MeasureMode.Undefined ? NaN : Math.max(0, width - paddingBorderWidth)
+    const innerH = hMode === MeasureMode.Undefined ? NaN : Math.max(0, height - paddingBorderHeight)
     _yogaMeasureCalls++
     const measured = node.measureFunc(innerW, wMode, innerH, hMode)
     node.layout.width =
@@ -1333,19 +1318,11 @@ function layoutNode(
   const mainPadBorder = isMainRow ? paddingBorderWidth : paddingBorderHeight
   const crossPadBorder = isMainRow ? paddingBorderHeight : paddingBorderWidth
 
-  const innerMainSize = isDefined(mainSize)
-    ? Math.max(0, mainSize - mainPadBorder)
-    : NaN
-  const innerCrossSize = isDefined(crossSize)
-    ? Math.max(0, crossSize - crossPadBorder)
-    : NaN
+  const innerMainSize = isDefined(mainSize) ? Math.max(0, mainSize - mainPadBorder) : NaN
+  const innerCrossSize = isDefined(crossSize) ? Math.max(0, crossSize - crossPadBorder) : NaN
 
   // Resolve gap
-  const gapMain = resolveGap(
-    style,
-    isMainRow ? Gutter.Column : Gutter.Row,
-    innerMainSize,
-  )
+  const gapMain = resolveGap(style, isMainRow ? Gutter.Column : Gutter.Row, innerMainSize)
 
   // Partition children into flow vs absolute. display:contents nodes are
   // transparent — their children are lifted into the grandparent's child list
@@ -1361,11 +1338,7 @@ function layoutNode(
   const ownerW = isDefined(width) ? width : NaN
   const ownerH = isDefined(height) ? height : NaN
   const isWrap = style.flexWrap !== Wrap.NoWrap
-  const gapCross = resolveGap(
-    style,
-    isMainRow ? Gutter.Row : Gutter.Column,
-    innerCrossSize,
-  )
+  const gapCross = resolveGap(style, isMainRow ? Gutter.Row : Gutter.Column, innerCrossSize)
 
   // STEP 1: Compute flex-basis for each flow child and break into lines.
   // Single-line (NoWrap) containers always get one line; multi-line containers
@@ -1430,35 +1403,21 @@ function layoutNode(
     let availMain = innerMainSize
     if (!isDefined(availMain)) {
       const mainOwner = isMainRow ? ownerWidth : ownerHeight
-      const minM = resolveValue(
-        isMainRow ? style.minWidth : style.minHeight,
-        mainOwner,
-      )
-      const maxM = resolveValue(
-        isMainRow ? style.maxWidth : style.maxHeight,
-        mainOwner,
-      )
+      const minM = resolveValue(isMainRow ? style.minWidth : style.minHeight, mainOwner)
+      const maxM = resolveValue(isMainRow ? style.maxWidth : style.maxHeight, mainOwner)
       if (isDefined(maxM) && lineBasis > maxM - mainPadBorder) {
         availMain = Math.max(0, maxM - mainPadBorder)
       } else if (isDefined(minM) && lineBasis < minM - mainPadBorder) {
         availMain = Math.max(0, minM - mainPadBorder)
       }
     }
-    resolveFlexibleLengths(
-      line,
-      availMain,
-      lineBasis,
-      isMainRow,
-      ownerW,
-      ownerH,
-    )
+    resolveFlexibleLengths(line, availMain, lineBasis, isMainRow, ownerW, ownerH)
 
     // Lay out each child in this line to measure cross
     let lineCross = 0
     for (const c of line) {
       const cStyle = c.style
-      const childAlign =
-        cStyle.alignSelf === Align.Auto ? style.alignItems : cStyle.alignSelf
+      const childAlign = cStyle.alignSelf === Align.Auto ? style.alignItems : cStyle.alignSelf
       const cMarginCross = childMarginForAxis(c, crossAx, ownerW)
       let childCrossSize = NaN
       let childCrossMode: MeasureMode = MeasureMode.Undefined
@@ -1470,8 +1429,7 @@ function layoutNode(
       const crossTrailE = isMainRow ? EDGE_BOTTOM : EDGE_RIGHT
       const hasCrossAutoMargin =
         c._hasAutoMargin &&
-        (isMarginAuto(cStyle.margin, crossLeadE) ||
-          isMarginAuto(cStyle.margin, crossTrailE))
+        (isMarginAuto(cStyle.margin, crossLeadE) || isMarginAuto(cStyle.margin, crossTrailE))
       // Single-line stretch goes directly to the container cross size.
       // Multi-line wrap measures intrinsic cross (Undefined mode) so
       // flex-grow grandchildren don't expand to the container — the line
@@ -1602,10 +1560,8 @@ function layoutNode(
 
   // STEP 5: Position lines (align-content) and children (justify-content +
   // align-items + auto margins).
-  const actualInnerMain =
-    (isMainRow ? node.layout.width : node.layout.height) - mainPadBorder
-  const actualInnerCross =
-    (isMainRow ? node.layout.height : node.layout.width) - crossPadBorder
+  const actualInnerMain = (isMainRow ? node.layout.width : node.layout.height) - mainPadBorder
+  const actualInnerCross = (isMainRow ? node.layout.height : node.layout.width) - crossPadBorder
   const mainLeadEdgePhys = leadingEdge(mainAxis)
   const mainTrailEdgePhys = trailingEdge(mainAxis)
   const crossLeadEdgePhys = isMainRow ? EDGE_TOP : EDGE_LEFT
@@ -1678,23 +1634,15 @@ function layoutNode(
     if (isWrap || crossMode !== MeasureMode.Exactly) {
       for (const c of line) {
         const cStyle = c.style
-        const childAlign =
-          cStyle.alignSelf === Align.Auto ? style.alignItems : cStyle.alignSelf
+        const childAlign = cStyle.alignSelf === Align.Auto ? style.alignItems : cStyle.alignSelf
         const crossStyleDef = isDefined(
-          resolveValue(
-            isMainRow ? cStyle.height : cStyle.width,
-            isMainRow ? ownerH : ownerW,
-          ),
+          resolveValue(isMainRow ? cStyle.height : cStyle.width, isMainRow ? ownerH : ownerW),
         )
         const hasCrossAutoMargin =
           c._hasAutoMargin &&
           (isMarginAuto(cStyle.margin, crossLeadEdgePhys) ||
             isMarginAuto(cStyle.margin, crossTrailEdgePhys))
-        if (
-          childAlign === Align.Stretch &&
-          !crossStyleDef &&
-          !hasCrossAutoMargin
-        ) {
+        if (childAlign === Align.Stretch && !crossStyleDef && !hasCrossAutoMargin) {
           const cMarginCross = childMarginForAxis(c, crossAx, ownerW)
           const target = Math.max(0, lineCross - cMarginCross)
           if (c._crossSize !== target) {
@@ -1730,9 +1678,7 @@ function layoutNode(
     const freeMain = actualInnerMain - consumedMain
     const remainingMain = Math.max(0, freeMain)
     const autoMarginMainSize =
-      numAutoMarginsMain > 0 && remainingMain > 0
-        ? remainingMain / numAutoMarginsMain
-        : 0
+      numAutoMarginsMain > 0 && remainingMain > 0 ? remainingMain / numAutoMarginsMain : 0
     if (numAutoMarginsMain === 0) {
       switch (style.justifyContent) {
         case Justify.FlexStart:
@@ -1787,12 +1733,8 @@ function layoutNode(
         autoMainTrail = isMarginAuto(cMargin, mainTrailEdgePhys)
         autoCrossLead = isMarginAuto(cMargin, crossLeadEdgePhys)
         autoCrossTrail = isMarginAuto(cMargin, crossTrailEdgePhys)
-        mMainLead = autoMainLead
-          ? autoMarginMainSize
-          : cLayoutMargin[mainLeadEdgePhys]!
-        mMainTrail = autoMainTrail
-          ? autoMarginMainSize
-          : cLayoutMargin[mainTrailEdgePhys]!
+        mMainLead = autoMainLead ? autoMarginMainSize : cLayoutMargin[mainLeadEdgePhys]!
+        mMainTrail = autoMainTrail ? autoMarginMainSize : cLayoutMargin[mainTrailEdgePhys]!
         mCrossLead = autoCrossLead ? 0 : cLayoutMargin[crossLeadEdgePhys]!
         mCrossTrail = autoCrossTrail ? 0 : cLayoutMargin[crossTrailEdgePhys]!
       } else {
@@ -1807,8 +1749,7 @@ function layoutNode(
         ? mainContainerSize - (pos + mMainLead) - c._mainSize
         : pos + mMainLead
 
-      const childAlign =
-        c.style.alignSelf === Align.Auto ? style.alignItems : c.style.alignSelf
+      const childAlign = c.style.alignSelf === Align.Auto ? style.alignItems : c.style.alignSelf
       let crossPos = effectiveLineCrossPos + mCrossLead
       const crossFree = lineCross - c._crossSize - mCrossLead - mCrossTrail
       if (autoCrossLead && autoCrossTrail) {
@@ -1834,10 +1775,7 @@ function layoutNode(
             // the child's baseline aligns with the line's max ascent. Per
             // yoga: top = currentLead + maxAscent - childBaseline + leadingPosition.
             if (isBaseline) {
-              crossPos =
-                effectiveLineCrossPos +
-                lineMaxAscent[li]! -
-                calculateBaseline(c)
+              crossPos = effectiveLineCrossPos + lineMaxAscent[li]! - calculateBaseline(c)
             }
             break
           default:
@@ -1850,32 +1788,12 @@ function layoutNode(
       let relX = 0
       let relY = 0
       if (c._hasPosition) {
-        const relLeft = resolveValue(
-          resolveEdgeRaw(c.style.position, EDGE_LEFT),
-          ownerW,
-        )
-        const relRight = resolveValue(
-          resolveEdgeRaw(c.style.position, EDGE_RIGHT),
-          ownerW,
-        )
-        const relTop = resolveValue(
-          resolveEdgeRaw(c.style.position, EDGE_TOP),
-          ownerW,
-        )
-        const relBottom = resolveValue(
-          resolveEdgeRaw(c.style.position, EDGE_BOTTOM),
-          ownerW,
-        )
-        relX = isDefined(relLeft)
-          ? relLeft
-          : isDefined(relRight)
-            ? -relRight
-            : 0
-        relY = isDefined(relTop)
-          ? relTop
-          : isDefined(relBottom)
-            ? -relBottom
-            : 0
+        const relLeft = resolveValue(resolveEdgeRaw(c.style.position, EDGE_LEFT), ownerW)
+        const relRight = resolveValue(resolveEdgeRaw(c.style.position, EDGE_RIGHT), ownerW)
+        const relTop = resolveValue(resolveEdgeRaw(c.style.position, EDGE_TOP), ownerW)
+        const relBottom = resolveValue(resolveEdgeRaw(c.style.position, EDGE_BOTTOM), ownerW)
+        relX = isDefined(relLeft) ? relLeft : isDefined(relRight) ? -relRight : 0
+        relY = isDefined(relTop) ? relTop : isDefined(relBottom) ? -relBottom : 0
       }
 
       if (isMainRow) {
@@ -1892,14 +1810,7 @@ function layoutNode(
 
   // STEP 6: Absolute-positioned children
   for (const c of absChildren) {
-    layoutAbsoluteChild(
-      node,
-      c,
-      node.layout.width,
-      node.layout.height,
-      pad,
-      bor,
-    )
+    layoutAbsoluteChild(node, c, node.layout.width, node.layout.height, pad, bor)
   }
 }
 
@@ -1959,8 +1870,7 @@ function layoutAbsoluteChild(
   const mainRow = isRow(mainAxis)
   const wrapReverse = parent.style.flexWrap === Wrap.WrapReverse
   // alignSelf overrides alignItems for absolute children (same as flow items)
-  const alignment =
-    cs.alignSelf === Align.Auto ? parent.style.alignItems : cs.alignSelf
+  const alignment = cs.alignSelf === Align.Auto ? parent.style.alignItems : cs.alignSelf
 
   // Position
   let left: number
@@ -1974,12 +1884,7 @@ function layoutAbsoluteChild(
     const trail = parentWidth - pad[2] - bor[2]
     left = reversed
       ? trail - child.layout.width - mR
-      : justifyAbsolute(
-          parent.style.justifyContent,
-          lead,
-          trail,
-          child.layout.width,
-        ) + mL
+      : justifyAbsolute(parent.style.justifyContent, lead, trail, child.layout.width) + mL
   } else {
     left =
       alignAbsolute(
@@ -2010,12 +1915,7 @@ function layoutAbsoluteChild(
     const trail = parentHeight - pad[3] - bor[3]
     top = reversed
       ? trail - child.layout.height - mB
-      : justifyAbsolute(
-          parent.style.justifyContent,
-          lead,
-          trail,
-          child.layout.height,
-        ) + mT
+      : justifyAbsolute(parent.style.justifyContent, lead, trail, child.layout.height) + mT
   }
 
   child.layout.left = left
@@ -2194,9 +2094,7 @@ function resolveFlexibleLengths(
   // violators, redistribute among unfrozen children. Repeat until stable.
   const n = children.length
   const frozen: boolean[] = new Array(n).fill(false)
-  const initialFree = isDefined(availableInnerMain)
-    ? availableInnerMain - totalFlexBasis
-    : 0
+  const initialFree = isDefined(availableInnerMain) ? availableInnerMain - totalFlexBasis : 0
   // Freeze inflexible items at their clamped basis
   for (let i = 0; i < n; i++) {
     const c = children[i]!
@@ -2256,14 +2154,10 @@ function resolveFlexibleLengths(
       if (remaining > 0 && totalGrow > 0) {
         t += (remaining * c.style.flexGrow) / totalGrow
       } else if (remaining < 0 && totalShrinkScaled > 0) {
-        t +=
-          (remaining * (c.style.flexShrink * c._flexBasis)) / totalShrinkScaled
+        t += (remaining * (c.style.flexShrink * c._flexBasis)) / totalShrinkScaled
       }
       unclamped[i] = t
-      const clamped = Math.max(
-        0,
-        boundAxis(c.style, isMainRow, t, ownerW, ownerH),
-      )
+      const clamped = Math.max(0, boundAxis(c.style, isMainRow, t, ownerW, ownerH))
       c._mainSize = clamped
       totalViolation += clamped - t
     }
@@ -2286,17 +2180,12 @@ function resolveFlexibleLengths(
 function isStretchAlign(child: Node): boolean {
   const p = child.parent
   if (!p) return false
-  const align =
-    child.style.alignSelf === Align.Auto
-      ? p.style.alignItems
-      : child.style.alignSelf
+  const align = child.style.alignSelf === Align.Auto ? p.style.alignItems : child.style.alignSelf
   return align === Align.Stretch
 }
 
 function resolveChildAlign(parent: Node, child: Node): Align {
-  return child.style.alignSelf === Align.Auto
-    ? parent.style.alignItems
-    : child.style.alignSelf
+  return child.style.alignSelf === Align.Auto ? parent.style.alignItems : child.style.alignSelf
 }
 
 // Baseline of a node per CSS Flexbox §8.5 / yoga's YGBaseline. Leaf nodes
@@ -2309,10 +2198,7 @@ function calculateBaseline(node: Node): number {
     if (c._lineIndex > 0) break
     if (c.style.positionType === PositionType.Absolute) continue
     if (c.style.display === Display.None) continue
-    if (
-      resolveChildAlign(node, c) === Align.Baseline ||
-      c.isReferenceBaseline_
-    ) {
+    if (resolveChildAlign(node, c) === Align.Baseline || c.isReferenceBaseline_) {
       baselineChild = c
       break
     }
@@ -2333,11 +2219,7 @@ function isBaselineLayout(node: Node, flowChildren: Node[]): boolean {
   return false
 }
 
-function childMarginForAxis(
-  child: Node,
-  axis: FlexDirection,
-  ownerWidth: number,
-): number {
+function childMarginForAxis(child: Node, axis: FlexDirection, ownerWidth: number): number {
   if (!child._hasMargin) return 0
   const lead = resolveEdge(child.style.margin, leadingEdge(axis), ownerWidth)
   const trail = resolveEdge(child.style.margin, trailingEdge(axis), ownerWidth)
@@ -2439,12 +2321,7 @@ function collectLayoutChildren(node: Node, flow: Node[], abs: Node[]): void {
   }
 }
 
-function roundLayout(
-  node: Node,
-  scale: number,
-  absLeft: number,
-  absTop: number,
-): void {
+function roundLayout(node: Node, scale: number, absLeft: number, absTop: number): void {
   if (scale === 0) return
   const l = node.layout
   const nodeLeft = l.left
@@ -2487,12 +2364,7 @@ function isWholeNumber(v: number): boolean {
   return frac < 0.0001 || frac > 0.9999
 }
 
-function roundValue(
-  v: number,
-  scale: number,
-  forceCeil: boolean,
-  forceFloor: boolean,
-): number {
+function roundValue(v: number, scale: number, forceCeil: boolean, forceFloor: boolean): number {
   let scaled = v * scale
   let frac = scaled - Math.floor(scaled)
   if (frac < 0) frac += 1
@@ -2583,4 +2455,3 @@ export function loadYoga(): Promise<Yoga> {
 }
 
 export default YOGA_INSTANCE
-

--- a/packages/shared/src/yoga-layout/index.ts
+++ b/packages/shared/src/yoga-layout/index.ts
@@ -109,9 +109,11 @@ function isDefined(n: number): boolean {
   return !isNaN(n)
 }
 
-// NaN-safe equality for layout-cache input comparison
+// NaN-safe equality for layout-cache input comparison.
+// `a === b` short-circuits the common case; the explicit isNaN check on
+// both sides handles NaN === NaN being false in JS.
 function sameFloat(a: number, b: number): boolean {
-  return a === b || (a !== a && b !== b)
+  return a === b || (Number.isNaN(a) && Number.isNaN(b))
 }
 
 // --

--- a/packages/shared/src/yoga-layout/index.ts
+++ b/packages/shared/src/yoga-layout/index.ts
@@ -99,14 +99,14 @@ function resolveValue(v: Value, ownerSize: number): number {
     case Unit.Point:
       return v.value
     case Unit.Percent:
-      return isNaN(ownerSize) ? NaN : (v.value * ownerSize) / 100
+      return Number.isNaN(ownerSize) ? Number.NaN : (v.value * ownerSize) / 100
     default:
-      return NaN
+      return Number.NaN
   }
 }
 
 function isDefined(n: number): boolean {
-  return !isNaN(n)
+  return !Number.isNaN(n)
 }
 
 // NaN-safe equality for layout-cache input comparison.
@@ -228,7 +228,7 @@ function resolveEdge(
     if (physicalEdge === EDGE_RIGHT) v = edges[Edge.End]!
   }
   if (v.unit === Unit.Undefined) return 0
-  if (v.unit === Unit.Auto) return allowAuto ? NaN : 0
+  if (v.unit === Unit.Auto) return allowAuto ? Number.NaN : 0
   return resolveValue(v, ownerSize)
 }
 
@@ -279,7 +279,7 @@ function resolveEdges4Into(
   const eA = edges[8]! // Edge.All
   const eS = edges[4]! // Edge.Start
   const eE = edges[5]! // Edge.End
-  const pctDenom = isNaN(ownerSize) ? NaN : ownerSize / 100
+  const pctDenom = Number.isNaN(ownerSize) ? Number.NaN : ownerSize / 100
 
   // Left: edges[0] → Horizontal → All → Start
   let v = edges[0]!
@@ -441,12 +441,12 @@ export class Node {
   // different inputs per parent pass — a single slot thrashes. Re-layout
   // bench (dirty one leaf, recompute root) went 2.7x→1.1x with this:
   // clean siblings skip straight through, only the dirty chain recomputes.
-  _lW = NaN
-  _lH = NaN
+  _lW = Number.NaN
+  _lH = Number.NaN
   _lWM: MeasureMode = 0
   _lHM: MeasureMode = 0
-  _lOW = NaN
-  _lOH = NaN
+  _lOW = Number.NaN
+  _lOH = Number.NaN
   _lFW = false
   _lFH = false
   // _hasL stores INPUTS early (before compute) but layout.width/height are
@@ -454,17 +454,17 @@ export class Node {
   // different inputs. Without storing OUTPUTS, a _hasL hit returns whatever
   // layout.width/height happened to be left by the last call — the scrollbox
   // vpH=33→2624 bug. Store + restore outputs like the multi-entry cache does.
-  _lOutW = NaN
-  _lOutH = NaN
+  _lOutW = Number.NaN
+  _lOutH = Number.NaN
   _hasL = false
-  _mW = NaN
-  _mH = NaN
+  _mW = Number.NaN
+  _mH = Number.NaN
   _mWM: MeasureMode = 0
   _mHM: MeasureMode = 0
-  _mOW = NaN
-  _mOH = NaN
-  _mOutW = NaN
-  _mOutH = NaN
+  _mOW = Number.NaN
+  _mOH = Number.NaN
+  _mOutW = Number.NaN
+  _mOutH = Number.NaN
   _hasM = false
   // Cached computeFlexBasis result. For clean children, basis only depends
   // on the container's inner dimensions — if those haven't changed, skip the
@@ -472,11 +472,11 @@ export class Node {
   // for scroll: 500-message content container is dirty, its 499 clean
   // children each get measured ~20× as the dirty chain's measure/layout
   // passes cascade. Basis cache short-circuits at the child boundary.
-  _fbBasis = NaN
-  _fbOwnerW = NaN
-  _fbOwnerH = NaN
-  _fbAvailMain = NaN
-  _fbAvailCross = NaN
+  _fbBasis = Number.NaN
+  _fbOwnerW = Number.NaN
+  _fbOwnerH = Number.NaN
+  _fbAvailMain = Number.NaN
+  _fbAvailCross = Number.NaN
   _fbCrossMode: MeasureMode = 0
   // Generation at which _fbBasis was written. Dirty nodes from a PREVIOUS
   // generation have stale cache (subtree changed), but within the SAME
@@ -571,7 +571,7 @@ export class Node {
     this._hasM = false
     this._cN = 0
     this._cWr = 0
-    this._fbBasis = NaN
+    this._fbBasis = Number.NaN
   }
 
   // -- Dirty tracking
@@ -722,7 +722,7 @@ export class Node {
     this.markDirty()
   }
   setFlex(v: number | undefined): void {
-    if (v === undefined || isNaN(v)) {
+    if (v === undefined || Number.isNaN(v)) {
       this.style.flexGrow = 0
       this.style.flexShrink = 0
     } else if (v > 0) {
@@ -919,7 +919,7 @@ export class Node {
   }
   setAspectRatio(_: number | undefined): void {}
   getAspectRatio(): number {
-    return NaN
+    return Number.NaN
   }
   setAlwaysFormsContainingBlock(_: boolean): void {}
 
@@ -934,8 +934,8 @@ export class Node {
     _yogaMeasureCalls = 0
     _yogaCacheHits = 0
     _generation++
-    const w = ownerWidth === undefined ? NaN : ownerWidth
-    const h = ownerHeight === undefined ? NaN : ownerHeight
+    const w = ownerWidth === undefined ? Number.NaN : ownerWidth
+    const h = ownerHeight === undefined ? Number.NaN : ownerHeight
     layoutNode(
       this,
       w,
@@ -1207,8 +1207,8 @@ function layoutNode(
   const paddingBorderHeight = pad[1] + pad[3] + bor[1] + bor[3]
 
   // Resolve style dimensions
-  const styleWidth = forceWidth ? NaN : resolveValue(style.width, ownerWidth)
-  const styleHeight = forceHeight ? NaN : resolveValue(style.height, ownerHeight)
+  const styleWidth = forceWidth ? Number.NaN : resolveValue(style.width, ownerWidth)
+  const styleHeight = forceHeight ? Number.NaN : resolveValue(style.height, ownerHeight)
 
   // If style dimension is defined, it overrides the available size
   let width = availableWidth
@@ -1230,8 +1230,10 @@ function layoutNode(
 
   // Measure-func leaf node
   if (node.measureFunc && node.children.length === 0) {
-    const innerW = wMode === MeasureMode.Undefined ? NaN : Math.max(0, width - paddingBorderWidth)
-    const innerH = hMode === MeasureMode.Undefined ? NaN : Math.max(0, height - paddingBorderHeight)
+    const innerW =
+      wMode === MeasureMode.Undefined ? Number.NaN : Math.max(0, width - paddingBorderWidth)
+    const innerH =
+      hMode === MeasureMode.Undefined ? Number.NaN : Math.max(0, height - paddingBorderHeight)
     _yogaMeasureCalls++
     const measured = node.measureFunc(innerW, wMode, innerH, hMode)
     node.layout.width =
@@ -1318,8 +1320,8 @@ function layoutNode(
   const mainPadBorder = isMainRow ? paddingBorderWidth : paddingBorderHeight
   const crossPadBorder = isMainRow ? paddingBorderHeight : paddingBorderWidth
 
-  const innerMainSize = isDefined(mainSize) ? Math.max(0, mainSize - mainPadBorder) : NaN
-  const innerCrossSize = isDefined(crossSize) ? Math.max(0, crossSize - crossPadBorder) : NaN
+  const innerMainSize = isDefined(mainSize) ? Math.max(0, mainSize - mainPadBorder) : Number.NaN
+  const innerCrossSize = isDefined(crossSize) ? Math.max(0, crossSize - crossPadBorder) : Number.NaN
 
   // Resolve gap
   const gapMain = resolveGap(style, isMainRow ? Gutter.Column : Gutter.Row, innerMainSize)
@@ -1335,8 +1337,8 @@ function layoutNode(
   // values. Per CSS, a % width resolves against the parent's content-box
   // width. If this node's width is indefinite, children's % widths are also
   // indefinite — do NOT fall through to the grandparent's size.
-  const ownerW = isDefined(width) ? width : NaN
-  const ownerH = isDefined(height) ? height : NaN
+  const ownerW = isDefined(width) ? width : Number.NaN
+  const ownerH = isDefined(height) ? height : Number.NaN
   const isWrap = style.flexWrap !== Wrap.NoWrap
   const gapCross = resolveGap(style, isMainRow ? Gutter.Row : Gutter.Column, innerCrossSize)
 
@@ -1419,7 +1421,7 @@ function layoutNode(
       const cStyle = c.style
       const childAlign = cStyle.alignSelf === Align.Auto ? style.alignItems : cStyle.alignSelf
       const cMarginCross = childMarginForAxis(c, crossAx, ownerW)
-      let childCrossSize = NaN
+      let childCrossSize = Number.NaN
       let childCrossMode: MeasureMode = MeasureMode.Undefined
       const resolvedCrossStyle = resolveValue(
         isMainRow ? cStyle.height : cStyle.width,
@@ -2049,7 +2051,7 @@ function computeFlexBasis(
   //     with flex-grow children would grow into the AtMost constraint,
   //     inflating the basis (breaks YGMinMaxDimensionTest flex_grow_in_at_most
   //     where a flexGrow:1 child should stay at basis 0, not grow to 100).
-  let mainConstraint = NaN
+  let mainConstraint = Number.NaN
   let mainConstraintMode: MeasureMode = MeasureMode.Undefined
   if (isMainRow && isDefined(availableMain) && hasMeasureFuncInSubtree(child)) {
     mainConstraint = availableMain
@@ -2398,10 +2400,10 @@ function parseDimension(v: number | string | undefined): Value {
     return Number.isFinite(v) ? pointValue(v) : UNDEFINED_VALUE
   }
   if (typeof v === 'string' && v.endsWith('%')) {
-    return percentValue(parseFloat(v))
+    return percentValue(Number.parseFloat(v))
   }
-  const n = parseFloat(v)
-  return isNaN(n) ? UNDEFINED_VALUE : pointValue(n)
+  const n = Number.parseFloat(v)
+  return Number.isNaN(n) ? UNDEFINED_VALUE : pointValue(n)
 }
 
 function physicalEdge(edge: Edge): number {


### PR DESCRIPTION
## Summary

Re-opened of #4 (auto-closed when its base \`restore/renderer-sources\` was deleted on merge of #3). Same 18 commits, rebased onto current main.

Brings biome to **zero violations** across both packages and flips the CI lint stage from advisory to blocking. See original #4 for the full per-commit breakdown — content unchanged.

## Test plan

- [x] Rebased onto current main cleanly
- [x] \`pnpm install --frozen-lockfile\` succeeds
- [x] \`pnpm -r typecheck\` succeeds
- [x] \`pnpm -r lint\` succeeds (0 violations)
- [x] \`pnpm test\` succeeds (35 tests pass)
- [ ] CI green on this PR

## Notes

- Eighteen commits to preserve. Per workflow rule: must be merged with a normal merge commit.