### PR TITLE
fix(render): in-flow children also need re-render when overlapped by moving absolute

### DIFF
--- a/packages/renderer/src/render-node-to-output.test.ts
+++ b/packages/renderer/src/render-node-to-output.test.ts
@@ -822,6 +822,54 @@ describe('renderNodeToOutput — absolute node moving between frames', () => {
     expect(charAt(frame2, 29, 0)).toBe('A')
   })
 
+  it('clean IN-FLOW sibling stays fully painted when overlapping absolute moves away', () => {
+    // Same notch class of bug, but the underneath sibling is an in-flow
+    // text element instead of another absolute. The drag demo has the
+    // header text and the draggable boxes as siblings inside the same
+    // column container — dragging a box over the text and back left
+    // chunks of the text empty.
+    //
+    // The fix must apply to ANY clean child overlapping a moving
+    // absolute's old rect, not just clean absolute siblings.
+    const text = txt('hello world')
+    const overlay = el('ink-box', {
+      position: 'absolute',
+      top: 0,
+      left: 3,
+      width: 5,
+      height: 1,
+    })
+    appendChildNode(overlay, txt('XXXXX'))
+    const root = el('ink-root', { width: 30, height: 1, flexDirection: 'row' })
+    appendChildNode(root, text)
+    appendChildNode(root, overlay)
+    root.yogaNode!.calculateLayout(30, 1)
+
+    const frame2 = render2Frames(root, 30, 1, () => {
+      // Move the overlay out of the text's row entirely
+      setStyle(overlay, { ...overlay.style, left: 20 })
+      applyStyles(overlay.yogaNode!, { ...overlay.style, left: 20 })
+    })
+
+    // 'hello world' = 11 chars at cols 0-10. Without the fix, cols 3-7
+    // (where the overlay used to sit on top in prev) get zeroed by the
+    // per-cell suppression and stay empty.
+    expect(charAt(frame2, 0, 0)).toBe('h')
+    expect(charAt(frame2, 1, 0)).toBe('e')
+    expect(charAt(frame2, 2, 0)).toBe('l')
+    expect(charAt(frame2, 3, 0)).toBe('l') // overlap cell, must NOT be empty
+    expect(charAt(frame2, 4, 0)).toBe('o')
+    expect(charAt(frame2, 5, 0)).toBe(' ')
+    expect(charAt(frame2, 6, 0)).toBe('w')
+    expect(charAt(frame2, 7, 0)).toBe('o') // last overlap cell
+    expect(charAt(frame2, 8, 0)).toBe('r')
+    expect(charAt(frame2, 9, 0)).toBe('l')
+    expect(charAt(frame2, 10, 0)).toBe('d')
+    // Overlay's new position
+    expect(charAt(frame2, 20, 0)).toBe('X')
+    expect(charAt(frame2, 24, 0)).toBe('X')
+  })
+
   it('clears the old position when an absolute node moves down', () => {
     // Same bug, vertical axis. Two-row viewport, overlay starts at
     // row 0, moves to row 1.

--- a/packages/renderer/src/render-node-to-output.ts
+++ b/packages/renderer/src/render-node-to-output.ts
@@ -1275,10 +1275,30 @@ function renderChildren(
     const wasDirty = childElem.dirty
     const isAbsolute = childElem.style.position === 'absolute'
 
-    // Force re-render for clean absolutes that overlap a moving sibling's
-    // OLD rect. See dirtyAbsoluteCachedRects comment above for why.
+    // Force re-render for ANY clean child that overlaps a moving
+    // sibling's OLD rect — applies to both absolute and in-flow
+    // children. The blit fast-path would copy prevScreen[my rect],
+    // which has the moving sibling's STALE paint at the overlap (it
+    // was on top in prev). Per-cell suppression in output.ts zeros
+    // those stale cells, but then this child has empty cells where
+    // its actual content should be — visible as missing chunks.
+    //
+    // Forcing skipSelfBlit makes this child take the full render path
+    // and paint its own content (text characters, fill, border, etc.)
+    // into all its cells, including the overlap region.
+    //
+    // Originally this only fired for clean ABSOLUTE siblings, but
+    // in-flow children sit at the same DOM level as absolutes in
+    // typical layouts (a column container with header text +
+    // absolutely-positioned overlays). Dragging an overlay over the
+    // text and back left chunks of the text empty until something
+    // else triggered a repaint.
     let overlapsMovingAbsolute = false
-    if (isAbsolute && !childElem.dirty && dirtyAbsoluteCachedRects !== undefined) {
+    if (
+      !childElem.dirty &&
+      childElem.nodeName !== '#text' &&
+      dirtyAbsoluteCachedRects !== undefined
+    ) {
       const myCached = nodeCache.get(childElem)
       if (myCached) {
         for (const r of dirtyAbsoluteCachedRects) {


### PR DESCRIPTION
## The bug

Drag demo, third overlap-related bug found by Mark: dragging a box up over the header text and back left chunks of the text **empty** mid-string. A subsequent text selection (which triggers a full repaint) restored them.

## Why #13 missed it

PR #13 forced re-render for clean **absolute** siblings overlapping a moving absolute's old rect, but kept the blit fast-path for in-flow children. They hit the same prevScreen-leak + per-cell-suppression interaction:

- In prev: absolute on top of the in-flow text at overlap
- In-flow's blit copies prev's stale absolute paint at overlap
- Per-cell suppression in #12 zeros those cells
- In-flow text has chunks empty where chars should be

## The fix

One-line change in \`renderChildren\`: remove the \`isAbsolute\` requirement from the overlap-rerender guard. **Any clean non-text child** that overlaps a moving absolute's old rect now takes the full render path.

Text nodes (\`#text\`) are still excluded — they don't go through \`renderNodeToOutput\`'s blit fast-path; their content is rendered by the ink-text parent's full-render path.

## Cost

Identical to #13: pre-scan only runs if any sibling is dirty AND absolute. AABB check per clean child per moving absolute. Microsecond overhead per affected frame.

## Test

New regression test: \`clean IN-FLOW sibling stays fully painted when overlapping absolute moves away\`. ink-text 'hello world' next to an absolute box; box overlaps cols 3-7 of the text in prev, then moves away. Asserts every char of 'hello world' is intact (cols 0-10).

76 tests pass (75 → 76).

## Test plan

- [x] \`pnpm -r typecheck\` passes
- [x] \`pnpm -r lint\` passes
- [x] \`pnpm test\` passes (76/76)
- [ ] CI green
- [ ] Mark verifies the demo: drag a box across the header text and back, no missing chars

## Notes

This is the third in a series of overlap-related fixes (#12 trail bug, #13 absolute-overlap notches, this one for in-flow overlap notches). The original \`absoluteClears\` mechanism in \`output.ts\` was designed for absolute REMOVALS, where the cleared rect was usually larger than any sibling and the strict full-containment check worked. The drag demo exposed three classes of cases the original design didn't handle. After this PR lands, all three families have explicit regression tests.