### PR TITLE
fix(render): build-fix — text-node guard reads from DOMNode union

### DIFF
--- a/packages/renderer/src/render-node-to-output.ts
+++ b/packages/renderer/src/render-node-to-output.ts
@@ -1293,10 +1293,16 @@ function renderChildren(
     // absolutely-positioned overlays). Dragging an overlay over the
     // text and back left chunks of the text empty until something
     // else triggered a repaint.
+    // Text-node guard reads childNode (DOMNode union) rather than
+    // childElem (asserted DOMElement). The cast is the existing
+    // pattern in this loop; text nodes flow through but only do
+    // anything in renderNodeToOutput's text-handling paths. The
+    // overlap-rerender shortcut is not meaningful for them.
+    const isTextNode = childNode.nodeName === '#text'
     let overlapsMovingAbsolute = false
     if (
       !childElem.dirty &&
-      childElem.nodeName !== '#text' &&
+      !isTextNode &&
       dirtyAbsoluteCachedRects !== undefined
     ) {
       const myCached = nodeCache.get(childElem)


### PR DESCRIPTION
## What

Build broke after #15 merged. \`childElem.nodeName !== '#text'\` is dead code under TypeScript's narrowing because \`childElem\` was cast as \`DOMElement\` (whose \`nodeName\` is \`ElementNames\`, no \`'#text'\` overlap).

\`tsc --noEmit\` was happy because tsup's stricter dts build runs a separate compiler pass that flagged TS2367. CI / dts builds fail, runtime is unaffected.

## Fix

Read \`nodeName\` from \`childNode\` (the DOMNode union, before the cast) instead. Same runtime check; types now correct.

## Test plan

- [x] \`pnpm build\` succeeds
- [x] \`pnpm -r typecheck\` passes
- [x] \`pnpm -r lint\` passes
- [x] \`pnpm test\` passes (76/76)