### PR TITLE
demo(constrained-drag): pure solid blocks, no inner labels

### DIFF
--- a/examples/constrained-drag/constrained.tsx
+++ b/examples/constrained-drag/constrained.tsx
@@ -44,14 +44,12 @@ function Draggable({
   width,
   height,
   color,
-  label,
   bounds,
 }: {
   initialPos: Pos
   width: number
   height: number
   color: string
-  label: string
   bounds?: Bounds
 }): React.ReactNode {
   const [pos, setPos] = useState(initialPos)
@@ -99,13 +97,7 @@ function Draggable({
       zIndex={isDragging ? 30 : 10}
       backgroundColor={fillColor}
       onMouseDown={handleMouseDown}
-    >
-      <Box flexGrow={1} justifyContent="center" alignItems="center" backgroundColor={fillColor}>
-        <Text color="black" bold backgroundColor={fillColor}>
-          {label}
-        </Text>
-      </Box>
-    </Box>
+    />
   )
 }
 
@@ -156,13 +148,17 @@ function App(): React.ReactNode {
       <Box flexDirection="column" width="100%" height="100%" padding={1}>
         <Text bold>yokai · constrained-vs-free drag demo</Text>
         <Text dim>
-          each container has a <Text color="cyan">CONSTRAINED</Text> box (clamped to the container's
-          interior) and a <Text color="magenta">FREE</Text> box (can drag anywhere, even out of the
-          container).
+          left container: <Text color="cyan">cyan</Text> = constrained,{' '}
+          <Text color="magenta">magenta</Text> = free
         </Text>
         <Text dim>
-          drag the constrained box against an edge — it stops. drag the free box past the edge —
-          it leaves. <Text bold>q</Text> or <Text bold>Esc</Text> to quit.
+          right container: <Text color="green">green</Text> = constrained,{' '}
+          <Text color="yellow">orange</Text> = free
+        </Text>
+        <Text dim>
+          drag a constrained box against an edge — it stops. drag a free box past the edge — it
+          leaves and can land anywhere on screen. <Text bold>q</Text> / <Text bold>Esc</Text>{' '}
+          quits.
         </Text>
 
         <Container top={6} left={2} bgColor="#1a1a3a">
@@ -171,7 +167,6 @@ function App(): React.ReactNode {
             width={BOX_W}
             height={BOX_H}
             color="cyan"
-            label="constrained"
             bounds={containerBounds}
           />
           <Draggable
@@ -179,7 +174,6 @@ function App(): React.ReactNode {
             width={BOX_W}
             height={BOX_H}
             color="magenta"
-            label="free"
           />
         </Container>
 
@@ -189,7 +183,6 @@ function App(): React.ReactNode {
             width={BOX_W}
             height={BOX_H}
             color="green"
-            label="constrained"
             bounds={containerBounds}
           />
           <Draggable
@@ -197,7 +190,6 @@ function App(): React.ReactNode {
             width={BOX_W}
             height={BOX_H}
             color="orange"
-            label="free"
           />
         </Container>
       </Box>


### PR DESCRIPTION
Strips the inner Text labels from each Draggable. Boxes are now pure solid colored blocks (same shape as the original drag demo's final form).

## Why

With labels, the demo surfaced what looked like a separate render bug — boxes with nested in-flow content (Text inside the absolute Box) seemed to leave **notches in the parent container's background** after being dragged. Mark's screenshot showed irregular black holes inside the dark-blue container interior.

Hard to tell from a screenshot whether the trigger is nested content or something more general, so this PR strips down the demo to isolate. **If the notches reproduce here**, we have a clear deeper bug to investigate. **If they don't**, the bug is specifically about nested content inside dragged absolutes (also worth fixing, but separate).

The constrained-vs-free behavior doesn't depend on labels — color is enough to distinguish, and the header legend explains.

## Test plan

- [x] \`pnpm demo:constrained-drag\` launches without error
- [ ] Mark verifies: drag boxes around inside containers — do notches still appear in the container background?

## Note on "the black one"

Mark's screenshot also shows what he called the "black one" he can't move anymore. That's most likely the orange free box dragged off-screen — free boxes have no clamp so they can land anywhere including outside the visible viewport, where there's no way to click them back. Not a bug per se, but worth knowing if it keeps happening. (Could add a "snap back to last visible position" recovery later, but that's a feature decision.)