### PR TITLE
fix(render): notches when overlapping absolutes get pulled apart

### DIFF
--- a/packages/renderer/src/render-node-to-output.test.ts
+++ b/packages/renderer/src/render-node-to-output.test.ts
@@ -767,6 +767,61 @@ describe('renderNodeToOutput — absolute node moving between frames', () => {
     }
   })
 
+  it('clean sibling stays fully painted when an overlapping absolute moves away (notch repro)', () => {
+    // Reproduces the "notches" bug from the drag demo: when A overlaps
+    // B in prev (A on top, last in tree), then A moves away, B's blit
+    // path would normally copy prev[B's rect] — which has A's old
+    // paint at the overlap. Per-cell suppression (the previous fix)
+    // hides that stale paint by zeroing those cells, but then B has
+    // empty cells where its paint should be — visible as missing
+    // chunks / notches.
+    //
+    // Fix: clean absolutes whose rect overlaps any moving sibling's
+    // OLD rect must re-render fully (not blit), so they paint their
+    // own content into the overlap cells.
+    const a = el('ink-box', {
+      position: 'absolute',
+      top: 0,
+      left: 0,
+      width: 10,
+      height: 1,
+    })
+    appendChildNode(a, txt('AAAAAAAAAA'))
+    const b = el('ink-box', {
+      position: 'absolute',
+      top: 0,
+      left: 5,
+      width: 10,
+      height: 1,
+    })
+    appendChildNode(b, txt('BBBBBBBBBB'))
+    const root = el('ink-root', { width: 30, height: 1, flexDirection: 'row' })
+    appendChildNode(root, a)
+    appendChildNode(root, b)
+    root.yogaNode!.calculateLayout(30, 1)
+
+    const frame2 = render2Frames(root, 30, 1, () => {
+      // Move A right, out of overlap with B
+      setStyle(a, { ...a.style, left: 20 })
+      applyStyles(a.yogaNode!, { ...a.style, left: 20 })
+    })
+
+    // B is at cols 5-14. ALL those cells should have 'B' — even the
+    // overlap region (cols 5-9) where A used to be on top in prev.
+    // Without the fix: cols 5-9 have empty cells (notch), cols 10-14
+    // have 'B' from B's own non-overlap area.
+    for (let col = 5; col <= 14; col++) {
+      expect(charAt(frame2, col, 0)).toBe('B')
+    }
+    // A's old non-overlap cells (cols 0-4) should be empty
+    for (let col = 0; col <= 4; col++) {
+      expect(charAt(frame2, col, 0)).not.toBe('A')
+    }
+    // A's new position (cols 20-29)
+    expect(charAt(frame2, 20, 0)).toBe('A')
+    expect(charAt(frame2, 29, 0)).toBe('A')
+  })
+
   it('clears the old position when an absolute node moves down', () => {
     // Same bug, vertical axis. Two-row viewport, overlay starts at
     // row 0, moves to row 1.

--- a/packages/renderer/src/render-node-to-output.ts
+++ b/packages/renderer/src/render-node-to-output.ts
@@ -1231,6 +1231,39 @@ function renderChildren(
     ? [...node.childNodes].sort((a, b) => effectiveZ(a) - effectiveZ(b))
     : node.childNodes
 
+  // Pre-scan for dirty absolute siblings whose OLD rect (cached from
+  // the previous frame) might overlap a clean absolute sibling's rect.
+  // When found, the clean sibling MUST re-render rather than blit:
+  //
+  //   prevScreen at the overlap holds the dirty sibling's OLD paint
+  //   (it was painted on top in prev — last-in-tree wins for equal z).
+  //   The clean sibling's blit would copy that stale paint into the new
+  //   frame, putting the moving box's old color where the clean box's
+  //   actual content should be. Per-cell suppression in output.ts hides
+  //   the stale paint by zeroing those cells — but then the clean
+  //   sibling has HOLES in its rect (the overlap cells stay empty).
+  //
+  //   Forcing re-render lets the clean sibling paint its own content
+  //   into the overlap cells, which is what the user sees as that box's
+  //   actual paint. The cost is one extra full-render per affected
+  //   sibling per frame the absolute moves — amortized across drag
+  //   frames, totally fine.
+  //
+  // Hot-path optimization: only run the scan if any sibling is BOTH
+  // dirty AND absolute. Most renders have no moving absolutes; we pay
+  // a single short loop per renderChildren call in that case.
+  let dirtyAbsoluteCachedRects: Rectangle[] | undefined
+  for (const c of orderedChildren) {
+    if (c.nodeName === '#text') continue
+    const elem = c as DOMElement
+    if (elem.dirty && elem.style.position === 'absolute') {
+      const cached = nodeCache.get(elem)
+      if (!cached) continue
+      if (!dirtyAbsoluteCachedRects) dirtyAbsoluteCachedRects = []
+      dirtyAbsoluteCachedRects.push(cached)
+    }
+  }
+
   // The contamination guards (seenDirtyChild, seenDirtyClipped) track
   // "earlier in CURRENT-frame paint order" — which is the new sorted
   // order, not raw tree order. Same logic, new iteration sequence.
@@ -1241,6 +1274,27 @@ function renderChildren(
     // Capture dirty before rendering — renderNodeToOutput clears the flag
     const wasDirty = childElem.dirty
     const isAbsolute = childElem.style.position === 'absolute'
+
+    // Force re-render for clean absolutes that overlap a moving sibling's
+    // OLD rect. See dirtyAbsoluteCachedRects comment above for why.
+    let overlapsMovingAbsolute = false
+    if (isAbsolute && !childElem.dirty && dirtyAbsoluteCachedRects !== undefined) {
+      const myCached = nodeCache.get(childElem)
+      if (myCached) {
+        for (const r of dirtyAbsoluteCachedRects) {
+          if (
+            myCached.x < r.x + r.width &&
+            myCached.x + myCached.width > r.x &&
+            myCached.y < r.y + r.height &&
+            myCached.y + myCached.height > r.y
+          ) {
+            overlapsMovingAbsolute = true
+            break
+          }
+        }
+      }
+    }
+
     renderNodeToOutput(childElem, output, {
       offsetX,
       offsetY,
@@ -1248,10 +1302,11 @@ function renderChildren(
       // Short-circuits on seenDirtyClipped (false in the common case) so
       // the opaque/bg reads don't happen per-child per-frame.
       skipSelfBlit:
-        seenDirtyClipped &&
-        isAbsolute &&
-        !childElem.style.opaque &&
-        childElem.style.backgroundColor === undefined,
+        overlapsMovingAbsolute ||
+        (seenDirtyClipped &&
+          isAbsolute &&
+          !childElem.style.opaque &&
+          childElem.style.backgroundColor === undefined),
       inheritedBackgroundColor,
     })
     if (wasDirty && !seenDirtyChild) {


### PR DESCRIPTION
## The bug

After fix #12 stopped the trail bug, dragging a box ON TOP of another and then OFF revealed a new failure mode: **missing chunks (notches)** in the underneath box, exactly where the dragged box used to overlap. Mark's screenshots show stair-step holes / cut-outs in the boxes left behind.

## Root cause

Two overlapping absolutes A (dirty, moving) and B (clean):
- In prev: A was painted on top (last-in-tree wins for equal z)
- prevScreen at A∩B has **A's old paint, NOT B's** (A overpainted B in prev)
- This frame: B is clean → takes the blit fast-path
- B's blit copies prev[B's rect] including A's stale paint at A∩B
- Per-cell suppression in fix #12 zeros those stale cells during the blit
- **Result**: B has empty cells where its actual content should be → the notches

The previous fix correctly removed A's stale paint, but the cleared cells stay empty because B's blit didn't fill them — and B's blit *can't* fill them, because B's prev paint at the overlap was already gone (overwritten by A in the previous frame).

## The fix

Lift the decision up to \`renderChildren\`: any clean absolute whose rect overlaps a moving (dirty) absolute sibling's old rect must **re-render**, not blit. The full render path repaints B's actual content into all its cells, including the overlap region.

Implementation: pre-scan children once to collect the cached rects of dirty absolute siblings. For each clean absolute child during iteration, AABB-overlap-check against those rects. If any overlap, set \`skipSelfBlit: true\` (an existing field, repurposed).

Combined with the per-cell suppression from #12, the final cell state at A's old rect:
- Cells in A's old not covered by any other absolute → zero (cleared) ✓
- Cells in A∩B (B's current rect) → B's fresh paint (re-rendered) ✓
- Cells outside A's old → untouched, normal blits ✓

## Cost

- Pre-scan gated: only runs if any sibling is dirty AND absolute. Most renders pay nothing.
- One extra full render per clean absolute that overlaps a moving sibling per frame the move happens. For typical drag (1-3 absolutes overlapping), microsecond overhead per frame.

## Test

New regression test in \`render-node-to-output.test.ts\`: \`clean sibling stays fully painted when an overlapping absolute moves away (notch repro)\`. Sets up A and B with partial overlap, A on top in prev, moves A away. Asserts B's cells in the overlap region all show 'B' (not empty). **Fails without the fix.**

75 tests pass total (74 → 75).

## Test plan

- [x] \`pnpm test\` passes (75/75 including notch-repro)
- [x] \`pnpm -r typecheck\` passes
- [x] \`pnpm -r lint\` passes
- [x] \`pnpm build\` succeeds
- [ ] CI green
- [ ] Mark verifies the demo: drag box on top of another, drag away, no notches

## Notes

Branches off main directly. Sequential fix: #12 stopped the trail bug, this addresses the new edge case it surfaced. After this lands and Mark confirms the demo is clean, drag-and-drop is genuinely working end-to-end.