### PR TITLE
fix(render): tree-wide overlap-rerender for cross-subtree absolute clears

### DIFF
--- a/packages/renderer/src/render-node-to-output.test.ts
+++ b/packages/renderer/src/render-node-to-output.test.ts
@@ -899,4 +899,76 @@ describe('renderNodeToOutput — absolute node moving between frames', () => {
     expect(charAt(frame2, 1, 1)).toBe('Y')
     expect(charAt(frame2, 2, 1)).toBe('Y')
   })
+
+  it('clean cousin of a moving absolute is repainted (cross-subtree notch repro)', () => {
+    // Reproduces the constrained-drag demo notch bug Mark observed:
+    //   Outer
+    //     ├─ text  (in-flow, rendered first)
+    //     └─ container (absolute, with bg)
+    //          └─ overlay (absolute, dragged this frame)
+    //
+    // The overlay clears its OLD rect with fromAbsolute=true, which adds
+    // that rect to absoluteClears (output.ts) — global, suppresses ANY
+    // blit covering those cells. If the overlay's old rect lies on a row
+    // shared with the in-flow text, the text's clean-blit at the outer
+    // renderChildren level gets per-cell suppressed there → cells go
+    // empty → notches in the text.
+    //
+    // The pre-fix overlap-rerender check at the outer level only looked
+    // at the container's cached rect (the only DIRECT dirty absolute
+    // sibling of the text). The overlay's rect, being a descendant, was
+    // invisible there, so the text wasn't forced to re-render.
+    //
+    // Fix: collect EVERY dirty absolute's cached rect tree-wide and use
+    // that for the overlap check at every level.
+    // Text on row 0. Container absolute on row 3 (does NOT overlap text).
+    // Overlay nested in container with negative top so its screen y lands
+    // back on row 0 (the text's row). Critical: at the root level, the
+    // only dirty absolute that's a direct child is the container, whose
+    // rect is at row 3 — does NOT overlap text. Without tree-wide
+    // collection, the text isn't forced to re-render and its blit cells
+    // get zeroed by the overlay's clear (in absoluteClears).
+    const text = txt('hello world hello world')
+    const overlay = el('ink-box', {
+      position: 'absolute',
+      top: -3, // container at row 3, overlay at -3 → screen row 0
+      left: 5,
+      width: 6,
+      height: 1,
+      backgroundColor: 'cyan',
+    })
+    const container = el('ink-box', {
+      position: 'absolute',
+      top: 3,
+      left: 0,
+      width: 30,
+      height: 1,
+    })
+    appendChildNode(container, overlay)
+
+    const root = el('ink-root', { width: 30, height: 4, flexDirection: 'column' })
+    appendChildNode(root, text)
+    appendChildNode(root, container)
+    root.yogaNode!.calculateLayout(30, 4)
+
+    const frame2 = render2Frames(root, 30, 4, () => {
+      // Move overlay sideways so it's no longer at cols 5..10 of row 0
+      setStyle(overlay, { ...overlay.style, left: 20 })
+      applyStyles(overlay.yogaNode!, { ...overlay.style, left: 20 })
+    })
+
+    // Cells (5..10, row 0) had the overlay in prev. The overlay moved
+    // away → text should be visible there. Without the tree-wide fix,
+    // those cells stay empty (per-cell suppression zeroed text's blit
+    // and nothing forced text to re-render).
+    expect(charAt(frame2, 5, 0)).toBe(' ')
+    expect(charAt(frame2, 6, 0)).toBe('w')
+    expect(charAt(frame2, 7, 0)).toBe('o')
+    expect(charAt(frame2, 8, 0)).toBe('r')
+    expect(charAt(frame2, 9, 0)).toBe('l')
+    expect(charAt(frame2, 10, 0)).toBe('d')
+    // Text still intact at non-overlap cells
+    expect(charAt(frame2, 0, 0)).toBe('h')
+    expect(charAt(frame2, 4, 0)).toBe('o')
+  })
 })

--- a/packages/renderer/src/render-node-to-output.ts
+++ b/packages/renderer/src/render-node-to-output.ts
@@ -54,6 +54,37 @@ let scrollHint: ScrollHint | null = null
 let absoluteRectsPrev: Rectangle[] = []
 let absoluteRectsCur: Rectangle[] = []
 
+// Cached rects of every dirty + position:absolute node anywhere in the
+// tree, captured ONCE at the start of each frame's render. Read by
+// renderChildren's overlap-rerender pre-scan to decide whether a clean
+// child must re-render (vs blit). Tree-wide rather than per-level
+// because a dirty absolute's clear lands in absoluteClears (output.ts),
+// which suppresses blits at any level — so a clean ancestor's clean
+// sibling can have its blit cells zeroed by a cousin's clear. The old
+// per-level check missed those cross-subtree overlaps; in the
+// constrained-drag demo, dragging a Draggable INSIDE a Container
+// stenciled the header text above (text is sibling of Container, not
+// of Draggable; Container's own rect doesn't overlap text rows; only
+// Draggable's clear does, and Draggable lived in a different subtree
+// from text's overlap check).
+let globalDirtyAbsoluteRects: Rectangle[] = []
+
+function resetGlobalDirtyAbsoluteRects(): void {
+  globalDirtyAbsoluteRects = []
+}
+
+function collectDirtyAbsoluteRects(node: DOMElement, out: Rectangle[]): void {
+  for (const c of node.childNodes) {
+    if (c.nodeName === '#text') continue
+    const elem = c as DOMElement
+    if (elem.dirty && elem.style.position === 'absolute') {
+      const cached = nodeCache.get(elem)
+      if (cached) out.push(cached)
+    }
+    collectDirtyAbsoluteRects(elem, out)
+  }
+}
+
 export function resetScrollHint(): void {
   scrollHint = null
   absoluteRectsPrev = absoluteRectsCur
@@ -379,6 +410,15 @@ function renderNodeToOutput(
     inheritedBackgroundColor?: Color
   },
 ): void {
+  // At the root entry, capture every dirty absolute's cached rect once
+  // for the whole frame. renderChildren reads this via the closure-shared
+  // module variable to do tree-wide overlap-rerender checks (see comment
+  // at globalDirtyAbsoluteRects). Recursive calls into renderNodeToOutput
+  // re-enter here too, but they pass non-root nodes — guard on ink-root.
+  if (node.nodeName === 'ink-root') {
+    resetGlobalDirtyAbsoluteRects()
+    collectDirtyAbsoluteRects(node, globalDirtyAbsoluteRects)
+  }
   const { yogaNode } = node
 
   if (yogaNode) {
@@ -1249,20 +1289,14 @@ function renderChildren(
   //   sibling per frame the absolute moves — amortized across drag
   //   frames, totally fine.
   //
-  // Hot-path optimization: only run the scan if any sibling is BOTH
-  // dirty AND absolute. Most renders have no moving absolutes; we pay
-  // a single short loop per renderChildren call in that case.
-  let dirtyAbsoluteCachedRects: Rectangle[] | undefined
-  for (const c of orderedChildren) {
-    if (c.nodeName === '#text') continue
-    const elem = c as DOMElement
-    if (elem.dirty && elem.style.position === 'absolute') {
-      const cached = nodeCache.get(elem)
-      if (!cached) continue
-      if (!dirtyAbsoluteCachedRects) dirtyAbsoluteCachedRects = []
-      dirtyAbsoluteCachedRects.push(cached)
-    }
-  }
+  // The dirty absolute rects we check overlap against are tree-wide,
+  // not just direct children of this node — see globalDirtyAbsoluteRects
+  // for the rationale (a clean child here can still have its blit cells
+  // suppressed by a moving absolute COUSIN's clear, since absoluteClears
+  // in output.ts is global). Computed once per frame at the ink-root
+  // entry; this loop just reads it.
+  const dirtyAbsoluteCachedRects =
+    globalDirtyAbsoluteRects.length > 0 ? globalDirtyAbsoluteRects : undefined
 
   // The contamination guards (seenDirtyChild, seenDirtyClipped) track
   // "earlier in CURRENT-frame paint order" — which is the new sorted


### PR DESCRIPTION
## Summary

Fixes the constrained-drag notch bug Mark hit: dragging a Draggable inside the absolute Container leaves stair-stepped black notches across the container bg AND the header text rows above it, accumulating one per drag motion. Force-redraw repaints clean.

## Root cause

The "clean child overlapping a moving absolute must re-render" guard in `renderChildren` only scanned **direct sibling** absolutes for its rect list. When a moving absolute is a deep descendant (Draggable inside Container), its old rect lands in `absoluteClears` (output.ts pass 1) — global, suppresses any blit covering those cells anywhere in the tree. A clean node at the outer level (the header text, which is a sibling of Container, not of Draggable) gets its blit cells zeroed and nothing forces it to re-render — only the Container's much larger cached rect was visible at the outer level, and that didn't overlap text rows.

The original drag demo doesn't reproduce because draggables are direct siblings of the text — same `renderChildren` call, the per-level scan caught it.

## Fix

Walk the tree once at the `ink-root` entry to collect every dirty + absolute node's cached rect. `renderChildren` reads the same module-scope list at every level for its overlap check. Same order of work overall (one O(N) walk replacing many small per-renderChildren walks).

## Test

Added a focused regression test that constructs the exact failure shape — text row 0, container row 3, overlay nested inside container with negative top so its screen rect lands on row 0 — proving:
- The bug was real (test fails on parent commit).
- The fix addresses it (test passes on tip).

## Test plan

- [x] `npx vitest run` — all 77 tests pass
- [x] `pnpm -r typecheck`
- [x] Regression test added that fails without the fix
- [ ] Manual: `pnpm demo:constrained-drag`, drag any box around — no notches accumulate