### PR TITLE
feat(components): DropTarget — receiver side of drag-and-drop

### DIFF
--- a/examples/drag-and-drop/dnd.tsx
+++ b/examples/drag-and-drop/dnd.tsx
@@ -1,0 +1,190 @@
+/**
+ * Drag-and-drop demo: cards into columns.
+ *
+ *   pnpm demo:drag-and-drop
+ *
+ * Three columns ("todo" / "doing" / "done"), each a `<DropTarget>` that
+ * accepts cards. Drag a card from any column to any other; release over
+ * a column to move it. Drop a card outside any column → snaps back.
+ *
+ * Exercises the full primitive stack:
+ *
+ *   - `<Draggable dragData={{ id, kind: 'card' }}>` — the gesture wiring,
+ *     raise-on-press, drag-time z boost. Cards live in absolute
+ *     coordinates per column so they can drag freely; on drop the parent
+ *     re-assigns ownership and the card snaps to its new column's slot.
+ *   - `<DropTarget accept={(d) => d.kind === 'card'}>` — fires onDragEnter
+ *     to highlight, onDragLeave to un-highlight, onDrop to commit the
+ *     move. Topmost rule resolves drop dispatch when columns overlap
+ *     mid-drag (during a between-columns swing the card paints over both).
+ *   - `accept` filtering — drop the title text on a column? Nothing
+ *     happens. Only cards are accepted. (This demo's title bar is plain
+ *     text, but in a real app you might have multiple kinds of draggables.)
+ *
+ * Press q or Escape to quit.
+ */
+
+import {
+  AlternateScreen,
+  Box,
+  Draggable,
+  DropTarget,
+  Text,
+  render,
+  useApp,
+  useInput,
+} from '@yokai/renderer'
+import type React from 'react'
+import { useState } from 'react'
+
+type Card = { id: string; label: string }
+type Columns = Record<ColumnId, Card[]>
+type ColumnId = 'todo' | 'doing' | 'done'
+
+const COLUMN_W = 24
+const COLUMN_H = 14
+const CARD_W = 20
+const CARD_H = 3
+const COLUMN_TOP = 6
+const CARD_SLOT_HEIGHT = CARD_H + 1 // 1-cell gap between cards
+
+const COLUMNS: { id: ColumnId; left: number; bg: string; bgHover: string; title: string }[] = [
+  { id: 'todo', left: 2, bg: '#1a1a3a', bgHover: '#2c2c66', title: 'todo' },
+  { id: 'doing', left: 30, bg: '#3a2e1a', bgHover: '#665322', title: 'doing' },
+  { id: 'done', left: 58, bg: '#1a3a1a', bgHover: '#2c662c', title: 'done' },
+]
+
+const CARD_COLOR: Record<ColumnId, string> = {
+  todo: 'cyan',
+  doing: 'yellow',
+  done: 'green',
+}
+
+function App(): React.ReactNode {
+  const { exit } = useApp()
+  useInput((input, key) => {
+    if (input === 'q' || key.escape || (key.ctrl && input === 'c')) exit()
+  })
+
+  const [columns, setColumns] = useState<Columns>({
+    todo: [
+      { id: 'c1', label: 'fix notch bug' },
+      { id: 'c2', label: 'add Draggable' },
+      { id: 'c3', label: 'add DropTarget' },
+    ],
+    doing: [{ id: 'c4', label: 'wire registry' }],
+    done: [
+      { id: 'c5', label: 'z-index suite' },
+      { id: 'c6', label: 'hit-test fixes' },
+    ],
+  })
+  // Per-column hover state for drag-over highlight.
+  const [hovered, setHovered] = useState<ColumnId | null>(null)
+  // Bumped on every release; folded into each Draggable's `key` so the
+  // component re-mounts and snaps to its column slot. <Draggable> is
+  // intentionally uncontrolled — `initialPos` only applies at mount —
+  // so this is the idiomatic way to push it back to a known position
+  // after a drag. Covers three cases at once: same-column drops (card
+  // returns to its slot), drops outside any column (`dropped:false`,
+  // card returns to its column), and cross-column drops (card mounts
+  // fresh at the new column's slot).
+  const [dropTick, setDropTick] = useState(0)
+
+  function findCard(id: string): { col: ColumnId; idx: number } | null {
+    for (const c of ['todo', 'doing', 'done'] as ColumnId[]) {
+      const idx = columns[c].findIndex((x) => x.id === id)
+      if (idx >= 0) return { col: c, idx }
+    }
+    return null
+  }
+
+  function moveCard(id: string, toCol: ColumnId): void {
+    const found = findCard(id)
+    if (!found) return
+    if (found.col === toCol) return // No-op; would re-render and snap to same slot anyway.
+    setColumns((prev) => {
+      const card = prev[found.col][found.idx]!
+      const next = { ...prev }
+      next[found.col] = prev[found.col].filter((x) => x.id !== id)
+      next[toCol] = [...prev[toCol], card]
+      return next
+    })
+  }
+
+  return (
+    <AlternateScreen mouseTracking>
+      <Box flexDirection="column" width="100%" height="100%" padding={1}>
+        <Text bold>yokai · drag-and-drop demo</Text>
+        <Text dim>
+          drag cards between columns. drop outside a column to snap back. <Text bold>q</Text> /{' '}
+          <Text bold>Esc</Text> quits.
+        </Text>
+
+        {COLUMNS.map((col) => (
+          <DropTarget
+            key={col.id}
+            accept={(d) => (d as { kind?: string } | undefined)?.kind === 'card'}
+            onDragEnter={() => setHovered(col.id)}
+            onDragLeave={() => {
+              // Leave only clears if we're STILL marked as hovered for
+              // this column. Two columns can't both be hovered (their
+              // rects don't overlap) so this is unambiguous.
+              setHovered((cur) => (cur === col.id ? null : cur))
+            }}
+            onDrop={({ data }) => {
+              const id = (data as { id: string }).id
+              moveCard(id, col.id)
+              setHovered(null)
+            }}
+            position="absolute"
+            top={COLUMN_TOP}
+            left={col.left}
+            width={COLUMN_W}
+            height={COLUMN_H}
+            backgroundColor={hovered === col.id ? col.bgHover : col.bg}
+            // Behind cards (which start at z=10 from Draggable's base).
+            zIndex={1}
+          >
+            <Box paddingX={1} paddingTop={0}>
+              <Text bold dim>
+                {col.title}
+              </Text>
+            </Box>
+          </DropTarget>
+        ))}
+
+        {/* Render cards. Each card lives at its column's slot position
+            (absolute, relative to column bounds via screen coords).
+            On drop, the column moves the card; on the next render the
+            card mounts at its new slot, snapping into place. */}
+        {(['todo', 'doing', 'done'] as ColumnId[]).flatMap((colId) => {
+          const col = COLUMNS.find((c) => c.id === colId)!
+          return columns[colId].map((card, idx) => (
+            <Draggable
+              // Re-key on every drop so the Draggable remounts at its
+              // column's slot — see `dropTick` comment above.
+              key={`${card.id}-${dropTick}`}
+              // Slot position. Top: under the column title row. Left:
+              // a bit inset from the column's left edge.
+              initialPos={{
+                top: COLUMN_TOP + 2 + idx * CARD_SLOT_HEIGHT,
+                left: col.left + 2,
+              }}
+              width={CARD_W}
+              height={CARD_H}
+              backgroundColor={CARD_COLOR[colId]}
+              dragData={{ kind: 'card', id: card.id }}
+              onDragEnd={() => setDropTick((t) => t + 1)}
+            >
+              <Box paddingX={1} paddingY={1}>
+                <Text>{card.label}</Text>
+              </Box>
+            </Draggable>
+          ))
+        })}
+      </Box>
+    </AlternateScreen>
+  )
+}
+
+render(<App />)

--- a/examples/drag-and-drop/package.json
+++ b/examples/drag-and-drop/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@yokai-example/drag-and-drop",
+  "version": "0.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "start": "tsx dnd.tsx"
+  },
+  "dependencies": {
+    "@yokai/renderer": "workspace:*",
+    "react": "^19.2.5"
+  },
+  "devDependencies": {
+    "tsx": "^4.21.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,8 @@
     "lint": "pnpm -r lint",
     "test": "vitest run",
     "demo:drag": "pnpm --filter @yokai-example/drag start",
-    "demo:constrained-drag": "pnpm --filter @yokai-example/constrained-drag start"
+    "demo:constrained-drag": "pnpm --filter @yokai-example/constrained-drag start",
+    "demo:drag-and-drop": "pnpm --filter @yokai-example/drag-and-drop start"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/packages/renderer/src/components/Draggable.test.tsx
+++ b/packages/renderer/src/components/Draggable.test.tsx
@@ -17,7 +17,14 @@
  */
 
 import { describe, expect, it, vi } from 'vitest'
+import { type DOMElement, createNode, setStyle } from '../dom.js'
+import {
+  _resetDragRegistryForTesting,
+  registerDropTarget,
+  unregisterDropTarget,
+} from '../drag-registry.js'
 import { MouseDownEvent, MouseMoveEvent, MouseUpEvent } from '../events/mouse-event.js'
+import { nodeCache } from '../node-cache.js'
 import {
   type DragBounds,
   type DragInfo,
@@ -108,6 +115,7 @@ function makeDeps(
     onDragStart?: (info: DragInfo) => void
     onDrag?: (info: DragInfo) => void
     onDragEnd?: (info: DragInfo) => void
+    dragData?: unknown
   } = {},
 ): Parameters<typeof handleDragPress>[1] & {
   setPos: ReturnType<typeof vi.fn>
@@ -129,6 +137,7 @@ function makeDeps(
     onDragStartRef: { current: opts.onDragStart },
     onDragRef: { current: opts.onDrag },
     onDragEndRef: { current: opts.onDragEnd },
+    dragDataRef: { current: opts.dragData },
   }
 }
 
@@ -254,6 +263,9 @@ describe('handleDragPress', () => {
       pos: { top: 3, left: 8 },
       startPos: { top: 0, left: 0 },
       delta: { dx: 8, dy: 3 },
+      // No drop targets registered → dropped is false. (See drop-target
+      // integration tests below for the truthy case.)
+      dropped: false,
     })
   })
 
@@ -326,5 +338,151 @@ describe('handleDragPress', () => {
     // No gesture captured → no onUp to call. Sanity-check the contract.
     expect(e._capturedHandlers).toBeNull()
     expect(onDragEnd).not.toHaveBeenCalled()
+  })
+})
+
+// ── drop-target integration ──────────────────────────────────────────
+
+/** Build a hand-positioned absolute ink-box and pre-populate its
+ *  nodeCache rect — same helper shape as drag-registry tests. */
+function mkDropZone(rect: { x: number; y: number; w: number; h: number }): DOMElement {
+  const node = createNode('ink-box')
+  setStyle(node, { position: 'absolute' })
+  nodeCache.set(node, { x: rect.x, y: rect.y, width: rect.w, height: rect.h, top: rect.y })
+  return node
+}
+
+describe('handleDragPress — drop-target integration', () => {
+  it('forwards dragData to startDrag (visible to drop targets)', () => {
+    _resetDraggableZForTesting()
+    _resetDragRegistryForTesting()
+    const onDragOver = vi.fn()
+    const target = mkDropZone({ x: 0, y: 0, w: 50, h: 50 })
+    const id = registerDropTarget({
+      getNode: () => target,
+      getCallbacks: () => ({ onDragOver }),
+    })
+
+    const e = new MouseDownEvent(0, 0, 0)
+    handleDragPress(e, makeDeps({ dragData: { id: 'card-7' } }))
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(5, 5, 0))
+
+    expect(onDragOver).toHaveBeenCalledTimes(1)
+    expect(onDragOver).toHaveBeenCalledWith({
+      data: { id: 'card-7' },
+      cursor: { col: 5, row: 5 },
+      local: { col: 5, row: 5 },
+    })
+    unregisterDropTarget(id)
+  })
+
+  it('does NOT engage drop targets on press alone (drag has not started)', () => {
+    _resetDraggableZForTesting()
+    _resetDragRegistryForTesting()
+    const onDragEnter = vi.fn()
+    const target = mkDropZone({ x: 0, y: 0, w: 50, h: 50 })
+    const id = registerDropTarget({
+      getNode: () => target,
+      getCallbacks: () => ({ onDragEnter }),
+    })
+
+    const e = new MouseDownEvent(5, 5, 0)
+    handleDragPress(e, makeDeps())
+    expect(onDragEnter).not.toHaveBeenCalled()
+    unregisterDropTarget(id)
+  })
+
+  it('ticks drop targets on EVERY motion event', () => {
+    _resetDraggableZForTesting()
+    _resetDragRegistryForTesting()
+    const onDragOver = vi.fn()
+    const target = mkDropZone({ x: 0, y: 0, w: 50, h: 50 })
+    const id = registerDropTarget({
+      getNode: () => target,
+      getCallbacks: () => ({ onDragOver }),
+    })
+
+    const e = new MouseDownEvent(0, 0, 0)
+    handleDragPress(e, makeDeps())
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(1, 1, 0))
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(2, 2, 0))
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(3, 3, 0))
+
+    expect(onDragOver).toHaveBeenCalledTimes(3)
+    unregisterDropTarget(id)
+  })
+
+  it('dispatches onDrop on release over a target, sets dropped=true on onDragEnd', () => {
+    _resetDraggableZForTesting()
+    _resetDragRegistryForTesting()
+    const onDrop = vi.fn()
+    const onDragEnd = vi.fn()
+    const target = mkDropZone({ x: 0, y: 0, w: 50, h: 50 })
+    const id = registerDropTarget({
+      getNode: () => target,
+      getCallbacks: () => ({ onDrop }),
+    })
+
+    const e = new MouseDownEvent(0, 0, 0)
+    handleDragPress(e, makeDeps({ onDragEnd, dragData: 'payload' }))
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(5, 5, 0))
+    e._capturedHandlers!.onUp!(new MouseUpEvent(5, 5, 0))
+
+    expect(onDrop).toHaveBeenCalledTimes(1)
+    expect(onDrop).toHaveBeenCalledWith({
+      data: 'payload',
+      cursor: { col: 5, row: 5 },
+      local: { col: 5, row: 5 },
+    })
+    expect(onDragEnd).toHaveBeenCalledWith(expect.objectContaining({ dropped: true }))
+    unregisterDropTarget(id)
+  })
+
+  it('sets dropped=false on onDragEnd when release lands outside any target', () => {
+    _resetDraggableZForTesting()
+    _resetDragRegistryForTesting()
+    const onDrop = vi.fn()
+    const onDragEnd = vi.fn()
+    const target = mkDropZone({ x: 100, y: 100, w: 10, h: 5 })
+    const id = registerDropTarget({
+      getNode: () => target,
+      getCallbacks: () => ({ onDrop }),
+    })
+
+    const e = new MouseDownEvent(0, 0, 0)
+    handleDragPress(e, makeDeps({ onDragEnd }))
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(5, 5, 0))
+    e._capturedHandlers!.onUp!(new MouseUpEvent(5, 5, 0))
+
+    expect(onDrop).not.toHaveBeenCalled()
+    expect(onDragEnd).toHaveBeenCalledWith(expect.objectContaining({ dropped: false }))
+    unregisterDropTarget(id)
+  })
+
+  it('clears the drag from the registry at release (so a subsequent click does not engage targets)', () => {
+    _resetDraggableZForTesting()
+    _resetDragRegistryForTesting()
+    const onDragEnter = vi.fn()
+    const target = mkDropZone({ x: 0, y: 0, w: 50, h: 50 })
+    const id = registerDropTarget({
+      getNode: () => target,
+      getCallbacks: () => ({ onDragEnter }),
+    })
+
+    // First gesture: full drag + release
+    const e1 = new MouseDownEvent(0, 0, 0)
+    handleDragPress(e1, makeDeps())
+    e1._capturedHandlers!.onMove!(new MouseMoveEvent(5, 5, 0))
+    e1._capturedHandlers!.onUp!(new MouseUpEvent(5, 5, 0))
+    expect(onDragEnter).toHaveBeenCalledTimes(1)
+
+    // Second gesture: press + release with NO motion → no drag → no
+    // tick → no enter on the target. Confirms the active drag was
+    // cleared on release of the first gesture.
+    const e2 = new MouseDownEvent(5, 5, 0)
+    handleDragPress(e2, makeDeps())
+    e2._capturedHandlers!.onUp!(new MouseUpEvent(5, 5, 0))
+    expect(onDragEnter).toHaveBeenCalledTimes(1)
+    unregisterDropTarget(id)
   })
 })

--- a/packages/renderer/src/components/Draggable.tsx
+++ b/packages/renderer/src/components/Draggable.tsx
@@ -1,6 +1,7 @@
 import type React from 'react'
 import { useCallback, useRef, useState } from 'react'
 import type { Except } from 'type-fest'
+import { dispatchDrop, endDrag, startDrag, tickDrag } from '../drag-registry.js'
 import type { MouseDownEvent, MouseMoveEvent, MouseUpEvent } from '../events/mouse-event.js'
 import Box, { type Props as BoxProps } from './Box.js'
 
@@ -22,12 +23,16 @@ export type DragBounds = { width: number; height: number }
 /**
  * Lifecycle payload passed to onDragStart / onDrag / onDragEnd.
  * `delta` is screen-space cell delta from the press point — not from
- * the previous frame.
+ * the previous frame. `dropped` is only set on `onDragEnd` and indicates
+ * whether a `<DropTarget>` accepted the drop (true) or the box landed
+ * on empty terminal space (false). Source consumers use this to e.g.
+ * snap-back if no target took the drop.
  */
 export type DragInfo = {
   pos: DragPos
   startPos: DragPos
   delta: { dx: number; dy: number }
+  dropped?: boolean
 }
 
 export type DraggableProps = Except<
@@ -79,6 +84,18 @@ export type DraggableProps = Except<
    * clamped to bounds.
    */
   onDragEnd?: (info: DragInfo) => void
+  /**
+   * Arbitrary payload to attach to this drag. Forwarded to any
+   * `<DropTarget>` the box hovers over or is released onto. Use to carry
+   * the identity of the dragged item ({ id: 'card-3' }), its kind for
+   * `accept` filtering, or whatever the receiving target needs to
+   * reconcile its own state on drop.
+   *
+   * Plain `unknown` rather than a generic — TUI app data is usually
+   * heterogeneous, and a user-supplied generic on `<Draggable>` would
+   * fight every JSX call site. Cast on the receiving side.
+   */
+  dragData?: unknown
 }
 
 /**
@@ -118,6 +135,7 @@ export default function Draggable({
   onDragStart,
   onDrag,
   onDragEnd,
+  dragData,
   ...boxProps
 }: DraggableProps): React.ReactNode {
   const [pos, setPos] = useState<DragPos>(initialPos)
@@ -140,10 +158,12 @@ export default function Draggable({
   const onDragRef = useRef(onDrag)
   const onDragEndRef = useRef(onDragEnd)
   const boundsRef = useRef(bounds)
+  const dragDataRef = useRef(dragData)
   onDragStartRef.current = onDragStart
   onDragRef.current = onDrag
   onDragEndRef.current = onDragEnd
   boundsRef.current = bounds
+  dragDataRef.current = dragData
 
   // boxWidth/boxHeight needed for bounds clamping. Drawn from props each
   // render so a hot-resize during drag clamps to the new size on the
@@ -172,6 +192,7 @@ export default function Draggable({
         onDragStartRef,
         onDragRef,
         onDragEndRef,
+        dragDataRef,
       })
     },
     [pos, disabled],
@@ -210,6 +231,8 @@ type DragPressDeps = {
   onDragStartRef: { current: ((info: DragInfo) => void) | undefined }
   onDragRef: { current: ((info: DragInfo) => void) | undefined }
   onDragEndRef: { current: ((info: DragInfo) => void) | undefined }
+  /** Latest `dragData` prop, payload forwarded to drop targets. */
+  dragDataRef: { current: unknown }
 }
 
 /**
@@ -253,15 +276,30 @@ export function handleDragPress(e: MouseDownEvent, deps: DragPressDeps): void {
       if (!dragStarted) {
         dragStarted = true
         deps.setIsDragging(true)
+        // Engage drop-target tracking on the SAME event we treat as
+        // drag-start. startDrag must come before onDragStart fires so
+        // user code in onDragStart can already query isDragActive() if
+        // it needs to (rare, but consistent ordering matters).
+        startDrag(deps.dragDataRef.current)
         deps.onDragStartRef.current?.({ pos: newPos, startPos, delta: { dx, dy } })
       }
       deps.latestPosRef.current = newPos
       deps.setPos(newPos)
       deps.onDragRef.current?.({ pos: newPos, startPos, delta: { dx, dy } })
+      // Tick AFTER setPos / onDrag so drop-target callbacks see the box
+      // already at its new position when they read from refs / state.
+      tickDrag(m.col, m.row)
     },
     onUp(u: MouseUpEvent) {
       if (!dragStarted) return
       deps.setIsDragging(false)
+      // dispatchDrop walks the registered targets and fires onDrop on
+      // the topmost containing one. Returns whether anyone took it so
+      // the source can react (e.g. snap back if no target accepted).
+      const dropped = dispatchDrop(u.col, u.row)
+      // endDrag must come AFTER dispatchDrop — it clears the active drag,
+      // and dispatchDrop reads activeDrag.data to populate the DropInfo.
+      endDrag()
       // The position the user SEES at release is whatever onMove last
       // committed — read straight from the ref so onDragEnd matches the
       // rendered state exactly, even if bounds or size shifted between
@@ -271,6 +309,7 @@ export function handleDragPress(e: MouseDownEvent, deps: DragPressDeps): void {
         pos: finalPos,
         startPos,
         delta: { dx: u.col - startCol, dy: u.row - startRow },
+        dropped,
       })
     },
   })

--- a/packages/renderer/src/components/DropTarget.tsx
+++ b/packages/renderer/src/components/DropTarget.tsx
@@ -1,0 +1,126 @@
+import type React from 'react'
+import { type PropsWithChildren, useEffect, useRef } from 'react'
+import type { Except } from 'type-fest'
+import type { DOMElement } from '../dom.js'
+import {
+  type DropInfo,
+  type DropTargetCallbacks,
+  registerDropTarget,
+  unregisterDropTarget,
+} from '../drag-registry.js'
+import Box, { type Props as BoxProps } from './Box.js'
+
+export type { DropInfo } from '../drag-registry.js'
+
+export type DropTargetProps = Except<BoxProps, 'ref'> & {
+  /**
+   * Predicate: should this target react to a drag carrying `data`? When
+   * present and returns false, the target is invisible to the drag —
+   * no enter / over / leave / drop callbacks fire, and a higher target
+   * underneath can receive the drop instead. When omitted, the target
+   * accepts every drag.
+   *
+   * Use for kind filtering (`(d) => d?.kind === 'card'`) or for
+   * conditional drop zones (e.g. only accept cards from a different
+   * column to prevent meaningless self-drops).
+   */
+  accept?: (data: unknown) => boolean
+  /**
+   * Fires once when the cursor first enters this target's rect during
+   * an active drag. Pair with `onDragLeave` to manage hover styling.
+   * Does not fire if `accept` rejects the data.
+   */
+  onDragEnter?: (info: DropInfo) => void
+  /**
+   * Fires on every motion event while the cursor is inside this
+   * target's rect. Useful for live previews like "show insertion
+   * indicator at cursor position."
+   */
+  onDragOver?: (info: DropInfo) => void
+  /**
+   * Fires when the cursor leaves this target's rect, or when the drag
+   * ends while still inside (so subscribers can clean up hover state
+   * symmetrically without observing the gesture transition).
+   */
+  onDragLeave?: () => void
+  /**
+   * Fires when the dragger releases over this target. Only the TOPMOST
+   * target containing the cursor at release receives onDrop — even if
+   * other targets are also containing it (matches paint-order: highest
+   * z-index wins, deeper-in-tree breaks ties).
+   */
+  onDrop?: (info: DropInfo) => void
+}
+
+/**
+ * A region that reacts to active drags from `<Draggable>`. Wraps a
+ * `<Box>` — pass any Box prop (size, bg, border, padding, children)
+ * and DropTarget hooks the gesture lifecycle on top.
+ *
+ * Behavior contract:
+ *
+ * - Targets only receive callbacks while a drag is in progress; the
+ *   element is inert outside drags.
+ * - `accept` is called once per gesture-tick to decide whether THIS
+ *   target participates. A target whose `accept` rejected at one tick
+ *   can accept at a later tick if its `accept` predicate becomes truthy
+ *   (e.g. the data changed somehow) — the registry re-evaluates on
+ *   every cursor motion.
+ * - `onDragEnter` / `onDragOver` / `onDragLeave` fire on EVERY containing
+ *   target (multiple may fire on the same tick, e.g. nested targets).
+ *   `onDrop` fires only on the topmost.
+ * - The `local` field on DropInfo gives the cursor's position relative
+ *   to this target's top-left, in cell coordinates — useful for
+ *   "insert at this position within the target" interactions.
+ *
+ * @example
+ *   <DropTarget
+ *     accept={(d) => (d as { kind?: string } | undefined)?.kind === 'card'}
+ *     onDragEnter={() => setHover(true)}
+ *     onDragLeave={() => setHover(false)}
+ *     onDrop={({ data }) => moveCardToColumn(data.id, columnId)}
+ *     backgroundColor={hover ? 'blue' : 'gray'}
+ *     width={30}
+ *     height={10}
+ *   />
+ */
+export default function DropTarget({
+  accept,
+  onDragEnter,
+  onDragOver,
+  onDragLeave,
+  onDrop,
+  children,
+  ...boxProps
+}: PropsWithChildren<DropTargetProps>): React.ReactNode {
+  const nodeRef = useRef<DOMElement>(null)
+  // Bundle the latest callbacks into a ref so the registry tick reads
+  // current props every time. Without this, registerDropTarget would
+  // capture stale closures from the first render and the user's
+  // callbacks would never see updated state.
+  const callbacksRef = useRef<DropTargetCallbacks>({
+    accept,
+    onDragEnter,
+    onDragOver,
+    onDragLeave,
+    onDrop,
+  })
+  callbacksRef.current = { accept, onDragEnter, onDragOver, onDragLeave, onDrop }
+
+  useEffect(() => {
+    const id = registerDropTarget({
+      // Reads ref.current each tick — refs aren't populated until after
+      // mount, and may be re-set if React re-creates the host node
+      // (rare but possible).
+      getNode: () => nodeRef.current,
+      getCallbacks: () => callbacksRef.current,
+    })
+    return () => unregisterDropTarget(id)
+  }, [])
+
+  return (
+    <Box ref={nodeRef} {...boxProps}>
+      {children}
+    </Box>
+  )
+}

--- a/packages/renderer/src/drag-registry.test.ts
+++ b/packages/renderer/src/drag-registry.test.ts
@@ -1,0 +1,315 @@
+/**
+ * drag-registry tests.
+ *
+ * The registry is module-scope mutable state. Each test resets it via
+ * `_resetDragRegistryForTesting` to keep them independent — without
+ * the reset a test that left an active drag would leak into the next.
+ *
+ * Drop targets are tested by registering hand-built DOMElements with
+ * pre-populated nodeCache rects. This bypasses both React and the
+ * layout pipeline so the registry's hit-test + dispatch logic is the
+ * only thing under test.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { type DOMElement, appendChildNode, createNode, setStyle } from './dom.js'
+import {
+  type DropTargetCallbacks,
+  _resetDragRegistryForTesting,
+  dispatchDrop,
+  endDrag,
+  isDragActive,
+  registerDropTarget,
+  startDrag,
+  tickDrag,
+  unregisterDropTarget,
+} from './drag-registry.js'
+import { nodeCache } from './node-cache.js'
+
+/** Build a hand-positioned absolute ink-box and pre-populate its
+ *  nodeCache rect. The drag-registry reads the rect via nodeCache, so
+ *  this is the minimum tree state needed to drive it. */
+function mkTarget(rect: { x: number; y: number; w: number; h: number; z?: number }): DOMElement {
+  const node = createNode('ink-box')
+  setStyle(node, { position: 'absolute', zIndex: rect.z ?? 0 })
+  nodeCache.set(node, { x: rect.x, y: rect.y, width: rect.w, height: rect.h, top: rect.y })
+  return node
+}
+
+/** Register a target with a fresh callback bundle. Returns an
+ *  unregister function and the bundle so tests can both clean up
+ *  AND inspect calls. */
+function register(
+  node: DOMElement,
+  cbs: DropTargetCallbacks = {},
+): { unregister: () => void; cbs: Required<DropTargetCallbacks> } {
+  const fullCbs: Required<DropTargetCallbacks> = {
+    accept: cbs.accept ?? (() => true),
+    onDragEnter: cbs.onDragEnter ?? vi.fn(),
+    onDragOver: cbs.onDragOver ?? vi.fn(),
+    onDragLeave: cbs.onDragLeave ?? vi.fn(),
+    onDrop: cbs.onDrop ?? vi.fn(),
+  }
+  const id = registerDropTarget({
+    getNode: () => node,
+    getCallbacks: () => fullCbs,
+  })
+  return { unregister: () => unregisterDropTarget(id), cbs: fullCbs }
+}
+
+describe('drag-registry — startDrag / endDrag / isDragActive', () => {
+  it('isDragActive is false before any drag starts', () => {
+    _resetDragRegistryForTesting()
+    expect(isDragActive()).toBe(false)
+  })
+
+  it('isDragActive is true between startDrag and endDrag', () => {
+    _resetDragRegistryForTesting()
+    startDrag({ id: 1 })
+    expect(isDragActive()).toBe(true)
+    endDrag()
+    expect(isDragActive()).toBe(false)
+  })
+
+  it('endDrag is idempotent — safe to call without an active drag', () => {
+    _resetDragRegistryForTesting()
+    expect(() => endDrag()).not.toThrow()
+    expect(isDragActive()).toBe(false)
+  })
+
+  it('tickDrag is a no-op when no drag is active', () => {
+    _resetDragRegistryForTesting()
+    const onDragEnter = vi.fn()
+    const target = mkTarget({ x: 0, y: 0, w: 10, h: 5 })
+    register(target, { onDragEnter })
+    tickDrag(5, 2)
+    expect(onDragEnter).not.toHaveBeenCalled()
+  })
+
+  it('dispatchDrop is a no-op (returns false) when no drag is active', () => {
+    _resetDragRegistryForTesting()
+    const onDrop = vi.fn()
+    const target = mkTarget({ x: 0, y: 0, w: 10, h: 5 })
+    register(target, { onDrop })
+    expect(dispatchDrop(5, 2)).toBe(false)
+    expect(onDrop).not.toHaveBeenCalled()
+  })
+})
+
+describe('drag-registry — tickDrag enter/over/leave', () => {
+  it('fires onDragEnter and onDragOver when cursor enters a target', () => {
+    _resetDragRegistryForTesting()
+    const target = mkTarget({ x: 10, y: 5, w: 10, h: 5 })
+    const { cbs } = register(target)
+    startDrag({ id: 'card' })
+    tickDrag(15, 7)
+    expect(cbs.onDragEnter).toHaveBeenCalledTimes(1)
+    expect(cbs.onDragOver).toHaveBeenCalledTimes(1)
+    // Local coords are cursor minus target's top-left.
+    expect(cbs.onDragOver).toHaveBeenCalledWith({
+      data: { id: 'card' },
+      cursor: { col: 15, row: 7 },
+      local: { col: 5, row: 2 },
+    })
+  })
+
+  it('fires onDragOver but NOT onDragEnter on subsequent ticks within the same target', () => {
+    _resetDragRegistryForTesting()
+    const target = mkTarget({ x: 0, y: 0, w: 20, h: 10 })
+    const { cbs } = register(target)
+    startDrag(undefined)
+    tickDrag(5, 5)
+    tickDrag(6, 6)
+    tickDrag(7, 7)
+    expect(cbs.onDragEnter).toHaveBeenCalledTimes(1)
+    expect(cbs.onDragOver).toHaveBeenCalledTimes(3)
+  })
+
+  it('fires onDragLeave when cursor exits a target', () => {
+    _resetDragRegistryForTesting()
+    const target = mkTarget({ x: 0, y: 0, w: 10, h: 5 })
+    const { cbs } = register(target)
+    startDrag(undefined)
+    tickDrag(5, 2)
+    tickDrag(50, 50)
+    expect(cbs.onDragLeave).toHaveBeenCalledTimes(1)
+  })
+
+  it('does NOT fire any callbacks for targets the cursor never enters', () => {
+    _resetDragRegistryForTesting()
+    const target = mkTarget({ x: 50, y: 50, w: 10, h: 5 })
+    const { cbs } = register(target)
+    startDrag(undefined)
+    tickDrag(5, 2)
+    expect(cbs.onDragEnter).not.toHaveBeenCalled()
+    expect(cbs.onDragOver).not.toHaveBeenCalled()
+    expect(cbs.onDragLeave).not.toHaveBeenCalled()
+  })
+
+  it('fires enter on multiple containing targets at the same tick (nested / overlap)', () => {
+    _resetDragRegistryForTesting()
+    const inner = mkTarget({ x: 5, y: 5, w: 10, h: 5 })
+    const outer = mkTarget({ x: 0, y: 0, w: 30, h: 20 })
+    const innerCbs = register(inner).cbs
+    const outerCbs = register(outer).cbs
+    startDrag(undefined)
+    tickDrag(7, 6)
+    expect(innerCbs.onDragEnter).toHaveBeenCalledTimes(1)
+    expect(outerCbs.onDragEnter).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips targets whose accept() rejects the drag data', () => {
+    _resetDragRegistryForTesting()
+    const target = mkTarget({ x: 0, y: 0, w: 10, h: 5 })
+    const { cbs } = register(target, { accept: () => false })
+    startDrag({ kind: 'wrong' })
+    tickDrag(5, 2)
+    expect(cbs.onDragEnter).not.toHaveBeenCalled()
+    expect(cbs.onDragOver).not.toHaveBeenCalled()
+  })
+
+  it('passes the drag data to accept()', () => {
+    _resetDragRegistryForTesting()
+    const accept = vi.fn().mockReturnValue(true)
+    const target = mkTarget({ x: 0, y: 0, w: 10, h: 5 })
+    register(target, { accept })
+    startDrag({ kind: 'card', id: 7 })
+    tickDrag(5, 2)
+    expect(accept).toHaveBeenCalledWith({ kind: 'card', id: 7 })
+  })
+
+  it('endDrag fires onDragLeave on any still-containing targets', () => {
+    _resetDragRegistryForTesting()
+    const target = mkTarget({ x: 0, y: 0, w: 10, h: 5 })
+    const { cbs } = register(target)
+    startDrag(undefined)
+    tickDrag(5, 2)
+    endDrag()
+    expect(cbs.onDragLeave).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('drag-registry — dispatchDrop', () => {
+  it('fires onDrop on the topmost containing target', () => {
+    _resetDragRegistryForTesting()
+    const back = mkTarget({ x: 0, y: 0, w: 20, h: 10, z: 1 })
+    const front = mkTarget({ x: 5, y: 2, w: 10, h: 5, z: 5 })
+    const backCbs = register(back).cbs
+    const frontCbs = register(front).cbs
+    startDrag({ id: 1 })
+    expect(dispatchDrop(7, 4)).toBe(true)
+    expect(frontCbs.onDrop).toHaveBeenCalledTimes(1)
+    expect(backCbs.onDrop).not.toHaveBeenCalled()
+  })
+
+  it('returns false if no target accepts the drop', () => {
+    _resetDragRegistryForTesting()
+    const target = mkTarget({ x: 50, y: 50, w: 10, h: 5 })
+    register(target)
+    startDrag(undefined)
+    expect(dispatchDrop(5, 2)).toBe(false)
+  })
+
+  it('skips targets whose accept() rejects', () => {
+    _resetDragRegistryForTesting()
+    const target = mkTarget({ x: 0, y: 0, w: 10, h: 5 })
+    const cbs = register(target, { accept: () => false }).cbs
+    startDrag(undefined)
+    expect(dispatchDrop(5, 2)).toBe(false)
+    expect(cbs.onDrop).not.toHaveBeenCalled()
+  })
+
+  it('falls through to a non-rejecting target when the topmost rejects', () => {
+    _resetDragRegistryForTesting()
+    const back = mkTarget({ x: 0, y: 0, w: 20, h: 10, z: 1 })
+    const front = mkTarget({ x: 5, y: 2, w: 10, h: 5, z: 5 })
+    const backCbs = register(back).cbs
+    const frontCbs = register(front, { accept: () => false }).cbs
+    startDrag(undefined)
+    expect(dispatchDrop(7, 4)).toBe(true)
+    expect(backCbs.onDrop).toHaveBeenCalledTimes(1)
+    expect(frontCbs.onDrop).not.toHaveBeenCalled()
+  })
+
+  it('breaks ties by tree depth (deeper wins) when z-indexes match', () => {
+    _resetDragRegistryForTesting()
+    // Build deeper-in-tree wrapper > inner; both at z=0.
+    const wrapper = createNode('ink-box')
+    const inner = createNode('ink-box')
+    appendChildNode(wrapper, inner)
+    setStyle(wrapper, { position: 'absolute' })
+    setStyle(inner, { position: 'absolute' })
+    nodeCache.set(wrapper, { x: 0, y: 0, width: 20, height: 10, top: 0 })
+    nodeCache.set(inner, { x: 0, y: 0, width: 20, height: 10, top: 0 })
+    const { cbs: wrapperCbs } = register(wrapper)
+    const { cbs: innerCbs } = register(inner)
+    startDrag(undefined)
+    expect(dispatchDrop(5, 5)).toBe(true)
+    expect(innerCbs.onDrop).toHaveBeenCalledTimes(1)
+    expect(wrapperCbs.onDrop).not.toHaveBeenCalled()
+  })
+
+  it('forwards the drag data and cursor + local coords to onDrop', () => {
+    _resetDragRegistryForTesting()
+    const target = mkTarget({ x: 10, y: 5, w: 20, h: 10 })
+    const { cbs } = register(target)
+    startDrag({ id: 'card-7' })
+    dispatchDrop(15, 8)
+    expect(cbs.onDrop).toHaveBeenCalledWith({
+      data: { id: 'card-7' },
+      cursor: { col: 15, row: 8 },
+      local: { col: 5, row: 3 },
+    })
+  })
+})
+
+describe('drag-registry — registration lifecycle', () => {
+  it('unregister removes a target from subsequent ticks', () => {
+    _resetDragRegistryForTesting()
+    const target = mkTarget({ x: 0, y: 0, w: 10, h: 5 })
+    const { unregister, cbs } = register(target)
+    startDrag(undefined)
+    tickDrag(5, 2)
+    expect(cbs.onDragEnter).toHaveBeenCalledTimes(1)
+    unregister()
+    tickDrag(6, 3)
+    // No additional calls — target is gone.
+    expect(cbs.onDragEnter).toHaveBeenCalledTimes(1)
+    expect(cbs.onDragOver).toHaveBeenCalledTimes(1)
+  })
+
+  it('reads the LATEST callbacks from getCallbacks each tick', () => {
+    // Simulates a re-rendered DropTarget whose props changed: registry
+    // entry stays the same but callbacks pointed-to switch.
+    _resetDragRegistryForTesting()
+    const target = mkTarget({ x: 0, y: 0, w: 10, h: 5 })
+    const onDragOver1 = vi.fn()
+    const onDragOver2 = vi.fn()
+    let current: DropTargetCallbacks = { onDragOver: onDragOver1 }
+    registerDropTarget({
+      getNode: () => target,
+      getCallbacks: () => current,
+    })
+    startDrag(undefined)
+    tickDrag(5, 2)
+    expect(onDragOver1).toHaveBeenCalledTimes(1)
+    expect(onDragOver2).not.toHaveBeenCalled()
+    // "Re-render" by swapping the bundle.
+    current = { onDragOver: onDragOver2 }
+    tickDrag(6, 3)
+    expect(onDragOver1).toHaveBeenCalledTimes(1)
+    expect(onDragOver2).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips entries whose getNode returns null (transient detach)', () => {
+    _resetDragRegistryForTesting()
+    const onDragEnter = vi.fn()
+    registerDropTarget({
+      getNode: () => null,
+      getCallbacks: () => ({ onDragEnter }),
+    })
+    startDrag(undefined)
+    tickDrag(5, 2)
+    expect(onDragEnter).not.toHaveBeenCalled()
+  })
+})

--- a/packages/renderer/src/drag-registry.ts
+++ b/packages/renderer/src/drag-registry.ts
@@ -1,0 +1,207 @@
+/**
+ * Drag/drop coordination registry.
+ *
+ * One active drag at a time (gestures are exclusive at the App level).
+ * `<Draggable>` calls `startDrag` on the first motion event of a press,
+ * `tickDrag` on each subsequent motion, and `dispatchDrop` + `endDrag`
+ * at release. `<DropTarget>` registers itself on mount and unregisters
+ * on unmount; tick walks the registered set, computes which targets
+ * currently contain the cursor, and fires the right enter / over / leave
+ * deltas relative to the previous tick.
+ *
+ * The registry is module-scope (mutable) because the draggable / drop-
+ * target relationship is global to the App — there's no React tree
+ * containment that constrains which Draggable can drop on which target.
+ * A user dragging in container A can perfectly well drop on a target in
+ * container B, so we can't piggyback on React context.
+ */
+import type { DOMElement } from './dom.js'
+import { nodeCache } from './node-cache.js'
+
+/**
+ * Payload passed to drop-target callbacks. `cursor` is in screen-cell
+ * coordinates (0-indexed). `local` is cursor minus the target's top-left,
+ * so a target at screen (10, 5) reporting `local = (3, 1)` means the
+ * cursor is 3 cols + 1 row inside its top-left corner — the same
+ * convention `ClickEvent.localCol` / `localRow` use.
+ */
+export type DropInfo = {
+  data: unknown
+  cursor: { col: number; row: number }
+  local: { col: number; row: number }
+}
+
+/**
+ * Callback bundle the registry reads each tick. Wrapped in a getter so
+ * the entry holds a STABLE reference for the lifetime of the registration
+ * but the values it returns are always the latest props from the
+ * subscribing component (re-rendered or not).
+ */
+export type DropTargetCallbacks = {
+  accept?: (data: unknown) => boolean
+  onDragEnter?: (info: DropInfo) => void
+  onDragOver?: (info: DropInfo) => void
+  onDragLeave?: () => void
+  onDrop?: (info: DropInfo) => void
+}
+
+type DropTargetEntry = {
+  /** Lazily-resolved DOM node — refs aren't populated until after mount,
+   *  so `registerDropTarget` is called from useEffect with a getter that
+   *  reads the ref each tick. Returns null when the ref is detached
+   *  (transient during reorder); registry skips null entries. */
+  getNode: () => DOMElement | null
+  /** Latest callback bundle. The component overwrites the value behind
+   *  this getter on every render so closures captured at registration
+   *  time still see fresh handlers. */
+  getCallbacks: () => DropTargetCallbacks
+}
+
+const targets = new Map<symbol, DropTargetEntry>()
+let activeDrag: { data: unknown } | null = null
+const containingPrev = new Set<symbol>()
+
+/** Register a drop target. Returns an opaque id used to unregister.
+ *  Called from `<DropTarget>`'s mount effect. */
+export function registerDropTarget(entry: DropTargetEntry): symbol {
+  const id = Symbol('DropTarget')
+  targets.set(id, entry)
+  return id
+}
+
+export function unregisterDropTarget(id: symbol): void {
+  targets.delete(id)
+  containingPrev.delete(id)
+}
+
+/** Reset registry state. Internal/test use only — not part of the
+ *  public API. Demos and apps never need this. @internal */
+export function _resetDragRegistryForTesting(): void {
+  targets.clear()
+  containingPrev.clear()
+  activeDrag = null
+}
+
+/** Begin tracking an active drag. Called by `<Draggable>` on the FIRST
+ *  motion of a press (i.e. when the gesture has actually become a drag),
+ *  not at press time — a press without motion does not engage drop
+ *  targets. */
+export function startDrag(data: unknown): void {
+  activeDrag = { data }
+  containingPrev.clear()
+}
+
+/** True iff a drag is currently in progress. */
+export function isDragActive(): boolean {
+  return activeDrag !== null
+}
+
+/**
+ * Walk all registered targets, compute which currently contain the cursor
+ * (and accept the active drag's data), and fire enter / over / leave
+ * relative to the last tick. Multiple targets can be "containing" at the
+ * same time (nested or overlapping); enter/over/leave fire on each
+ * independently — matches DOM `dragenter`/`dragover` semantics where
+ * each ancestor in the chain receives the event.
+ */
+export function tickDrag(col: number, row: number): void {
+  if (!activeDrag) return
+  const data = activeDrag.data
+  const containingNow = new Set<symbol>()
+  for (const [id, entry] of targets) {
+    const node = entry.getNode()
+    if (!node) continue
+    const rect = nodeCache.get(node)
+    if (!rect) continue
+    if (col < rect.x || col >= rect.x + rect.width || row < rect.y || row >= rect.y + rect.height)
+      continue
+    const cb = entry.getCallbacks()
+    if (cb.accept && !cb.accept(data)) continue
+    containingNow.add(id)
+    const local = { col: col - rect.x, row: row - rect.y }
+    const info: DropInfo = { data, cursor: { col, row }, local }
+    if (!containingPrev.has(id)) cb.onDragEnter?.(info)
+    cb.onDragOver?.(info)
+  }
+  // Fire leave for anything in prev but not now. Read callbacks fresh —
+  // the target may have re-rendered with a new handler bundle since the
+  // last tick, and we want the latest.
+  for (const id of containingPrev) {
+    if (!containingNow.has(id)) {
+      targets.get(id)?.getCallbacks().onDragLeave?.()
+    }
+  }
+  containingPrev.clear()
+  for (const id of containingNow) containingPrev.add(id)
+}
+
+/**
+ * Fire `onDrop` on the topmost (paint-order) drop target containing the
+ * cursor that accepts the dragged data. Returns true if any target
+ * received the drop, false otherwise. Source `<Draggable>` uses the
+ * return value to populate `onDragEnd`'s `dropped` field so it can
+ * react (e.g. snap back if no target accepted).
+ *
+ * Topmost = highest effective z-index, with deeper-in-tree as the
+ * tie-breaker. Mirrors how the renderer paints overlapping absolute
+ * boxes; the user's eye and the drop target see the same winner.
+ */
+export function dispatchDrop(col: number, row: number): boolean {
+  if (!activeDrag) return false
+  const data = activeDrag.data
+  type Cand = {
+    id: symbol
+    entry: DropTargetEntry
+    rectX: number
+    rectY: number
+    z: number
+    depth: number
+  }
+  const cands: Cand[] = []
+  for (const [id, entry] of targets) {
+    const node = entry.getNode()
+    if (!node) continue
+    const rect = nodeCache.get(node)
+    if (!rect) continue
+    if (col < rect.x || col >= rect.x + rect.width || row < rect.y || row >= rect.y + rect.height)
+      continue
+    const cb = entry.getCallbacks()
+    if (cb.accept && !cb.accept(data)) continue
+    const z = node.style.position === 'absolute' ? (node.style.zIndex ?? 0) : 0
+    cands.push({ id, entry, rectX: rect.x, rectY: rect.y, z, depth: nodeDepth(node) })
+  }
+  if (cands.length === 0) return false
+  cands.sort((a, b) => b.z - a.z || b.depth - a.depth)
+  const top = cands[0]!
+  top.entry.getCallbacks().onDrop?.({
+    data,
+    cursor: { col, row },
+    local: { col: col - top.rectX, row: row - top.rectY },
+  })
+  return true
+}
+
+/**
+ * End the active drag. Fires `onDragLeave` on any target the cursor
+ * was still inside at end-time so subscribers can clean up hover
+ * styling without observing the gesture transition explicitly.
+ * Idempotent — calling without an active drag is a no-op.
+ */
+export function endDrag(): void {
+  if (!activeDrag) return
+  for (const id of containingPrev) {
+    targets.get(id)?.getCallbacks().onDragLeave?.()
+  }
+  containingPrev.clear()
+  activeDrag = null
+}
+
+function nodeDepth(node: DOMElement): number {
+  let n: DOMElement | undefined = node
+  let d = 0
+  while (n?.parentNode) {
+    d++
+    n = n.parentNode
+  }
+  return d
+}

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -17,6 +17,8 @@ export type {
   DragBounds,
   DragInfo,
 } from './components/Draggable'
+export { default as DropTarget } from './components/DropTarget'
+export type { DropTargetProps, DropInfo } from './components/DropTarget'
 export { default as ScrollBox } from './components/ScrollBox'
 export type { ScrollBoxHandle } from './components/ScrollBox'
 export { AlternateScreen } from './components/AlternateScreen'

--- a/packages/renderer/src/render-node-to-output.ts
+++ b/packages/renderer/src/render-node-to-output.ts
@@ -1334,11 +1334,7 @@ function renderChildren(
     // overlap-rerender shortcut is not meaningful for them.
     const isTextNode = childNode.nodeName === '#text'
     let overlapsMovingAbsolute = false
-    if (
-      !childElem.dirty &&
-      !isTextNode &&
-      dirtyAbsoluteCachedRects !== undefined
-    ) {
+    if (!childElem.dirty && !isTextNode && dirtyAbsoluteCachedRects !== undefined) {
       const myCached = nodeCache.get(childElem)
       if (myCached) {
         for (const r of dirtyAbsoluteCachedRects) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -41,6 +41,19 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
 
+  examples/drag-and-drop:
+    dependencies:
+      '@yokai/renderer':
+        specifier: workspace:*
+        version: link:../../packages/renderer
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+    devDependencies:
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+
   packages/renderer:
     dependencies:
       '@alcalzone/ansi-tokenize':


### PR DESCRIPTION
## Summary

Lands the receiver half of drag-and-drop. Pairs with the existing `<Draggable>` to give consumers a full DnD primitive set:

```tsx
<Draggable dragData={{ kind: 'card', id: 'c1' }} ... />
<DropTarget
  accept={(d) => d.kind === 'card'}
  onDragEnter={() => setHover(true)}
  onDragLeave={() => setHover(false)}
  onDrop={({ data }) => moveCardTo(data.id, columnId)}
  ...
/>
```

## Architecture

Three pieces, in dependency order:

1. **`drag-registry.ts`** — module-scope coordination. One active drag at a time. Targets register on mount with `(getNode, getCallbacks)` closures so the registry always reads fresh state. Lifecycle: `startDrag` → `tickDrag` (per motion) → `dispatchDrop` + `endDrag`.
2. **`<DropTarget>`** — wraps `<Box>`, registers/unregisters in the registry. Calls bundle into a ref that updates on every render so re-rendered targets get fresh handlers without re-registering.
3. **`<Draggable>` updates** — adds `dragData` prop, calls `startDrag` on first motion, `tickDrag` on every motion, `dispatchDrop` + `endDrag` on release. `onDragEnd` gains a `dropped: boolean` field.

## Behavior contract

- **Inert outside drags.** No callbacks fire when no Draggable is being dragged.
- **`accept` is per-tick.** Predicate is queried each motion; a target whose accept rejected at one tick can accept at a later tick.
- **enter/over/leave fire on every containing target** (multiple nested targets all fire).
- **onDrop fires only on the topmost** (highest z-index, deeper-in-tree as tiebreak — matches paint order so the user's eye and dispatch agree).
- **`local` cell coords** on every `DropInfo` (cursor minus target top-left) for "insert at this position within target" interactions.

## Demo

`examples/drag-and-drop/dnd.tsx` — three-column kanban. Drag cards between columns, hover highlights, drop commits the move, drop outside any column snaps back. ~190 lines exercising the full surface.

Run it: `pnpm demo:drag-and-drop`

## Tests

22 registry tests + 6 new Draggable integration tests + the existing 23 Draggable tests + the existing 24 renderer tests + ... 129 total, all green. Granular coverage: lifecycle, tick deltas, accept filtering, topmost dispatch, depth tiebreak, registration cleanup, callback ref re-read, null-node skip.

## Test plan

- [x] `npx vitest run` — 129 tests pass
- [x] `pnpm -r typecheck`
- [x] `pnpm --filter @yokai/renderer lint`
- [x] `pnpm build`
- [x] All three demos smoke-test cleanly (drag, constrained-drag, drag-and-drop)
- [ ] Manual: kanban demo — drag cards between columns, drop outside, hover columns, confirm filter rejects non-cards if you wired such a thing

## Commits

5 granular:

1. `chore(lint): biome format drive-by on render-node-to-output`
2. `feat(drag): drag-registry — coordination layer for drag/drop`
3. `feat(components): DropTarget — receiver side of drag-and-drop`
4. `feat(components): wire Draggable to drop-target dispatch`
5. `demo(drag-and-drop): kanban — Draggable + DropTarget end-to-end`