### PR TITLE
demo: raise on press so dragged boxes stay grabbable

### DIFF
--- a/examples/constrained-drag/constrained.tsx
+++ b/examples/constrained-drag/constrained.tsx
@@ -39,6 +39,18 @@ import {
 type Pos = { top: number; left: number }
 type Bounds = { width: number; height: number }
 
+// Monotonic counter for "raise on press" behavior. Each press bumps
+// the counter and assigns the new value to the pressed box's zIndex.
+// After release the box keeps that value, so subsequent clicks on the
+// same screen position correctly hit-test to the most-recently-pressed
+// box (rather than reverting to whoever's last in tree order). Matches
+// how every web drag-and-drop UI handles "bring to front."
+let nextZ = 10
+function takeNextZ(): number {
+  nextZ += 1
+  return nextZ
+}
+
 function Draggable({
   initialPos,
   width,
@@ -54,6 +66,9 @@ function Draggable({
 }): React.ReactNode {
   const [pos, setPos] = useState(initialPos)
   const [isDragging, setIsDragging] = useState(false)
+  // Persisted across renders: the box's current paint-order rank.
+  // Starts at the base z (10) and bumps on each press.
+  const [zIndex, setZIndex] = useState(10)
 
   const handleMouseDown = (e: MouseDownEvent): void => {
     const startTop = pos.top
@@ -61,6 +76,7 @@ function Draggable({
     const startCol = e.col
     const startRow = e.row
     setIsDragging(true)
+    setZIndex(takeNextZ())
     e.captureGesture({
       onMove(m) {
         let newTop = startTop + (m.row - startRow)
@@ -92,9 +108,13 @@ function Draggable({
       left={pos.left}
       width={width}
       height={height}
-      // Lift the dragged box above its siblings so it paints on top
-      // while moving. Z drops back when released.
-      zIndex={isDragging ? 30 : 10}
+      // While dragging, lift WAY above any sibling's persisted z
+      // (siblings cap out at the latest takeNextZ value, drag offset
+      // ensures we paint on top regardless of what they grew to).
+      // Otherwise use this box's own persisted z, which was bumped on
+      // its last press — so it stays in front of siblings it was
+      // recently dragged on top of.
+      zIndex={isDragging ? zIndex + 1000 : zIndex}
       backgroundColor={fillColor}
       onMouseDown={handleMouseDown}
     />

--- a/examples/drag/drag.tsx
+++ b/examples/drag/drag.tsx
@@ -33,6 +33,18 @@ import {
 
 type Pos = { top: number; left: number }
 
+// Monotonic counter for "raise on press" behavior. Each press bumps
+// the counter; the new value is assigned to the pressed box's zIndex.
+// Without this, after a drag releases the box's z drops back to the
+// shared base value (10), and the next click on its overlap area
+// hit-tests to whichever sibling is later in tree order — meaning
+// you can't easily re-grab the box you just moved.
+let nextZ = 10
+function takeNextZ(): number {
+  nextZ += 1
+  return nextZ
+}
+
 function Draggable({
   initialPos,
   color,
@@ -42,6 +54,7 @@ function Draggable({
 }): React.ReactNode {
   const [pos, setPos] = useState(initialPos)
   const [isDragging, setIsDragging] = useState(false)
+  const [zIndex, setZIndex] = useState(10)
 
   const handleMouseDown = (e: MouseDownEvent): void => {
     // Anchor the drag at the cursor's offset within the box so the
@@ -51,6 +64,7 @@ function Draggable({
     const startCol = e.col
     const startRow = e.row
     setIsDragging(true)
+    setZIndex(takeNextZ())
     e.captureGesture({
       onMove(m) {
         setPos({
@@ -72,7 +86,11 @@ function Draggable({
       left={pos.left}
       width={20}
       height={3}
-      zIndex={10}
+      // While dragging, lift WAY above any sibling's persisted z
+      // so we paint on top during motion. Otherwise use this box's
+      // own persisted z, which was bumped on press — keeps the box
+      // in front of siblings it was just dragged on top of.
+      zIndex={isDragging ? zIndex + 1000 : zIndex}
       backgroundColor={fillColor}
       onMouseDown={handleMouseDown}
     />


### PR DESCRIPTION
## The bug Mark hit

Drag a box on top of another, release. Now you can't pick the moved box up again — clicks land on the sibling underneath.

## Why

Both demos had every Draggable at fixed \`zIndex={10}\`. While dragging it bumped to \`30\`; on release it dropped back. With every sibling also at 10, paint and hit-test order fall through to DOM tree order — and the most-recently-dragged box is rarely last in tree, so it ends up buried.

## Fix

Monotonic \`nextZ\` counter shared across Draggable instances in each file. On press: bump the counter, store the new value as the box's own \`zIndex\` state. The bumped value persists across re-renders, so after release the box stays in front. Subsequent presses bump it further as needed.

This is exactly how every web drag-and-drop UI handles "bring to front" — z is sticky to interaction order, not to identity.

Applied to both \`examples/drag\` and \`examples/constrained-drag\`.

## Test plan

- [x] \`pnpm demo:drag\` launches
- [x] \`pnpm demo:constrained-drag\` launches
- [ ] Mark verifies: drag a box on top of another, release, then click + drag the (now-on-top) box again — works