### PR TITLE
feat(components): Draggable — first-class drag primitive

### DIFF
--- a/examples/constrained-drag/constrained.tsx
+++ b/examples/constrained-drag/constrained.tsx
@@ -3,129 +3,31 @@
  *
  *   pnpm demo:constrained-drag
  *
- * Two parent containers side by side. Each contains two draggable
- * rectangles:
+ * Two parent containers side by side. Each contains two `<Draggable>`s:
  *
- *   - **constrained** (cyan/green): clamped to the parent's interior.
- *     Drag it right against an edge — it stops there. Useful for
- *     real-world UIs where some elements must stay within their
- *     region (resize handles, sliders, in-pane drag-to-reorder).
+ *   - **constrained** (cyan/green): pass `bounds={containerBounds}` so
+ *     the box stays inside the parent. Drag against an edge, it stops.
  *
- *   - **free** (orange/pink): no clamping. Drag it anywhere on screen,
- *     including past its parent's edge or into the other container.
- *     Useful for elements that can be detached from their starting
- *     pane (moving cards between columns, dragging an item to trash).
+ *   - **free** (magenta/orange): no `bounds` prop → drag anywhere on
+ *     screen, including past the parent's edge into the other container
+ *     or onto the title text.
  *
- * The same Draggable component handles both — the only difference is
- * an optional `bounds` prop. When set, onMove clamps the new position;
- * when unset, the box can go anywhere. Mixed-mode drag in one screen
- * is the realistic shape for actual TUI apps: persistent layout
- * elements alongside transient draggable widgets.
+ * Same `<Draggable>` component handles both — the only difference is
+ * presence/absence of `bounds`. Mixed-mode drag in one screen is the
+ * realistic shape for actual TUI apps: persistent layout regions
+ * alongside transient widgets that can be repositioned anywhere.
  *
  * Press q or Escape to quit.
  */
 
-import React, { useState } from 'react'
-import {
-  AlternateScreen,
-  Box,
-  type MouseDownEvent,
-  Text,
-  render,
-  useApp,
-  useInput,
-} from '@yokai/renderer'
-
-type Pos = { top: number; left: number }
-type Bounds = { width: number; height: number }
-
-// Monotonic counter for "raise on press" behavior. Each press bumps
-// the counter and assigns the new value to the pressed box's zIndex.
-// After release the box keeps that value, so subsequent clicks on the
-// same screen position correctly hit-test to the most-recently-pressed
-// box (rather than reverting to whoever's last in tree order). Matches
-// how every web drag-and-drop UI handles "bring to front."
-let nextZ = 10
-function takeNextZ(): number {
-  nextZ += 1
-  return nextZ
-}
-
-function Draggable({
-  initialPos,
-  width,
-  height,
-  color,
-  bounds,
-}: {
-  initialPos: Pos
-  width: number
-  height: number
-  color: string
-  bounds?: Bounds
-}): React.ReactNode {
-  const [pos, setPos] = useState(initialPos)
-  const [isDragging, setIsDragging] = useState(false)
-  // Persisted across renders: the box's current paint-order rank.
-  // Starts at the base z (10) and bumps on each press.
-  const [zIndex, setZIndex] = useState(10)
-
-  const handleMouseDown = (e: MouseDownEvent): void => {
-    const startTop = pos.top
-    const startLeft = pos.left
-    const startCol = e.col
-    const startRow = e.row
-    setIsDragging(true)
-    setZIndex(takeNextZ())
-    e.captureGesture({
-      onMove(m) {
-        let newTop = startTop + (m.row - startRow)
-        let newLeft = startLeft + (m.col - startCol)
-        // Clamp to the container's interior if bounds were provided.
-        // The min/max are inclusive on the leading edge and exclusive
-        // on the trailing edge minus our own size — i.e. the box's
-        // (top, left) can be at the container's top-left corner (0,0)
-        // but no further than (bounds.height - height, bounds.width
-        // - width), so the box's bottom-right edge lands exactly on
-        // the container's bottom-right edge.
-        if (bounds) {
-          newTop = Math.max(0, Math.min(bounds.height - height, newTop))
-          newLeft = Math.max(0, Math.min(bounds.width - width, newLeft))
-        }
-        setPos({ top: newTop, left: newLeft })
-      },
-      onUp() {
-        setIsDragging(false)
-      },
-    })
-  }
-
-  const fillColor = isDragging ? 'yellow' : color
-  return (
-    <Box
-      position="absolute"
-      top={pos.top}
-      left={pos.left}
-      width={width}
-      height={height}
-      // While dragging, lift WAY above any sibling's persisted z
-      // (siblings cap out at the latest takeNextZ value, drag offset
-      // ensures we paint on top regardless of what they grew to).
-      // Otherwise use this box's own persisted z, which was bumped on
-      // its last press — so it stays in front of siblings it was
-      // recently dragged on top of.
-      zIndex={isDragging ? zIndex + 1000 : zIndex}
-      backgroundColor={fillColor}
-      onMouseDown={handleMouseDown}
-    />
-  )
-}
+import { AlternateScreen, Box, Draggable, Text, render, useApp, useInput } from '@yokai/renderer'
+import type React from 'react'
 
 const CONTAINER_W = 36
 const CONTAINER_H = 10
 const BOX_W = 10
 const BOX_H = 3
-const containerBounds: Bounds = { width: CONTAINER_W, height: CONTAINER_H }
+const containerBounds = { width: CONTAINER_W, height: CONTAINER_H }
 
 function Container({
   top,
@@ -146,8 +48,8 @@ function Container({
       width={CONTAINER_W}
       height={CONTAINER_H}
       backgroundColor={bgColor}
-      // zIndex keeps the container behind the inner draggables (which
-      // are z=10+ when idle, z=30 while dragging) but in front of
+      // zIndex keeps the container behind the inner draggables (Draggable
+      // base z is 10, drag-time boost adds 1000 on top) but in front of
       // background. Without it the in-flow header text could end up
       // on top in the equal-z tree-order tiebreak.
       zIndex={1}
@@ -177,8 +79,7 @@ function App(): React.ReactNode {
         </Text>
         <Text dim>
           drag a constrained box against an edge — it stops. drag a free box past the edge — it
-          leaves and can land anywhere on screen. <Text bold>q</Text> / <Text bold>Esc</Text>{' '}
-          quits.
+          leaves and can land anywhere on screen. <Text bold>q</Text> / <Text bold>Esc</Text> quits.
         </Text>
 
         <Container top={6} left={2} bgColor="#1a1a3a">
@@ -186,14 +87,14 @@ function App(): React.ReactNode {
             initialPos={{ top: 1, left: 2 }}
             width={BOX_W}
             height={BOX_H}
-            color="cyan"
+            backgroundColor="cyan"
             bounds={containerBounds}
           />
           <Draggable
             initialPos={{ top: 5, left: 18 }}
             width={BOX_W}
             height={BOX_H}
-            color="magenta"
+            backgroundColor="magenta"
           />
         </Container>
 
@@ -202,14 +103,14 @@ function App(): React.ReactNode {
             initialPos={{ top: 1, left: 2 }}
             width={BOX_W}
             height={BOX_H}
-            color="green"
+            backgroundColor="green"
             bounds={containerBounds}
           />
           <Draggable
             initialPos={{ top: 5, left: 18 }}
             width={BOX_W}
             height={BOX_H}
-            color="orange"
+            backgroundColor="orange"
           />
         </Container>
       </Box>

--- a/examples/drag/drag.tsx
+++ b/examples/drag/drag.tsx
@@ -3,99 +3,17 @@
  *
  *   pnpm demo:drag
  *
- * Renders a draggable box in the alt-screen buffer. Press the box,
+ * Renders three draggable boxes in the alt-screen buffer. Press a box,
  * drag it with the mouse, release to drop. Press 'q' or Escape to exit.
  *
- * Exercises the full mouse-events stack:
- *   - <AlternateScreen mouseTracking> enables SGR mouse modes
- *   - onMouseDown fires on press
- *   - event.captureGesture() claims the gesture for this drag, suppressing
- *     selection extension
- *   - onMove updates React state on each cell-crossing motion event
- *   - The diff engine repaints only the changed cells per frame
- *   - zIndex={10} keeps the box on top of background content
- *   - onUp fires once at release; capture clears
- *
- * If anything stutters, lags, or the box doesn't follow the cursor,
- * something in the chain is broken — file a bug.
+ * Exercises the full mouse-events stack via the polished `<Draggable>`
+ * primitive — the demo no longer reimplements the gesture wiring,
+ * z-index bumping, or drag-time z boost. Those are baked into the
+ * component now; demos just position boxes and let drag happen.
  */
 
-import React, { useState } from 'react'
-import {
-  AlternateScreen,
-  Box,
-  type MouseDownEvent,
-  Text,
-  render,
-  useApp,
-  useInput,
-} from '@yokai/renderer'
-
-type Pos = { top: number; left: number }
-
-// Monotonic counter for "raise on press" behavior. Each press bumps
-// the counter; the new value is assigned to the pressed box's zIndex.
-// Without this, after a drag releases the box's z drops back to the
-// shared base value (10), and the next click on its overlap area
-// hit-tests to whichever sibling is later in tree order — meaning
-// you can't easily re-grab the box you just moved.
-let nextZ = 10
-function takeNextZ(): number {
-  nextZ += 1
-  return nextZ
-}
-
-function Draggable({
-  initialPos,
-  color,
-}: {
-  initialPos: Pos
-  color: string
-}): React.ReactNode {
-  const [pos, setPos] = useState(initialPos)
-  const [isDragging, setIsDragging] = useState(false)
-  const [zIndex, setZIndex] = useState(10)
-
-  const handleMouseDown = (e: MouseDownEvent): void => {
-    // Anchor the drag at the cursor's offset within the box so the
-    // grabbed point stays under the cursor as the user moves.
-    const startTop = pos.top
-    const startLeft = pos.left
-    const startCol = e.col
-    const startRow = e.row
-    setIsDragging(true)
-    setZIndex(takeNextZ())
-    e.captureGesture({
-      onMove(m) {
-        setPos({
-          top: startTop + (m.row - startRow),
-          left: startLeft + (m.col - startCol),
-        })
-      },
-      onUp() {
-        setIsDragging(false)
-      },
-    })
-  }
-
-  const fillColor = isDragging ? 'yellow' : color
-  return (
-    <Box
-      position="absolute"
-      top={pos.top}
-      left={pos.left}
-      width={20}
-      height={3}
-      // While dragging, lift WAY above any sibling's persisted z
-      // so we paint on top during motion. Otherwise use this box's
-      // own persisted z, which was bumped on press — keeps the box
-      // in front of siblings it was just dragged on top of.
-      zIndex={isDragging ? zIndex + 1000 : zIndex}
-      backgroundColor={fillColor}
-      onMouseDown={handleMouseDown}
-    />
-  )
-}
+import { AlternateScreen, Box, Draggable, Text, render, useApp, useInput } from '@yokai/renderer'
+import type React from 'react'
 
 function App(): React.ReactNode {
   const { exit } = useApp()
@@ -114,12 +32,16 @@ function App(): React.ReactNode {
           three boxes overlap at start — drag the front one (highest zIndex) to expose the others.
         </Text>
 
-        {/* Three boxes at staggered start positions, different zIndexes
-            so we can see the z-index code in action. The box at z=12
-            paints on top until the user drags it elsewhere. */}
-        <Draggable initialPos={{ top: 6, left: 4 }} color="cyan" />
-        <Draggable initialPos={{ top: 7, left: 8 }} color="green" />
-        <Draggable initialPos={{ top: 8, left: 12 }} color="magenta" />
+        {/* Three solid boxes at staggered start positions. Draggable owns
+            the position state, raise-on-press, and drag-time z boost. */}
+        <Draggable initialPos={{ top: 6, left: 4 }} width={20} height={3} backgroundColor="cyan" />
+        <Draggable initialPos={{ top: 7, left: 8 }} width={20} height={3} backgroundColor="green" />
+        <Draggable
+          initialPos={{ top: 8, left: 12 }}
+          width={20}
+          height={3}
+          backgroundColor="magenta"
+        />
       </Box>
     </AlternateScreen>
   )

--- a/packages/renderer/src/components/Draggable.test.tsx
+++ b/packages/renderer/src/components/Draggable.test.tsx
@@ -1,0 +1,330 @@
+/**
+ * Draggable component tests.
+ *
+ * Two tiers of coverage:
+ *
+ *   1. **Pure-math** tests for `computeDraggedPos` — the cell-arithmetic
+ *      that drives every drag motion. Covered exhaustively here so any
+ *      regression in the offset/clamp math is caught without spinning
+ *      up React.
+ *
+ *   2. **Gesture-protocol** tests that drive `handleDragPress` directly
+ *      with stub setters and capture the gesture handlers it installs
+ *      on the MouseDownEvent. This skips React's render loop deliberately
+ *      — what we're testing is the press → motion → release contract,
+ *      not React's reconciler. The component's only job is wiring this
+ *      function to useState/useRef, which the demos exercise live.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { MouseDownEvent, MouseMoveEvent, MouseUpEvent } from '../events/mouse-event.js'
+import {
+  type DragBounds,
+  type DragInfo,
+  type DragPos,
+  _resetDraggableZForTesting,
+  computeDraggedPos,
+  handleDragPress,
+} from './Draggable.js'
+
+// ── pure math ────────────────────────────────────────────────────────
+
+describe('computeDraggedPos', () => {
+  it('returns the start position when cursor has not moved', () => {
+    const startPos = { top: 5, left: 10 }
+    expect(computeDraggedPos(startPos, 20, 30, 20, 30)).toEqual({ top: 5, left: 10 })
+  })
+
+  it('translates by the cursor delta when unbounded', () => {
+    expect(computeDraggedPos({ top: 5, left: 10 }, 20, 30, 23, 32)).toEqual({
+      top: 7,
+      left: 13,
+    })
+  })
+
+  it('handles negative deltas (drag up-left)', () => {
+    expect(computeDraggedPos({ top: 5, left: 10 }, 20, 30, 18, 27)).toEqual({
+      top: 2,
+      left: 8,
+    })
+  })
+
+  it('clamps top within bounds when bounds + size are supplied', () => {
+    // Drag past the bottom: bounds.height=10, box.height=3 → max top=7.
+    expect(
+      computeDraggedPos({ top: 0, left: 0 }, 0, 0, 0, 15, { width: 20, height: 10 }, 5, 3),
+    ).toEqual({ top: 7, left: 0 })
+  })
+
+  it('clamps left within bounds when bounds + size are supplied', () => {
+    // Drag past the right: bounds.width=20, box.width=5 → max left=15.
+    expect(
+      computeDraggedPos({ top: 0, left: 0 }, 0, 0, 30, 0, { width: 20, height: 10 }, 5, 3),
+    ).toEqual({ top: 0, left: 15 })
+  })
+
+  it('clamps to zero when dragged past the top-left edge', () => {
+    expect(
+      computeDraggedPos({ top: 0, left: 0 }, 0, 0, -10, -10, { width: 20, height: 10 }, 5, 3),
+    ).toEqual({ top: 0, left: 0 })
+  })
+
+  it('does not clamp when bounds is omitted (free drag)', () => {
+    expect(computeDraggedPos({ top: 0, left: 0 }, 0, 0, -100, -100)).toEqual({
+      top: -100,
+      left: -100,
+    })
+  })
+
+  it('does not clamp when only width is supplied (no bounds)', () => {
+    // Bounds requires BOTH dims and a width/height — partial info → no clamp.
+    expect(computeDraggedPos({ top: 0, left: 0 }, 0, 0, 100, 100, undefined, 5, 3)).toEqual({
+      top: 100,
+      left: 100,
+    })
+  })
+
+  it('returns top-left zero when bounds smaller than the box (degenerate)', () => {
+    // box 10x5 inside 5x3 bounds — max top/left would be negative; clamp pins at 0.
+    expect(
+      computeDraggedPos({ top: 0, left: 0 }, 0, 0, 50, 50, { width: 5, height: 3 }, 10, 5),
+    ).toEqual({ top: 0, left: 0 })
+  })
+})
+
+// ── gesture-protocol ─────────────────────────────────────────────────
+
+/** Build a stub deps object so each test can drive handleDragPress
+ *  in isolation. setters are vi.fn() so tests can assert call counts;
+ *  refs start with the values typically supplied by useRef in the
+ *  component (latest props at press time). */
+function makeDeps(
+  opts: {
+    startPos?: DragPos
+    bounds?: DragBounds
+    width?: number
+    height?: number
+    disabled?: boolean
+    onDragStart?: (info: DragInfo) => void
+    onDrag?: (info: DragInfo) => void
+    onDragEnd?: (info: DragInfo) => void
+  } = {},
+): Parameters<typeof handleDragPress>[1] & {
+  setPos: ReturnType<typeof vi.fn>
+  setIsDragging: ReturnType<typeof vi.fn>
+  setPersistedZ: ReturnType<typeof vi.fn>
+  latestPosRef: { current: DragPos }
+} {
+  const startPos = opts.startPos ?? { top: 0, left: 0 }
+  return {
+    startPos,
+    disabled: opts.disabled,
+    boundsRef: { current: opts.bounds },
+    widthRef: { current: opts.width },
+    heightRef: { current: opts.height },
+    latestPosRef: { current: startPos },
+    setPos: vi.fn(),
+    setIsDragging: vi.fn(),
+    setPersistedZ: vi.fn(),
+    onDragStartRef: { current: opts.onDragStart },
+    onDragRef: { current: opts.onDrag },
+    onDragEndRef: { current: opts.onDragEnd },
+  }
+}
+
+describe('handleDragPress', () => {
+  it('captures a gesture on press', () => {
+    _resetDraggableZForTesting()
+    const e = new MouseDownEvent(5, 1, 0)
+    handleDragPress(e, makeDeps())
+    expect(e._capturedHandlers).not.toBeNull()
+    expect(e._capturedHandlers?.onMove).toBeTypeOf('function')
+    expect(e._capturedHandlers?.onUp).toBeTypeOf('function')
+  })
+
+  it('bumps persisted z on press, even with no motion', () => {
+    _resetDraggableZForTesting()
+    const e = new MouseDownEvent(5, 1, 0)
+    const deps = makeDeps()
+    handleDragPress(e, deps)
+    expect(deps.setPersistedZ).toHaveBeenCalledTimes(1)
+    // Subsequent press bumps strictly higher
+    const e2 = new MouseDownEvent(5, 1, 0)
+    const deps2 = makeDeps()
+    handleDragPress(e2, deps2)
+    const z1 = deps.setPersistedZ.mock.calls[0]![0] as number
+    const z2 = deps2.setPersistedZ.mock.calls[0]![0] as number
+    expect(z2).toBeGreaterThan(z1)
+  })
+
+  it('does NOT capture a gesture when disabled', () => {
+    _resetDraggableZForTesting()
+    const e = new MouseDownEvent(5, 1, 0)
+    const deps = makeDeps({ disabled: true })
+    handleDragPress(e, deps)
+    expect(e._capturedHandlers).toBeNull()
+    expect(deps.setPersistedZ).not.toHaveBeenCalled()
+  })
+
+  it('does NOT fire onDragStart on press alone', () => {
+    _resetDraggableZForTesting()
+    const onDragStart = vi.fn()
+    const e = new MouseDownEvent(5, 1, 0)
+    handleDragPress(e, makeDeps({ onDragStart }))
+    expect(onDragStart).not.toHaveBeenCalled()
+  })
+
+  it('fires onDragStart on the FIRST motion event with start + delta', () => {
+    _resetDraggableZForTesting()
+    const onDragStart = vi.fn()
+    const e = new MouseDownEvent(15, 6, 0)
+    handleDragPress(
+      e,
+      makeDeps({ startPos: { top: 5, left: 10 }, onDragStart, width: 10, height: 3 }),
+    )
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(17, 7, 0))
+    expect(onDragStart).toHaveBeenCalledTimes(1)
+    expect(onDragStart).toHaveBeenCalledWith({
+      pos: { top: 6, left: 12 },
+      startPos: { top: 5, left: 10 },
+      delta: { dx: 2, dy: 1 },
+    })
+  })
+
+  it('fires onDragStart only ONCE across many motion events', () => {
+    _resetDraggableZForTesting()
+    const onDragStart = vi.fn()
+    const e = new MouseDownEvent(0, 0, 0)
+    handleDragPress(e, makeDeps({ onDragStart }))
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(1, 0, 0))
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(2, 0, 0))
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(3, 0, 0))
+    expect(onDragStart).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires onDrag on each motion event', () => {
+    _resetDraggableZForTesting()
+    const onDrag = vi.fn()
+    const e = new MouseDownEvent(0, 0, 0)
+    handleDragPress(e, makeDeps({ onDrag }))
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(1, 0, 0))
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(2, 0, 0))
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(3, 1, 0))
+    expect(onDrag).toHaveBeenCalledTimes(3)
+    expect(onDrag).toHaveBeenLastCalledWith({
+      pos: { top: 1, left: 3 },
+      startPos: { top: 0, left: 0 },
+      delta: { dx: 3, dy: 1 },
+    })
+  })
+
+  it('updates setPos on every motion (so the rendered pos tracks the cursor)', () => {
+    _resetDraggableZForTesting()
+    const e = new MouseDownEvent(0, 0, 0)
+    const deps = makeDeps()
+    handleDragPress(e, deps)
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(5, 2, 0))
+    expect(deps.setPos).toHaveBeenLastCalledWith({ top: 2, left: 5 })
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(8, 3, 0))
+    expect(deps.setPos).toHaveBeenLastCalledWith({ top: 3, left: 8 })
+  })
+
+  it('flips isDragging true on first motion and false on release', () => {
+    _resetDraggableZForTesting()
+    const e = new MouseDownEvent(0, 0, 0)
+    const deps = makeDeps()
+    handleDragPress(e, deps)
+    expect(deps.setIsDragging).not.toHaveBeenCalled()
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(1, 0, 0))
+    expect(deps.setIsDragging).toHaveBeenLastCalledWith(true)
+    e._capturedHandlers!.onUp!(new MouseUpEvent(1, 0, 0))
+    expect(deps.setIsDragging).toHaveBeenLastCalledWith(false)
+  })
+
+  it('fires onDragEnd at release with the final visible pos', () => {
+    _resetDraggableZForTesting()
+    const onDragEnd = vi.fn()
+    const e = new MouseDownEvent(0, 0, 0)
+    handleDragPress(e, makeDeps({ onDragEnd }))
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(5, 2, 0))
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(8, 3, 0))
+    e._capturedHandlers!.onUp!(new MouseUpEvent(8, 3, 0))
+    expect(onDragEnd).toHaveBeenCalledTimes(1)
+    expect(onDragEnd).toHaveBeenCalledWith({
+      pos: { top: 3, left: 8 },
+      startPos: { top: 0, left: 0 },
+      delta: { dx: 8, dy: 3 },
+    })
+  })
+
+  it('does NOT fire onDragEnd on release if no motion happened', () => {
+    _resetDraggableZForTesting()
+    const onDragEnd = vi.fn()
+    const e = new MouseDownEvent(0, 0, 0)
+    handleDragPress(e, makeDeps({ onDragEnd }))
+    e._capturedHandlers!.onUp!(new MouseUpEvent(0, 0, 0))
+    expect(onDragEnd).not.toHaveBeenCalled()
+  })
+
+  it('does NOT flip isDragging false on release if no drag happened', () => {
+    _resetDraggableZForTesting()
+    const e = new MouseDownEvent(0, 0, 0)
+    const deps = makeDeps()
+    handleDragPress(e, deps)
+    e._capturedHandlers!.onUp!(new MouseUpEvent(0, 0, 0))
+    expect(deps.setIsDragging).not.toHaveBeenCalled()
+  })
+
+  it('clamps motion to bounds when supplied', () => {
+    _resetDraggableZForTesting()
+    const onDrag = vi.fn()
+    const e = new MouseDownEvent(0, 0, 0)
+    handleDragPress(
+      e,
+      makeDeps({
+        bounds: { width: 20, height: 10 },
+        width: 5,
+        height: 3,
+        onDrag,
+      }),
+    )
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(100, 100, 0))
+    // Max valid top = 10 - 3 = 7; max valid left = 20 - 5 = 15.
+    expect(onDrag).toHaveBeenLastCalledWith({
+      pos: { top: 7, left: 15 },
+      startPos: { top: 0, left: 0 },
+      delta: { dx: 100, dy: 100 },
+    })
+  })
+
+  it('reads bounds from the ref at gesture time (so mid-drag bounds changes apply)', () => {
+    _resetDraggableZForTesting()
+    const onDrag = vi.fn()
+    const e = new MouseDownEvent(0, 0, 0)
+    const deps = makeDeps({
+      bounds: { width: 20, height: 10 },
+      width: 5,
+      height: 3,
+      onDrag,
+    })
+    handleDragPress(e, deps)
+    // First motion with original bounds (clamped to 15, 7).
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(100, 100, 0))
+    expect(onDrag).toHaveBeenLastCalledWith(expect.objectContaining({ pos: { top: 7, left: 15 } }))
+    // Now shrink bounds mid-drag — next motion should clamp to the new max.
+    deps.boundsRef.current = { width: 10, height: 5 }
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(100, 100, 0))
+    // Max now: top = 5 - 3 = 2; left = 10 - 5 = 5.
+    expect(onDrag).toHaveBeenLastCalledWith(expect.objectContaining({ pos: { top: 2, left: 5 } }))
+  })
+
+  it('does NOT fire onUp from a captured gesture when disabled (no gesture captured)', () => {
+    _resetDraggableZForTesting()
+    const onDragEnd = vi.fn()
+    const e = new MouseDownEvent(0, 0, 0)
+    handleDragPress(e, makeDeps({ disabled: true, onDragEnd }))
+    // No gesture captured → no onUp to call. Sanity-check the contract.
+    expect(e._capturedHandlers).toBeNull()
+    expect(onDragEnd).not.toHaveBeenCalled()
+  })
+})

--- a/packages/renderer/src/components/Draggable.tsx
+++ b/packages/renderer/src/components/Draggable.tsx
@@ -1,0 +1,353 @@
+import type React from 'react'
+import { useCallback, useRef, useState } from 'react'
+import type { Except } from 'type-fest'
+import type { MouseDownEvent, MouseMoveEvent, MouseUpEvent } from '../events/mouse-event.js'
+import Box, { type Props as BoxProps } from './Box.js'
+
+/**
+ * A position in cell coordinates relative to the parent's content edge.
+ * Mirrors yoga's absolute-positioning convention: `top`/`left` are integer
+ * cell offsets, the same shape Yoga's `top`/`left` style accepts.
+ */
+export type DragPos = { top: number; left: number }
+
+/**
+ * Constraints in cell dimensions. When supplied, the draggable's `top`
+ * stays within `[0, height - draggableHeight]` and `left` within
+ * `[0, width - draggableWidth]`. Use the parent container's interior
+ * dimensions to clamp inside it (the constrained-drag demo does this).
+ */
+export type DragBounds = { width: number; height: number }
+
+/**
+ * Lifecycle payload passed to onDragStart / onDrag / onDragEnd.
+ * `delta` is screen-space cell delta from the press point — not from
+ * the previous frame.
+ */
+export type DragInfo = {
+  pos: DragPos
+  startPos: DragPos
+  delta: { dx: number; dy: number }
+}
+
+export type DraggableProps = Except<
+  BoxProps,
+  // We own placement and the press handler. Letting the user override
+  // `position` would break drag math; overriding `top`/`left` would
+  // fight the internal pos state every render.
+  'position' | 'top' | 'left' | 'onMouseDown'
+> & {
+  /**
+   * Where the draggable sits before the user moves it. Cell offsets
+   * relative to the parent's content edge, same as `<Box top>` / `<Box left>`.
+   * Internal state seeds from this on mount; subsequent renders use the
+   * dragged position. Changing this prop after mount is ignored — treat it
+   * as initial-state-only, like React's `defaultValue`.
+   */
+  initialPos: DragPos
+  /**
+   * Optional bounds in the parent's content space. When set, drag motion
+   * clamps the new position so the draggable's full rect stays inside
+   * `[0,0]` to `[bounds.width, bounds.height]`. When omitted, drag is
+   * unbounded — useful for "free" pieces that can land anywhere on screen
+   * (the constrained-drag demo's `magenta`/`orange` boxes).
+   */
+  bounds?: DragBounds
+  /**
+   * When true, press events are ignored — no gesture is captured, no
+   * z-index bump, no callbacks fire. The element still renders and
+   * occupies space; it's just immobile. Mirrors HTML `<input disabled>`
+   * for click semantics.
+   */
+  disabled?: boolean
+  /**
+   * Fires once per gesture, the first time the cursor MOVES after press
+   * (NOT on press itself). A press+release with no motion is not a drag,
+   * so this won't fire — that lets you treat sub-cell-cursor twitches
+   * as clicks rather than spurious drag-starts.
+   */
+  onDragStart?: (info: DragInfo) => void
+  /**
+   * Fires on every cell-crossing motion event during the drag. Useful
+   * for live previews, syncing pos to a parent store, snapping
+   * indicators, etc. Called AFTER the internal pos state updates.
+   */
+  onDrag?: (info: DragInfo) => void
+  /**
+   * Fires once at release if the gesture became a drag (i.e. onDragStart
+   * fired). The pos at this point is the final landing spot, already
+   * clamped to bounds.
+   */
+  onDragEnd?: (info: DragInfo) => void
+}
+
+/**
+ * Draggable cell rectangle. Press, hold, drag, release. Behaviors baked
+ * in to match real-world expectations:
+ *
+ * - **Press anchors at cursor offset** so the grabbed point stays under
+ *   the cursor as the box moves. (Without this, picking up a box by its
+ *   right edge would teleport it to align under the cursor at the start
+ *   of the drag — jarring.)
+ * - **Raise on press**: each press bumps the box's z-index above any
+ *   sibling's. Persists after release so the most-recently-grabbed box
+ *   stays on top — re-grabbable from the same screen position rather
+ *   than getting buried under a sibling that was last in tree order.
+ * - **Drag-time z boost**: while a drag is in progress the box paints
+ *   ~1000 above its persisted z, so it stays on top of every sibling
+ *   regardless of their persisted z values.
+ * - **Bounds clamping** (optional): the box's top-left can range over
+ *   `[(0,0), (bounds.width - width, bounds.height - height)]`, inclusive
+ *   — i.e. the box's bottom-right edge can land exactly on the bounds'
+ *   bottom-right edge but no further.
+ *
+ * @example
+ *   <Draggable
+ *     initialPos={{ top: 0, left: 0 }}
+ *     width={20}
+ *     height={3}
+ *     bounds={{ width: 80, height: 24 }}
+ *     backgroundColor="cyan"
+ *     onDragEnd={({ pos }) => persist(pos)}
+ *   />
+ */
+export default function Draggable({
+  initialPos,
+  bounds,
+  disabled,
+  onDragStart,
+  onDrag,
+  onDragEnd,
+  ...boxProps
+}: DraggableProps): React.ReactNode {
+  const [pos, setPos] = useState<DragPos>(initialPos)
+  const [isDragging, setIsDragging] = useState(false)
+  // Persisted z-index: bumped on each press, retained after release
+  // so the box stays in front of siblings it was just dragged onto.
+  // Drag-time boost is layered on top of this in the render output.
+  const [persistedZ, setPersistedZ] = useState(BASE_Z)
+  // Mirror of `pos` accessible synchronously from gesture callbacks.
+  // setPos batches asynchronously, so onUp can't read the latest pos
+  // through the React state directly; this ref always holds whatever
+  // value onMove last computed. Updated alongside setPos so they
+  // never drift.
+  const latestPosRef = useRef<DragPos>(pos)
+
+  // Keep latest props in refs so the gesture callbacks (captured at
+  // press time, used over many motion events) read fresh values without
+  // forcing re-creation of the callback on every prop change.
+  const onDragStartRef = useRef(onDragStart)
+  const onDragRef = useRef(onDrag)
+  const onDragEndRef = useRef(onDragEnd)
+  const boundsRef = useRef(bounds)
+  onDragStartRef.current = onDragStart
+  onDragRef.current = onDrag
+  onDragEndRef.current = onDragEnd
+  boundsRef.current = bounds
+
+  // boxWidth/boxHeight needed for bounds clamping. Drawn from props each
+  // render so a hot-resize during drag clamps to the new size on the
+  // next motion event.
+  const widthRef = useRef<number | undefined>(
+    typeof boxProps.width === 'number' ? boxProps.width : undefined,
+  )
+  const heightRef = useRef<number | undefined>(
+    typeof boxProps.height === 'number' ? boxProps.height : undefined,
+  )
+  widthRef.current = typeof boxProps.width === 'number' ? boxProps.width : undefined
+  heightRef.current = typeof boxProps.height === 'number' ? boxProps.height : undefined
+
+  const handleMouseDown = useCallback(
+    (e: MouseDownEvent): void => {
+      handleDragPress(e, {
+        startPos: pos,
+        disabled,
+        boundsRef,
+        widthRef,
+        heightRef,
+        latestPosRef,
+        setPos,
+        setIsDragging,
+        setPersistedZ,
+        onDragStartRef,
+        onDragRef,
+        onDragEndRef,
+      })
+    },
+    [pos, disabled],
+  )
+
+  return (
+    <Box
+      {...boxProps}
+      position="absolute"
+      top={pos.top}
+      left={pos.left}
+      zIndex={isDragging ? persistedZ + DRAG_Z_BOOST : persistedZ}
+      onMouseDown={handleMouseDown}
+    />
+  )
+}
+
+// ── gesture handler (extracted so tests can drive it without React) ──
+
+/**
+ * Inputs the press handler needs from the React component. Refs are
+ * passed in so the extracted function reads them at gesture time —
+ * matches the original inline behavior where each onMove read the
+ * latest bounds/size/callbacks from refs filled in on every render.
+ */
+type DragPressDeps = {
+  startPos: DragPos
+  disabled: boolean | undefined
+  boundsRef: { current: DragBounds | undefined }
+  widthRef: { current: number | undefined }
+  heightRef: { current: number | undefined }
+  latestPosRef: { current: DragPos }
+  setPos: (p: DragPos) => void
+  setIsDragging: (d: boolean) => void
+  setPersistedZ: (n: number) => void
+  onDragStartRef: { current: ((info: DragInfo) => void) | undefined }
+  onDragRef: { current: ((info: DragInfo) => void) | undefined }
+  onDragEndRef: { current: ((info: DragInfo) => void) | undefined }
+}
+
+/**
+ * Implements the press → motion → release lifecycle. Public via the
+ * component's `onMouseDown`; exported here so tests can call it with
+ * stub setters and drive the captured gesture handlers directly,
+ * without spinning up React or Ink.
+ */
+export function handleDragPress(e: MouseDownEvent, deps: DragPressDeps): void {
+  if (deps.disabled) return
+  // Snapshot at press: where the box was, where the cursor was.
+  // The drag math = startPos + (cursor - startCursor), so the grabbed
+  // point stays under the cursor as the box moves.
+  const startPos = deps.startPos
+  const startCol = e.col
+  const startRow = e.row
+  // Defer onDragStart until first motion. A press without motion is not
+  // a drag — letting subscribers distinguish hold-and-release from
+  // drag-and-drop.
+  let dragStarted = false
+
+  // Bump persisted z immediately on press. Even if no drag follows,
+  // pressing communicates "I'm interacting with this box" — raising it
+  // above siblings is the right affordance.
+  deps.setPersistedZ(takeNextZ())
+
+  e.captureGesture({
+    onMove(m: MouseMoveEvent) {
+      const dx = m.col - startCol
+      const dy = m.row - startRow
+      const newPos = computeDraggedPos(
+        startPos,
+        startCol,
+        startRow,
+        m.col,
+        m.row,
+        deps.boundsRef.current,
+        deps.widthRef.current,
+        deps.heightRef.current,
+      )
+      if (!dragStarted) {
+        dragStarted = true
+        deps.setIsDragging(true)
+        deps.onDragStartRef.current?.({ pos: newPos, startPos, delta: { dx, dy } })
+      }
+      deps.latestPosRef.current = newPos
+      deps.setPos(newPos)
+      deps.onDragRef.current?.({ pos: newPos, startPos, delta: { dx, dy } })
+    },
+    onUp(u: MouseUpEvent) {
+      if (!dragStarted) return
+      deps.setIsDragging(false)
+      // The position the user SEES at release is whatever onMove last
+      // committed — read straight from the ref so onDragEnd matches the
+      // rendered state exactly, even if bounds or size shifted between
+      // the last motion and release.
+      const finalPos = deps.latestPosRef.current
+      deps.onDragEndRef.current?.({
+        pos: finalPos,
+        startPos,
+        delta: { dx: u.col - startCol, dy: u.row - startRow },
+      })
+    },
+  })
+}
+
+// ── helpers (exported for testing; keep behavior here pure) ───────────
+
+/**
+ * Clamp `value` to `[min, max]` inclusive. When max < min (degenerate
+ * bounds — e.g. parent smaller than the draggable), returns min so the
+ * draggable pins to the top/left rather than getting an inverted range.
+ * Local rather than reusing layout/geometry's clamp because that one
+ * doesn't define behavior for inverted ranges; this one does, and the
+ * draggable's bounds clamp DOES hit that case (mount inside a too-small
+ * parent during transient layout shifts).
+ */
+function clampRange(value: number, min: number, max: number): number {
+  if (max < min) return min
+  if (value < min) return min
+  if (value > max) return max
+  return value
+}
+
+/**
+ * Compute the new (top, left) for a draggable given a start pos, the
+ * cursor's start cell, the cursor's current cell, and optional bounds +
+ * box size. Pure — drives both the live drag math and tests.
+ */
+export function computeDraggedPos(
+  startPos: DragPos,
+  startCol: number,
+  startRow: number,
+  curCol: number,
+  curRow: number,
+  bounds?: DragBounds,
+  boxWidth?: number,
+  boxHeight?: number,
+): DragPos {
+  let top = startPos.top + (curRow - startRow)
+  let left = startPos.left + (curCol - startCol)
+  if (bounds && typeof boxWidth === 'number' && typeof boxHeight === 'number') {
+    top = clampRange(top, 0, bounds.height - boxHeight)
+    left = clampRange(left, 0, bounds.width - boxWidth)
+  }
+  return { top, left }
+}
+
+// ── module-scope z-index counter ─────────────────────────────────────
+
+/**
+ * Base z-index for a freshly-mounted draggable. Picked above 1 so a
+ * draggable paints over a typical container with `zIndex={1}` (the
+ * idiomatic "this box wraps draggables" pattern in our demos).
+ */
+const BASE_Z = 10
+
+/**
+ * How much higher to paint a draggable WHILE its drag is in progress.
+ * Large enough that even after many siblings have bumped their persisted
+ * z via raise-on-press, the actively-dragged box still wins paint order
+ * (a thousand presses without a re-mount is well past any realistic UX).
+ */
+const DRAG_Z_BOOST = 1000
+
+let nextZ = BASE_Z
+function takeNextZ(): number {
+  nextZ += 1
+  return nextZ
+}
+
+/**
+ * Reset the raise-on-press counter. Internal/test use only — not part
+ * of the public API. Useful for deterministic snapshots; the demos
+ * never need this.
+ *
+ * @internal
+ */
+export function _resetDraggableZForTesting(): void {
+  nextZ = BASE_Z
+}

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -10,6 +10,13 @@ export { default as Spacer } from './components/Spacer'
 export { default as Newline } from './components/Newline'
 export { default as Link } from './components/Link'
 export { default as Button } from './components/Button'
+export { default as Draggable } from './components/Draggable'
+export type {
+  DraggableProps,
+  DragPos,
+  DragBounds,
+  DragInfo,
+} from './components/Draggable'
 export { default as ScrollBox } from './components/ScrollBox'
 export type { ScrollBoxHandle } from './components/ScrollBox'
 export { AlternateScreen } from './components/AlternateScreen'

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -8,7 +8,7 @@ export default defineConfig({
     // through packages/renderer/node_modules/@yokai/shared/src/foo.test.ts
     // and run twice.
     exclude: ['**/node_modules/**', '**/dist/**'],
-    include: ['packages/*/src/**/*.test.ts'],
+    include: ['packages/*/src/**/*.test.ts', 'packages/*/src/**/*.test.tsx'],
   },
 })
 


### PR DESCRIPTION
## Summary

Adds `<Draggable>` — a polished, OOTB-correct drag primitive that bakes in the gesture wiring users were copy-pasting out of the demos. With this in, building a draggable widget collapses from ~40 lines of state + counter + `captureGesture` + clamp math to:

```tsx
<Draggable initialPos={{ top: 0, left: 0 }} width={20} height={3} backgroundColor="cyan" />
```

## What's baked in

- **Press-anchored cursor offset** — grabbed point stays under the cursor through the drag.
- **Raise-on-press** — module-scope monotonic counter assigns a higher z-index on each press; persists past release so the most-recently-grabbed box is regrabbable from its current screen position even after siblings have been dragged on top of where it used to be.
- **Drag-time z boost** — while a drag is in progress, paint `+1000` above the persisted z so the active drag wins paint regardless of how high siblings have climbed.
- **Bounds clamping (optional)** — `bounds={{ width, height }}` constrains the box to `[0,0]..[w-boxW, h-boxH]`. Degenerate-safe (bounds smaller than the box pin to (0,0)).
- **Lifecycle separation** — `onDragStart` deferred to the FIRST motion event; press+release with no motion fires nothing visible. `onDragEnd` mirrors that.
- **Refs read at gesture time** — mid-drag changes to bounds, size, or callbacks apply on the next motion event.

## Implementation

The press → motion → release contract lives in a free function `handleDragPress(e, deps)` that the component wires to `useState` + `useRef`. Tests drive `handleDragPress` directly with stub setters — sturdier than mounting through Ink + faking stdin/stdout, and the React glue is a one-line `useCallback`.

## Tests

24 new tests cover:
- **`computeDraggedPos` math** — translation in every direction, clamp at every edge, degenerate bounds, partial-info no-clamp, free drag.
- **`handleDragPress` protocol** — capture-on-press, deferred `onDragStart`, `onDrag` per motion event, `onDragEnd` at release with final pos, no-motion releases fire nothing, mid-drag bounds change applies on next motion, `disabled` blocks capture entirely, persisted-z counter monotonic.

77 → 101 tests total. Both demos updated and exercise the new component.

## Known limitations (planned for follow-ups)

- **No `onClick`** — gesture capture suppresses click dispatch in `App.handleMouseEvent`. Press+release without motion is currently a no-op visible callback. Will revisit when `<DropTarget>` needs the same kind of "press classification" hook.
- **Uncontrolled only** — `initialPos` seeds internal state; later prop changes are ignored. Add controlled mode (`pos` + `onPosChange`) when a real consumer asks for it.
- **No escape-cancel** — pressing Escape mid-drag doesn't snap back. Needs a public way to release a captured gesture, which is bigger than this PR.

These are documented in the component docstring + commit body so future-us doesn't forget.

## Test plan

- [x] `npx vitest run` — 101 tests pass
- [x] `pnpm -r typecheck`
- [x] `pnpm build`
- [x] `pnpm demo:drag` smoke run — clean output, no errors
- [x] `pnpm demo:constrained-drag` smoke run — clean output, no errors
- [ ] Manual: drag interactively in both demos, confirm raise-on-press, drag-time-on-top, bounds clamping all behave like before