### PR TITLE
feat(components): Resizable — first-class resize primitive

### DIFF
--- a/examples/resizable/package.json
+++ b/examples/resizable/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@yokai-example/resizable",
+  "version": "0.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "start": "tsx resizable.tsx"
+  },
+  "dependencies": {
+    "@yokai/renderer": "workspace:*",
+    "react": "^19.2.5"
+  },
+  "devDependencies": {
+    "tsx": "^4.21.0"
+  }
+}

--- a/examples/resizable/resizable.tsx
+++ b/examples/resizable/resizable.tsx
@@ -1,0 +1,93 @@
+/**
+ * Resizable demo.
+ *
+ *   pnpm demo:resizable
+ *
+ * Two `<Resizable>` panels side by side. The left panel exposes all
+ * three handles (s, e, se) so you can grab any edge. The right panel
+ * has only the SE corner handle — the most common case for a "panel
+ * you can drag the bottom-right corner of."
+ *
+ * Each handle paints a 1-cell strip of contrasting bg color so you can
+ * see where to grab. Hover brightens the handle. Drag to resize; min
+ * and max bounds keep the size sensible.
+ *
+ * Press q or Escape to quit.
+ */
+
+import { AlternateScreen, Box, Resizable, Text, render, useApp, useInput } from '@yokai/renderer'
+import type React from 'react'
+import { useState } from 'react'
+
+function App(): React.ReactNode {
+  const { exit } = useApp()
+  useInput((input, key) => {
+    if (input === 'q' || key.escape || (key.ctrl && input === 'c')) exit()
+  })
+
+  // Track sizes so we can display them — pure observability for the demo,
+  // <Resizable> manages its own size internally.
+  const [leftSize, setLeftSize] = useState({ width: 30, height: 8 })
+  const [rightSize, setRightSize] = useState({ width: 30, height: 8 })
+
+  return (
+    <AlternateScreen mouseTracking>
+      <Box flexDirection="column" width="100%" height="100%" padding={1}>
+        <Text bold>yokai · resizable demo</Text>
+        <Text dim>
+          drag the gray edges to resize. <Text bold>q</Text> / <Text bold>Esc</Text> quits.
+        </Text>
+        <Text dim>
+          left: all three handles (south, east, south-east). right: south-east corner only.
+        </Text>
+
+        <Box flexDirection="row" gap={4} marginTop={1}>
+          <Box flexDirection="column">
+            <Text dim>
+              size: <Text bold>{leftSize.width}</Text>×<Text bold>{leftSize.height}</Text>
+            </Text>
+            <Resizable
+              initialSize={{ width: 30, height: 8 }}
+              minSize={{ width: 10, height: 3 }}
+              maxSize={{ width: 60, height: 16 }}
+              handles={['s', 'e', 'se']}
+              backgroundColor="#1a1a3a"
+              onResize={({ size }) => setLeftSize(size)}
+            >
+              <Box padding={1}>
+                <Text>
+                  Drag any of my three handles. The south handle (bottom strip) only changes my
+                  height; the east handle (right strip) only changes my width; the SE corner does
+                  both at once.
+                </Text>
+              </Box>
+            </Resizable>
+          </Box>
+
+          <Box flexDirection="column">
+            <Text dim>
+              size: <Text bold>{rightSize.width}</Text>×<Text bold>{rightSize.height}</Text>
+            </Text>
+            <Resizable
+              initialSize={{ width: 30, height: 8 }}
+              minSize={{ width: 10, height: 3 }}
+              maxSize={{ width: 60, height: 16 }}
+              backgroundColor="#3a1a1a"
+              onResize={({ size }) => setRightSize(size)}
+            >
+              <Box padding={1}>
+                <Text>
+                  Default `handles={'{'}['se']{'}'}`. Grab the small marked corner to resize me
+                  diagonally — the common case for a panel you want to grow without intrusive edge
+                  chrome.
+                </Text>
+              </Box>
+            </Resizable>
+          </Box>
+        </Box>
+      </Box>
+    </AlternateScreen>
+  )
+}
+
+render(<App />)

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test": "vitest run",
     "demo:drag": "pnpm --filter @yokai-example/drag start",
     "demo:constrained-drag": "pnpm --filter @yokai-example/constrained-drag start",
-    "demo:drag-and-drop": "pnpm --filter @yokai-example/drag-and-drop start"
+    "demo:drag-and-drop": "pnpm --filter @yokai-example/drag-and-drop start",
+    "demo:resizable": "pnpm --filter @yokai-example/resizable start"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/packages/renderer/src/components/Resizable.test.tsx
+++ b/packages/renderer/src/components/Resizable.test.tsx
@@ -1,0 +1,338 @@
+/**
+ * Resizable component tests.
+ *
+ * Same two-tier shape as Draggable.test.tsx:
+ *
+ *   1. Pure-math tests for `computeResizedSize` — covers every direction,
+ *      clamping in both axes, degenerate min/max, default min.
+ *   2. Gesture-protocol tests that drive `handleResizePress` directly
+ *      with stub setters and capture the gesture handlers it installs
+ *      on the MouseDownEvent. Skips React's render loop so the press
+ *      → motion → release contract is the only thing under test.
+ */
+
+import { describe, expect, it, vi } from 'vitest'
+import { MouseDownEvent, MouseMoveEvent, MouseUpEvent } from '../events/mouse-event.js'
+import {
+  type ResizeHandleDirection,
+  type ResizeInfo,
+  type ResizeSize,
+  computeResizedSize,
+  handleResizePress,
+} from './Resizable.js'
+
+// ── pure math ────────────────────────────────────────────────────────
+
+describe('computeResizedSize', () => {
+  it('returns the start size when cursor has not moved', () => {
+    const start = { width: 20, height: 5 }
+    expect(computeResizedSize(start, 0, 0, 0, 0, 'se')).toEqual({ width: 20, height: 5 })
+  })
+
+  it('grows only width on direction "e"', () => {
+    expect(computeResizedSize({ width: 10, height: 5 }, 0, 0, 5, 3, 'e')).toEqual({
+      width: 15,
+      height: 5,
+    })
+  })
+
+  it('grows only height on direction "s"', () => {
+    expect(computeResizedSize({ width: 10, height: 5 }, 0, 0, 5, 3, 's')).toEqual({
+      width: 10,
+      height: 8,
+    })
+  })
+
+  it('grows both dimensions on direction "se"', () => {
+    expect(computeResizedSize({ width: 10, height: 5 }, 0, 0, 5, 3, 'se')).toEqual({
+      width: 15,
+      height: 8,
+    })
+  })
+
+  it('shrinks when cursor moves opposite direction (negative delta)', () => {
+    expect(computeResizedSize({ width: 20, height: 10 }, 5, 5, 2, 3, 'se')).toEqual({
+      width: 17,
+      height: 8,
+    })
+  })
+
+  it('clamps to min width (defaults to 1)', () => {
+    // Drag way past the left → would shrink to negative; clamp to default 1.
+    expect(computeResizedSize({ width: 5, height: 5 }, 10, 10, 0, 10, 'e')).toEqual({
+      width: 1,
+      height: 5,
+    })
+  })
+
+  it('clamps to min height (defaults to 1)', () => {
+    expect(computeResizedSize({ width: 5, height: 5 }, 10, 10, 10, 0, 's')).toEqual({
+      width: 5,
+      height: 1,
+    })
+  })
+
+  it('respects user-supplied minSize', () => {
+    expect(
+      computeResizedSize({ width: 20, height: 10 }, 0, 0, -100, -100, 'se', {
+        width: 5,
+        height: 3,
+      }),
+    ).toEqual({ width: 5, height: 3 })
+  })
+
+  it('respects user-supplied maxSize', () => {
+    expect(
+      computeResizedSize({ width: 5, height: 5 }, 0, 0, 100, 100, 'se', undefined, {
+        width: 20,
+        height: 10,
+      }),
+    ).toEqual({ width: 20, height: 10 })
+  })
+
+  it('clamps each axis independently', () => {
+    // Width hits max, height stays in range.
+    expect(
+      computeResizedSize({ width: 5, height: 5 }, 0, 0, 100, 3, 'se', undefined, {
+        width: 20,
+        height: 50,
+      }),
+    ).toEqual({ width: 20, height: 8 })
+  })
+
+  it('returns min when max < min (degenerate bounds)', () => {
+    expect(
+      computeResizedSize(
+        { width: 10, height: 10 },
+        0,
+        0,
+        50,
+        50,
+        'se',
+        { width: 20, height: 20 },
+        { width: 5, height: 5 },
+      ),
+    ).toEqual({ width: 20, height: 20 })
+  })
+
+  it('does not change height on direction "e" even with row delta', () => {
+    expect(computeResizedSize({ width: 10, height: 5 }, 0, 0, 5, 99, 'e')).toEqual({
+      width: 15,
+      height: 5,
+    })
+  })
+
+  it('does not change width on direction "s" even with col delta', () => {
+    expect(computeResizedSize({ width: 10, height: 5 }, 0, 0, 99, 3, 's')).toEqual({
+      width: 10,
+      height: 8,
+    })
+  })
+})
+
+// ── gesture-protocol ─────────────────────────────────────────────────
+
+function makeDeps(
+  opts: {
+    startSize?: ResizeSize
+    minSize?: ResizeSize
+    maxSize?: ResizeSize
+    onResizeStart?: (info: ResizeInfo) => void
+    onResize?: (info: ResizeInfo) => void
+    onResizeEnd?: (info: ResizeInfo) => void
+  } = {},
+): Parameters<typeof handleResizePress>[2] & {
+  setSize: ReturnType<typeof vi.fn>
+  latestSizeRef: { current: ResizeSize }
+} {
+  const startSize = opts.startSize ?? { width: 10, height: 5 }
+  return {
+    startSize,
+    minSizeRef: { current: opts.minSize },
+    maxSizeRef: { current: opts.maxSize },
+    latestSizeRef: { current: startSize },
+    setSize: vi.fn(),
+    onResizeStartRef: { current: opts.onResizeStart },
+    onResizeRef: { current: opts.onResize },
+    onResizeEndRef: { current: opts.onResizeEnd },
+  }
+}
+
+describe('handleResizePress', () => {
+  it('captures a gesture on press', () => {
+    const e = new MouseDownEvent(10, 5, 0)
+    handleResizePress(e, 'se', makeDeps())
+    expect(e._capturedHandlers).not.toBeNull()
+    expect(e._capturedHandlers?.onMove).toBeTypeOf('function')
+    expect(e._capturedHandlers?.onUp).toBeTypeOf('function')
+  })
+
+  it('does NOT fire onResizeStart on press alone', () => {
+    const onResizeStart = vi.fn()
+    const e = new MouseDownEvent(10, 5, 0)
+    handleResizePress(e, 'se', makeDeps({ onResizeStart }))
+    expect(onResizeStart).not.toHaveBeenCalled()
+  })
+
+  it('fires onResizeStart on the FIRST motion event with new size + direction', () => {
+    const onResizeStart = vi.fn()
+    const e = new MouseDownEvent(10, 5, 0)
+    handleResizePress(e, 'se', makeDeps({ startSize: { width: 10, height: 5 }, onResizeStart }))
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(13, 7, 0))
+    expect(onResizeStart).toHaveBeenCalledTimes(1)
+    expect(onResizeStart).toHaveBeenCalledWith({
+      size: { width: 13, height: 7 },
+      startSize: { width: 10, height: 5 },
+      delta: { dw: 3, dh: 2 },
+      direction: 'se',
+    })
+  })
+
+  it('fires onResizeStart only ONCE across many motion events', () => {
+    const onResizeStart = vi.fn()
+    const e = new MouseDownEvent(0, 0, 0)
+    handleResizePress(e, 'se', makeDeps({ onResizeStart }))
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(1, 1, 0))
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(2, 2, 0))
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(3, 3, 0))
+    expect(onResizeStart).toHaveBeenCalledTimes(1)
+  })
+
+  it('fires onResize on each motion event', () => {
+    const onResize = vi.fn()
+    const e = new MouseDownEvent(0, 0, 0)
+    handleResizePress(e, 'se', makeDeps({ onResize }))
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(1, 0, 0))
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(2, 1, 0))
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(3, 2, 0))
+    expect(onResize).toHaveBeenCalledTimes(3)
+  })
+
+  it('updates setSize on every motion (so the rendered size tracks the cursor)', () => {
+    const e = new MouseDownEvent(0, 0, 0)
+    const deps = makeDeps({ startSize: { width: 10, height: 5 } })
+    handleResizePress(e, 'se', deps)
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(5, 2, 0))
+    expect(deps.setSize).toHaveBeenLastCalledWith({ width: 15, height: 7 })
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(8, 3, 0))
+    expect(deps.setSize).toHaveBeenLastCalledWith({ width: 18, height: 8 })
+  })
+
+  it('only updates width when direction is "e"', () => {
+    const e = new MouseDownEvent(0, 0, 0)
+    const deps = makeDeps({ startSize: { width: 10, height: 5 } })
+    handleResizePress(e, 'e', deps)
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(5, 99, 0))
+    expect(deps.setSize).toHaveBeenLastCalledWith({ width: 15, height: 5 })
+  })
+
+  it('only updates height when direction is "s"', () => {
+    const e = new MouseDownEvent(0, 0, 0)
+    const deps = makeDeps({ startSize: { width: 10, height: 5 } })
+    handleResizePress(e, 's', deps)
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(99, 3, 0))
+    expect(deps.setSize).toHaveBeenLastCalledWith({ width: 10, height: 8 })
+  })
+
+  it('fires onResizeEnd at release with the final visible size and direction', () => {
+    const onResizeEnd = vi.fn()
+    const e = new MouseDownEvent(0, 0, 0)
+    handleResizePress(e, 'se', makeDeps({ onResizeEnd }))
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(5, 2, 0))
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(8, 3, 0))
+    e._capturedHandlers!.onUp!(new MouseUpEvent(8, 3, 0))
+    expect(onResizeEnd).toHaveBeenCalledTimes(1)
+    expect(onResizeEnd).toHaveBeenCalledWith({
+      size: { width: 18, height: 8 },
+      startSize: { width: 10, height: 5 },
+      delta: { dw: 8, dh: 3 },
+      direction: 'se',
+    })
+  })
+
+  it('does NOT fire onResizeEnd on release if no motion happened', () => {
+    const onResizeEnd = vi.fn()
+    const e = new MouseDownEvent(0, 0, 0)
+    handleResizePress(e, 'se', makeDeps({ onResizeEnd }))
+    e._capturedHandlers!.onUp!(new MouseUpEvent(0, 0, 0))
+    expect(onResizeEnd).not.toHaveBeenCalled()
+  })
+
+  it('clamps to minSize during motion', () => {
+    const onResize = vi.fn()
+    const e = new MouseDownEvent(0, 0, 0)
+    handleResizePress(
+      e,
+      'se',
+      makeDeps({
+        startSize: { width: 10, height: 5 },
+        minSize: { width: 5, height: 3 },
+        onResize,
+      }),
+    )
+    // Drag way past the top-left → clamp to (5, 3).
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(-100, -100, 0))
+    expect(onResize).toHaveBeenLastCalledWith({
+      size: { width: 5, height: 3 },
+      startSize: { width: 10, height: 5 },
+      delta: { dw: -100, dh: -100 },
+      direction: 'se',
+    })
+  })
+
+  it('clamps to maxSize during motion', () => {
+    const onResize = vi.fn()
+    const e = new MouseDownEvent(0, 0, 0)
+    handleResizePress(
+      e,
+      'se',
+      makeDeps({
+        startSize: { width: 10, height: 5 },
+        maxSize: { width: 20, height: 12 },
+        onResize,
+      }),
+    )
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(1000, 1000, 0))
+    expect(onResize).toHaveBeenLastCalledWith({
+      size: { width: 20, height: 12 },
+      startSize: { width: 10, height: 5 },
+      delta: { dw: 1000, dh: 1000 },
+      direction: 'se',
+    })
+  })
+
+  it('reads min/max from refs at gesture time (so mid-resize bounds changes apply)', () => {
+    const onResize = vi.fn()
+    const e = new MouseDownEvent(0, 0, 0)
+    const deps = makeDeps({
+      startSize: { width: 10, height: 5 },
+      maxSize: { width: 20, height: 12 },
+      onResize,
+    })
+    handleResizePress(e, 'se', deps)
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(100, 100, 0))
+    expect(onResize).toHaveBeenLastCalledWith(
+      expect.objectContaining({ size: { width: 20, height: 12 } }),
+    )
+    // Tighten max mid-resize.
+    deps.maxSizeRef.current = { width: 15, height: 8 }
+    e._capturedHandlers!.onMove!(new MouseMoveEvent(100, 100, 0))
+    expect(onResize).toHaveBeenLastCalledWith(
+      expect.objectContaining({ size: { width: 15, height: 8 } }),
+    )
+  })
+
+  it('handles every direction correctly in one gesture lifecycle', () => {
+    // Spot-check that direction stays consistent across the whole gesture
+    // — the press captures it; subsequent motions don't get to change it.
+    const onResize = vi.fn()
+    const dirs: ResizeHandleDirection[] = ['e', 's', 'se']
+    for (const dir of dirs) {
+      onResize.mockReset()
+      const e = new MouseDownEvent(0, 0, 0)
+      handleResizePress(e, dir, makeDeps({ onResize }))
+      e._capturedHandlers!.onMove!(new MouseMoveEvent(5, 5, 0))
+      expect(onResize).toHaveBeenCalledWith(expect.objectContaining({ direction: dir }))
+    }
+  })
+})

--- a/packages/renderer/src/components/Resizable.tsx
+++ b/packages/renderer/src/components/Resizable.tsx
@@ -1,7 +1,6 @@
 import type React from 'react'
-import { type PropsWithChildren, useCallback, useLayoutEffect, useRef, useState } from 'react'
+import { type PropsWithChildren, useCallback, useRef, useState } from 'react'
 import type { Except } from 'type-fest'
-import type { DOMElement } from '../dom.js'
 import type { MouseDownEvent, MouseMoveEvent, MouseUpEvent } from '../events/mouse-event.js'
 import type { Color } from '../styles.js'
 import Box, { type Props as BoxProps } from './Box.js'
@@ -58,21 +57,6 @@ export type ResizableProps = Except<BoxProps, 'width' | 'height' | 'onMouseDown'
   /** Background color of the handle when the cursor is over it. Hover
    *  affordance. Default `'white'`. */
   handleHoverColor?: Color
-  /**
-   * When true (default), the box's effective minimum height tracks its
-   * content's natural height — i.e. you cannot shrink the box smaller
-   * than the space its content needs to display. As the user shrinks
-   * the WIDTH (text wraps into more lines), the box auto-grows in
-   * HEIGHT to accommodate. The `minSize.height` you pass still applies
-   * as a FLOOR; the effective minimum is `max(minSize.height,
-   * contentNaturalHeight)`.
-   *
-   * Set to false to opt out — the box will accept any minSize down to
-   * (1, 1) and clip overflowing content. Useful when the content is
-   * itself scrollable / virtualised and the user wants raw size
-   * control.
-   */
-  autoFit?: boolean
   /** Fires once at the FIRST motion of a resize (not on press). A press
    *  on a handle without subsequent motion is not a resize, so this won't
    *  fire — symmetrical with Draggable's onDragStart. */
@@ -127,7 +111,6 @@ export default function Resizable({
   handles = ['se'],
   handleColor = 'gray',
   handleHoverColor = 'white',
-  autoFit = true,
   onResizeStart,
   onResize,
   onResizeEnd,
@@ -136,65 +119,19 @@ export default function Resizable({
 }: PropsWithChildren<ResizableProps>): React.ReactNode {
   const [size, setSize] = useState<ResizeSize>(initialSize)
   const [hoveredHandle, setHoveredHandle] = useState<ResizeHandleDirection | null>(null)
-  // Tracks the content's natural height for the current width (yoga's
-  // computed height of the content wrapper, ignoring the box's height
-  // constraint). Used as the effective minHeight when autoFit is on.
-  // Starts at 0; first useLayoutEffect after mount fills it in.
-  const [contentNaturalHeight, setContentNaturalHeight] = useState(0)
-  // Ref to the inner content wrapper, queried by useLayoutEffect to read
-  // its yoga-computed height.
-  const contentRef = useRef<DOMElement>(null)
 
   // Refs read at gesture time so mid-resize prop changes apply on the
   // next motion event (mirrors Draggable's pattern).
   const onResizeStartRef = useRef(onResizeStart)
   const onResizeRef = useRef(onResize)
   const onResizeEndRef = useRef(onResizeEnd)
+  const minSizeRef = useRef(minSize)
   const maxSizeRef = useRef(maxSize)
   onResizeStartRef.current = onResizeStart
   onResizeRef.current = onResize
   onResizeEndRef.current = onResizeEnd
+  minSizeRef.current = minSize
   maxSizeRef.current = maxSize
-
-  // Effective min: width from user (or default 1); height is the larger
-  // of user-supplied min and the content's natural height when autoFit
-  // is on. This is what the resize gesture clamps against, so the box
-  // refuses to shrink past what its content needs to show.
-  const effectiveMin: ResizeSize = {
-    width: minSize?.width ?? 1,
-    height: autoFit
-      ? Math.max(minSize?.height ?? 1, contentNaturalHeight || 1)
-      : (minSize?.height ?? 1),
-  }
-  const minSizeRef = useRef(effectiveMin)
-  minSizeRef.current = effectiveMin
-
-  // After every render, read the content wrapper's yoga-computed height.
-  // Wrapper has no height constraint, so yoga gives it its content's
-  // natural height for the wrapper's own width (which equals box width
-  // via alignSelf:'stretch'). When that height differs from what we last
-  // saw, update state — gated by equality so this isn't a render loop.
-  useLayoutEffect(() => {
-    if (!autoFit) return
-    if (!contentRef.current?.yogaNode) return
-    const h = contentRef.current.yogaNode.getComputedHeight()
-    if (h > 0) {
-      setContentNaturalHeight((prev) => (h !== prev ? h : prev))
-    }
-  })
-
-  // Auto-grow size.height when content needs more than current height
-  // can show. Pairs with the gesture's effectiveMin clamp to guarantee
-  // the box never displays less than the full content. Fires both on
-  // initial measurement (first render → useLayoutEffect → bump if
-  // needed) and on width-driven re-wrap (text wraps tighter → more
-  // lines → contentNaturalHeight grows → height bumps up to match).
-  useLayoutEffect(() => {
-    if (!autoFit) return
-    if (size.height < effectiveMin.height) {
-      setSize((s) => ({ ...s, height: effectiveMin.height }))
-    }
-  }, [autoFit, effectiveMin.height, size.height])
 
   // Mirror of `size` accessible synchronously from gesture callbacks
   // (setSize batches; onResizeEnd needs the latest committed size).
@@ -237,21 +174,20 @@ export default function Resizable({
     hoveredHandle === dir ? handleHoverColor : handleColor
 
   return (
-    // overflow:'hidden' default protects against the auto-fit timing
-    // gap (one frame between content growing and the box catching up)
-    // AND against autoFit={false} cases where content is intentionally
-    // larger than the box. Spread boxProps after our default so user
-    // can override with `overflow:"visible"` for an opt-in bleed.
+    // overflow:'hidden' default keeps content from bleeding outside the
+    // box when the user shrinks past what content needs to display.
+    // Spread boxProps after our default so users can override with
+    // `overflow:'visible'` if they explicitly want the bleed (e.g. the
+    // content is itself responsible for size).
+    //
+    // KNOWN LIMITATION: when content overflows, it's clipped (visible
+    // chunks vanish below the box edge). True "box can't shrink past
+    // content" auto-fit needs to read yoga's computed height after a
+    // layout pass, but useLayoutEffect runs BEFORE ink's renderer calls
+    // calculateLayout, so measurements come back stale. Tracked for a
+    // follow-up that hooks into ink's onFrame callback.
     <Box overflow="hidden" {...boxProps} width={size.width} height={size.height}>
-      {/* Inner content wrapper exists solely so we have a stable yoga
-          node to measure for autoFit. Default alignSelf in yoga is
-          'auto' which inherits 'stretch' from the parent's column
-          flex, so the wrapper takes the full box width — its measured
-          natural height then reflects how content wraps at that width,
-          which is the input we need for the auto-min calculation.
-          Skipped measurement-wise when autoFit is false; the wrapper
-          itself is harmless either way (no margins, no flex shrink). */}
-      <Box ref={contentRef}>{children}</Box>
+      {children}
       {/* Handles are absolute children so they paint on top of content
           without affecting flex layout inside the Resizable. zIndex on
           SE > E,S so the corner cell paints over the edge strips when

--- a/packages/renderer/src/components/Resizable.tsx
+++ b/packages/renderer/src/components/Resizable.tsx
@@ -1,6 +1,7 @@
 import type React from 'react'
-import { type PropsWithChildren, useCallback, useRef, useState } from 'react'
+import { type PropsWithChildren, useCallback, useLayoutEffect, useRef, useState } from 'react'
 import type { Except } from 'type-fest'
+import type { DOMElement } from '../dom.js'
 import type { MouseDownEvent, MouseMoveEvent, MouseUpEvent } from '../events/mouse-event.js'
 import type { Color } from '../styles.js'
 import Box, { type Props as BoxProps } from './Box.js'
@@ -57,6 +58,21 @@ export type ResizableProps = Except<BoxProps, 'width' | 'height' | 'onMouseDown'
   /** Background color of the handle when the cursor is over it. Hover
    *  affordance. Default `'white'`. */
   handleHoverColor?: Color
+  /**
+   * When true (default), the box's effective minimum height tracks its
+   * content's natural height — i.e. you cannot shrink the box smaller
+   * than the space its content needs to display. As the user shrinks
+   * the WIDTH (text wraps into more lines), the box auto-grows in
+   * HEIGHT to accommodate. The `minSize.height` you pass still applies
+   * as a FLOOR; the effective minimum is `max(minSize.height,
+   * contentNaturalHeight)`.
+   *
+   * Set to false to opt out — the box will accept any minSize down to
+   * (1, 1) and clip overflowing content. Useful when the content is
+   * itself scrollable / virtualised and the user wants raw size
+   * control.
+   */
+  autoFit?: boolean
   /** Fires once at the FIRST motion of a resize (not on press). A press
    *  on a handle without subsequent motion is not a resize, so this won't
    *  fire — symmetrical with Draggable's onDragStart. */
@@ -111,6 +127,7 @@ export default function Resizable({
   handles = ['se'],
   handleColor = 'gray',
   handleHoverColor = 'white',
+  autoFit = true,
   onResizeStart,
   onResize,
   onResizeEnd,
@@ -119,19 +136,65 @@ export default function Resizable({
 }: PropsWithChildren<ResizableProps>): React.ReactNode {
   const [size, setSize] = useState<ResizeSize>(initialSize)
   const [hoveredHandle, setHoveredHandle] = useState<ResizeHandleDirection | null>(null)
+  // Tracks the content's natural height for the current width (yoga's
+  // computed height of the content wrapper, ignoring the box's height
+  // constraint). Used as the effective minHeight when autoFit is on.
+  // Starts at 0; first useLayoutEffect after mount fills it in.
+  const [contentNaturalHeight, setContentNaturalHeight] = useState(0)
+  // Ref to the inner content wrapper, queried by useLayoutEffect to read
+  // its yoga-computed height.
+  const contentRef = useRef<DOMElement>(null)
 
   // Refs read at gesture time so mid-resize prop changes apply on the
   // next motion event (mirrors Draggable's pattern).
   const onResizeStartRef = useRef(onResizeStart)
   const onResizeRef = useRef(onResize)
   const onResizeEndRef = useRef(onResizeEnd)
-  const minSizeRef = useRef(minSize)
   const maxSizeRef = useRef(maxSize)
   onResizeStartRef.current = onResizeStart
   onResizeRef.current = onResize
   onResizeEndRef.current = onResizeEnd
-  minSizeRef.current = minSize
   maxSizeRef.current = maxSize
+
+  // Effective min: width from user (or default 1); height is the larger
+  // of user-supplied min and the content's natural height when autoFit
+  // is on. This is what the resize gesture clamps against, so the box
+  // refuses to shrink past what its content needs to show.
+  const effectiveMin: ResizeSize = {
+    width: minSize?.width ?? 1,
+    height: autoFit
+      ? Math.max(minSize?.height ?? 1, contentNaturalHeight || 1)
+      : (minSize?.height ?? 1),
+  }
+  const minSizeRef = useRef(effectiveMin)
+  minSizeRef.current = effectiveMin
+
+  // After every render, read the content wrapper's yoga-computed height.
+  // Wrapper has no height constraint, so yoga gives it its content's
+  // natural height for the wrapper's own width (which equals box width
+  // via alignSelf:'stretch'). When that height differs from what we last
+  // saw, update state — gated by equality so this isn't a render loop.
+  useLayoutEffect(() => {
+    if (!autoFit) return
+    if (!contentRef.current?.yogaNode) return
+    const h = contentRef.current.yogaNode.getComputedHeight()
+    if (h > 0) {
+      setContentNaturalHeight((prev) => (h !== prev ? h : prev))
+    }
+  })
+
+  // Auto-grow size.height when content needs more than current height
+  // can show. Pairs with the gesture's effectiveMin clamp to guarantee
+  // the box never displays less than the full content. Fires both on
+  // initial measurement (first render → useLayoutEffect → bump if
+  // needed) and on width-driven re-wrap (text wraps tighter → more
+  // lines → contentNaturalHeight grows → height bumps up to match).
+  useLayoutEffect(() => {
+    if (!autoFit) return
+    if (size.height < effectiveMin.height) {
+      setSize((s) => ({ ...s, height: effectiveMin.height }))
+    }
+  }, [autoFit, effectiveMin.height, size.height])
 
   // Mirror of `size` accessible synchronously from gesture callbacks
   // (setSize batches; onResizeEnd needs the latest committed size).
@@ -174,8 +237,21 @@ export default function Resizable({
     hoveredHandle === dir ? handleHoverColor : handleColor
 
   return (
-    <Box {...boxProps} width={size.width} height={size.height}>
-      {children}
+    // overflow:'hidden' default protects against the auto-fit timing
+    // gap (one frame between content growing and the box catching up)
+    // AND against autoFit={false} cases where content is intentionally
+    // larger than the box. Spread boxProps after our default so user
+    // can override with `overflow:"visible"` for an opt-in bleed.
+    <Box overflow="hidden" {...boxProps} width={size.width} height={size.height}>
+      {/* Inner content wrapper exists solely so we have a stable yoga
+          node to measure for autoFit. Default alignSelf in yoga is
+          'auto' which inherits 'stretch' from the parent's column
+          flex, so the wrapper takes the full box width — its measured
+          natural height then reflects how content wraps at that width,
+          which is the input we need for the auto-min calculation.
+          Skipped measurement-wise when autoFit is false; the wrapper
+          itself is harmless either way (no margins, no flex shrink). */}
+      <Box ref={contentRef}>{children}</Box>
       {/* Handles are absolute children so they paint on top of content
           without affecting flex layout inside the Resizable. zIndex on
           SE > E,S so the corner cell paints over the edge strips when

--- a/packages/renderer/src/components/Resizable.tsx
+++ b/packages/renderer/src/components/Resizable.tsx
@@ -1,6 +1,7 @@
 import type React from 'react'
-import { type PropsWithChildren, useCallback, useRef, useState } from 'react'
+import { type PropsWithChildren, useCallback, useEffect, useRef, useState } from 'react'
 import type { Except } from 'type-fest'
+import type { DOMElement } from '../dom.js'
 import type { MouseDownEvent, MouseMoveEvent, MouseUpEvent } from '../events/mouse-event.js'
 import type { Color } from '../styles.js'
 import Box, { type Props as BoxProps } from './Box.js'
@@ -57,6 +58,19 @@ export type ResizableProps = Except<BoxProps, 'width' | 'height' | 'onMouseDown'
   /** Background color of the handle when the cursor is over it. Hover
    *  affordance. Default `'white'`. */
   handleHoverColor?: Color
+  /**
+   * When true (default), the box's effective minimum height tracks its
+   * content's natural height — i.e. the user cannot shrink the box past
+   * the space its content needs to display. As the WIDTH shrinks, text
+   * wraps into more lines, and the box auto-grows in HEIGHT to keep
+   * everything visible. The user-supplied `minSize.height` still acts
+   * as a floor; effective min is `max(minSize.height, contentHeight)`.
+   *
+   * Set to false for raw size control (e.g. when content is itself
+   * scrollable / virtualised). The `overflow:'hidden'` default still
+   * keeps content from bleeding outside the box.
+   */
+  autoFit?: boolean
   /** Fires once at the FIRST motion of a resize (not on press). A press
    *  on a handle without subsequent motion is not a resize, so this won't
    *  fire — symmetrical with Draggable's onDragStart. */
@@ -111,6 +125,7 @@ export default function Resizable({
   handles = ['se'],
   handleColor = 'gray',
   handleHoverColor = 'white',
+  autoFit = true,
   onResizeStart,
   onResize,
   onResizeEnd,
@@ -119,18 +134,68 @@ export default function Resizable({
 }: PropsWithChildren<ResizableProps>): React.ReactNode {
   const [size, setSize] = useState<ResizeSize>(initialSize)
   const [hoveredHandle, setHoveredHandle] = useState<ResizeHandleDirection | null>(null)
+  const contentRef = useRef<DOMElement>(null)
+
+  // ── autoFit: read content's natural height from yoga ──────────────
+  //
+  // Yoga lays out the wrapper inside our outer Box. With overflow set
+  // to visible on the wrapper (default) and no fixed height on it,
+  // yoga gives the wrapper its content's intrinsic height for the
+  // current width — exactly the value we need to know "how tall must
+  // this box be to show all the text?"
+  //
+  // Timing caveat: ink calls calculateLayout AFTER React's commit, so
+  // at the moment THIS render runs, contentRef.yogaNode reflects the
+  // PREVIOUS frame's layout. That's stale-by-one-frame, but for
+  // continuous interactions (drag, resize) the lag is invisible: each
+  // motion event triggers a re-render, the next render reads the
+  // value we just measured, and within 1-2 frames the box converges.
+  // overflow:'hidden' on the outer Box hides the in-between state.
+  //
+  // First render: ref is null, returns 0 → effectiveMin falls back to
+  // user min. After mount the ref is populated and subsequent renders
+  // get real values.
+  const measuredHeight =
+    autoFit && contentRef.current?.yogaNode?.getComputedHeight()
+      ? contentRef.current.yogaNode.getComputedHeight()
+      : 0
+
+  // Effective min: width is user's (or 1); height is the larger of
+  // user min and the measured content height. Resize gesture clamps
+  // against this — the box refuses to shrink past content.
+  const effectiveMin: ResizeSize = {
+    width: minSize?.width ?? 1,
+    height: autoFit
+      ? Math.max(minSize?.height ?? 1, measuredHeight || 1)
+      : (minSize?.height ?? 1),
+  }
+
+  // Catch up state when measuredHeight reveals the box is currently
+  // smaller than effective min — happens when the user shrinks WIDTH
+  // and content suddenly needs more rows. useEffect (post-commit, not
+  // useLayoutEffect) so React commits the current render first; the
+  // next render then renders at the corrected size. Convergence in
+  // 1-2 frames; overflow:'hidden' hides the transient.
+  useEffect(() => {
+    if (!autoFit) return
+    if (size.height < effectiveMin.height) {
+      setSize((s) => ({ ...s, height: effectiveMin.height }))
+    }
+  }, [autoFit, effectiveMin.height, size.height])
 
   // Refs read at gesture time so mid-resize prop changes apply on the
-  // next motion event (mirrors Draggable's pattern).
+  // next motion event (mirrors Draggable's pattern). minSizeRef holds
+  // the EFFECTIVE min (post-autoFit) so the gesture clamp against it
+  // matches what the user can actually see.
   const onResizeStartRef = useRef(onResizeStart)
   const onResizeRef = useRef(onResize)
   const onResizeEndRef = useRef(onResizeEnd)
-  const minSizeRef = useRef(minSize)
+  const minSizeRef = useRef(effectiveMin)
   const maxSizeRef = useRef(maxSize)
   onResizeStartRef.current = onResizeStart
   onResizeRef.current = onResize
   onResizeEndRef.current = onResizeEnd
-  minSizeRef.current = minSize
+  minSizeRef.current = effectiveMin
   maxSizeRef.current = maxSize
 
   // Mirror of `size` accessible synchronously from gesture callbacks
@@ -174,20 +239,19 @@ export default function Resizable({
     hoveredHandle === dir ? handleHoverColor : handleColor
 
   return (
-    // overflow:'hidden' default keeps content from bleeding outside the
-    // box when the user shrinks past what content needs to display.
-    // Spread boxProps after our default so users can override with
-    // `overflow:'visible'` if they explicitly want the bleed (e.g. the
-    // content is itself responsible for size).
-    //
-    // KNOWN LIMITATION: when content overflows, it's clipped (visible
-    // chunks vanish below the box edge). True "box can't shrink past
-    // content" auto-fit needs to read yoga's computed height after a
-    // layout pass, but useLayoutEffect runs BEFORE ink's renderer calls
-    // calculateLayout, so measurements come back stale. Tracked for a
-    // follow-up that hooks into ink's onFrame callback.
+    // overflow:'hidden' default hides any transient where content
+    // briefly exceeds the box (during the 1-2 frame autoFit catch-up,
+    // or always when autoFit is false). Spread boxProps after the
+    // default so users can opt back into 'visible'.
     <Box overflow="hidden" {...boxProps} width={size.width} height={size.height}>
-      {children}
+      {/* Inner content wrapper exists solely so we have a stable yoga
+          node to measure for autoFit. Default alignSelf inherits
+          'stretch' from the column flex, so the wrapper takes the full
+          box width — its measured natural height then reflects how
+          content wraps at that width, which is the input we need.
+          Wrapper has no fixed size, no flex shrink override; layout-wise
+          it's transparent for typical column-of-content children. */}
+      <Box ref={contentRef}>{children}</Box>
       {/* Handles are absolute children so they paint on top of content
           without affecting flex layout inside the Resizable. zIndex on
           SE > E,S so the corner cell paints over the edge strips when

--- a/packages/renderer/src/components/Resizable.tsx
+++ b/packages/renderer/src/components/Resizable.tsx
@@ -1,0 +1,351 @@
+import type React from 'react'
+import { type PropsWithChildren, useCallback, useRef, useState } from 'react'
+import type { Except } from 'type-fest'
+import type { MouseDownEvent, MouseMoveEvent, MouseUpEvent } from '../events/mouse-event.js'
+import type { Color } from '../styles.js'
+import Box, { type Props as BoxProps } from './Box.js'
+import Text from './Text.js'
+
+/** Cell-grid size. width/height are integer cell counts. */
+export type ResizeSize = { width: number; height: number }
+
+/** Which edges/corners can be grabbed to resize. v1 supports the
+ *  bottom-right family — `s` (south, bottom edge), `e` (east, right
+ *  edge), `se` (south-east corner). All three grow the box outward
+ *  toward the bottom-right; the box's top-left stays put.
+ *
+ *  North / west / NW / SW / NE handles aren't supported in v1 because
+ *  resizing those edges shifts the layout origin, which fights flexbox
+ *  in non-obvious ways for in-flow components. They're a clean follow-up
+ *  for absolute-positioned Resizables. */
+export type ResizeHandleDirection = 's' | 'e' | 'se'
+
+/** Lifecycle payload passed to onResize callbacks. `delta` is total
+ *  cell delta from the resize start point — not from the previous
+ *  motion event. */
+export type ResizeInfo = {
+  size: ResizeSize
+  startSize: ResizeSize
+  delta: { dw: number; dh: number }
+  /** Which handle the user grabbed (`s`, `e`, or `se`). Useful when
+   *  the same callback handles multiple handles. */
+  direction: ResizeHandleDirection
+}
+
+export type ResizableProps = Except<BoxProps, 'width' | 'height' | 'onMouseDown'> & {
+  /** Cell dimensions before the user resizes. Internal state seeds from
+   *  this on mount; subsequent renders use the resized dimensions.
+   *  Changing this prop after mount is ignored — `defaultValue` semantics. */
+  initialSize: ResizeSize
+  /** Lower bound on size. Default `{ width: 1, height: 1 }` (the smallest
+   *  meaningful box). User-supplied min wins over the default — pass e.g.
+   *  `{ width: 10, height: 3 }` to keep the resizable at least the size
+   *  of an inner control. */
+  minSize?: ResizeSize
+  /** Upper bound on size. Optional — when omitted the box can grow
+   *  unbounded (in practice, until it overflows its container or the
+   *  terminal). Pass e.g. `{ width: cols, height: rows }` to clamp at the
+   *  terminal viewport. */
+  maxSize?: ResizeSize
+  /** Which handles to render. Default `['se']` — bottom-right corner only,
+   *  the common case for resizable panels. Pass `['s', 'e', 'se']` for
+   *  three independent handles, or any subset. */
+  handles?: ResizeHandleDirection[]
+  /** Background color of the handle when idle. Visible chrome so the user
+   *  knows where to grab. Default `'gray'`. */
+  handleColor?: Color
+  /** Background color of the handle when the cursor is over it. Hover
+   *  affordance. Default `'white'`. */
+  handleHoverColor?: Color
+  /** Fires once at the FIRST motion of a resize (not on press). A press
+   *  on a handle without subsequent motion is not a resize, so this won't
+   *  fire — symmetrical with Draggable's onDragStart. */
+  onResizeStart?: (info: ResizeInfo) => void
+  /** Fires on every cell-crossing motion event during the resize. */
+  onResize?: (info: ResizeInfo) => void
+  /** Fires once at release if the gesture became a resize. */
+  onResizeEnd?: (info: ResizeInfo) => void
+}
+
+/**
+ * Resizable container. Wraps a `<Box>`; renders one or more grab handles
+ * along its bottom / right / SE-corner edges; updates its own size as
+ * the user drags those handles.
+ *
+ * What's baked in:
+ *
+ * - **Visible handle chrome** — a 1-cell strip on each enabled edge,
+ *   plus a 1×1 corner marker for SE (with a `◢` glyph for clarity).
+ *   Brightens on hover so the user can see the affordance.
+ * - **Min/max clamping** — `minSize` defaults to (1, 1); `maxSize` is
+ *   optional and unbounded by default. Both are respected at every
+ *   motion event, not just at release.
+ * - **Lifecycle separation** — `onResizeStart` is deferred to the first
+ *   motion (a press without motion isn't a resize). `onResizeEnd` only
+ *   fires if the gesture actually became a resize.
+ * - **Handle isolation** — each handle calls `stopImmediatePropagation`
+ *   on its mousedown, so a Resizable nested inside a Draggable won't
+ *   start a drag when the user grabs a resize handle. Press anywhere
+ *   ELSE on the Resizable still bubbles normally (clickable, draggable
+ *   wrappers still work).
+ *
+ * v1 limitation: only south / east / SE handles. North / west / NW / SW /
+ * NE are tricky for in-flow components (they shift the layout origin)
+ * and are deferred to a follow-up.
+ *
+ * @example
+ *   <Resizable
+ *     initialSize={{ width: 30, height: 8 }}
+ *     minSize={{ width: 10, height: 3 }}
+ *     handles={['s', 'e', 'se']}
+ *     borderStyle="single"
+ *     onResizeEnd={({ size }) => persistPanelSize(size)}
+ *   >
+ *     <Text>I'm resizable.</Text>
+ *   </Resizable>
+ */
+export default function Resizable({
+  initialSize,
+  minSize,
+  maxSize,
+  handles = ['se'],
+  handleColor = 'gray',
+  handleHoverColor = 'white',
+  onResizeStart,
+  onResize,
+  onResizeEnd,
+  children,
+  ...boxProps
+}: PropsWithChildren<ResizableProps>): React.ReactNode {
+  const [size, setSize] = useState<ResizeSize>(initialSize)
+  const [hoveredHandle, setHoveredHandle] = useState<ResizeHandleDirection | null>(null)
+
+  // Refs read at gesture time so mid-resize prop changes apply on the
+  // next motion event (mirrors Draggable's pattern).
+  const onResizeStartRef = useRef(onResizeStart)
+  const onResizeRef = useRef(onResize)
+  const onResizeEndRef = useRef(onResizeEnd)
+  const minSizeRef = useRef(minSize)
+  const maxSizeRef = useRef(maxSize)
+  onResizeStartRef.current = onResizeStart
+  onResizeRef.current = onResize
+  onResizeEndRef.current = onResizeEnd
+  minSizeRef.current = minSize
+  maxSizeRef.current = maxSize
+
+  // Mirror of `size` accessible synchronously from gesture callbacks
+  // (setSize batches; onResizeEnd needs the latest committed size).
+  const latestSizeRef = useRef<ResizeSize>(size)
+
+  const startResize = useCallback(
+    (e: MouseDownEvent, dir: ResizeHandleDirection): void => {
+      // Stop propagation so a wrapping Draggable's onMouseDown doesn't
+      // also fire and capture the gesture for itself. The handle's
+      // captureGesture must win unambiguously.
+      e.stopImmediatePropagation()
+      handleResizePress(e, dir, {
+        startSize: size,
+        minSizeRef,
+        maxSizeRef,
+        latestSizeRef,
+        setSize,
+        onResizeStartRef,
+        onResizeRef,
+        onResizeEndRef,
+      })
+    },
+    [size],
+  )
+
+  const handleE = useCallback((e: MouseDownEvent) => startResize(e, 'e'), [startResize])
+  const handleS = useCallback((e: MouseDownEvent) => startResize(e, 's'), [startResize])
+  const handleSe = useCallback((e: MouseDownEvent) => startResize(e, 'se'), [startResize])
+
+  // Hover handlers: per-handle so leave only clears for the handle
+  // that's actually exiting (multiple handles can be present, mouse
+  // moving from one to the other should swap, not clear-and-clear).
+  const enter = useCallback((dir: ResizeHandleDirection) => () => setHoveredHandle(dir), [])
+  const leave = useCallback(
+    (dir: ResizeHandleDirection) => () => setHoveredHandle((cur) => (cur === dir ? null : cur)),
+    [],
+  )
+
+  const colorFor = (dir: ResizeHandleDirection): Color =>
+    hoveredHandle === dir ? handleHoverColor : handleColor
+
+  return (
+    <Box {...boxProps} width={size.width} height={size.height}>
+      {children}
+      {/* Handles are absolute children so they paint on top of content
+          without affecting flex layout inside the Resizable. zIndex on
+          SE > E,S so the corner cell paints over the edge strips when
+          all three handles are enabled at once. */}
+      {handles.includes('e') && (
+        <Box
+          position="absolute"
+          top={0}
+          left={size.width - 1}
+          width={1}
+          height={size.height}
+          backgroundColor={colorFor('e')}
+          onMouseDown={handleE}
+          onMouseEnter={enter('e')}
+          onMouseLeave={leave('e')}
+          // Above sibling chrome but below the SE corner.
+          zIndex={1}
+        />
+      )}
+      {handles.includes('s') && (
+        <Box
+          position="absolute"
+          top={size.height - 1}
+          left={0}
+          width={size.width}
+          height={1}
+          backgroundColor={colorFor('s')}
+          onMouseDown={handleS}
+          onMouseEnter={enter('s')}
+          onMouseLeave={leave('s')}
+          zIndex={1}
+        />
+      )}
+      {handles.includes('se') && (
+        <Box
+          position="absolute"
+          top={size.height - 1}
+          left={size.width - 1}
+          width={1}
+          height={1}
+          backgroundColor={colorFor('se')}
+          onMouseDown={handleSe}
+          onMouseEnter={enter('se')}
+          onMouseLeave={leave('se')}
+          // Above E and S so the corner cell wins paint when all three
+          // are enabled (the E/S strips overlap the corner cell otherwise).
+          zIndex={2}
+        >
+          <Text>◢</Text>
+        </Box>
+      )}
+    </Box>
+  )
+}
+
+// ── gesture handler (extracted so tests can drive it without React) ──
+
+type ResizePressDeps = {
+  startSize: ResizeSize
+  minSizeRef: { current: ResizeSize | undefined }
+  maxSizeRef: { current: ResizeSize | undefined }
+  latestSizeRef: { current: ResizeSize }
+  setSize: (s: ResizeSize) => void
+  onResizeStartRef: { current: ((info: ResizeInfo) => void) | undefined }
+  onResizeRef: { current: ((info: ResizeInfo) => void) | undefined }
+  onResizeEndRef: { current: ((info: ResizeInfo) => void) | undefined }
+}
+
+/**
+ * Implements the resize press → motion → release lifecycle. Used by
+ * `<Resizable>` for each handle; exported here so tests can drive it
+ * with stub setters and assert the contract without spinning up React.
+ */
+export function handleResizePress(
+  e: MouseDownEvent,
+  dir: ResizeHandleDirection,
+  deps: ResizePressDeps,
+): void {
+  const startSize = deps.startSize
+  const startCol = e.col
+  const startRow = e.row
+  // Defer onResizeStart to the first motion event. A press without
+  // motion isn't a resize — symmetrical with Draggable.
+  let resizeStarted = false
+
+  e.captureGesture({
+    onMove(m: MouseMoveEvent) {
+      const dw = m.col - startCol
+      const dh = m.row - startRow
+      const newSize = computeResizedSize(
+        startSize,
+        startCol,
+        startRow,
+        m.col,
+        m.row,
+        dir,
+        deps.minSizeRef.current,
+        deps.maxSizeRef.current,
+      )
+      const info: ResizeInfo = { size: newSize, startSize, delta: { dw, dh }, direction: dir }
+      if (!resizeStarted) {
+        resizeStarted = true
+        deps.onResizeStartRef.current?.(info)
+      }
+      deps.latestSizeRef.current = newSize
+      deps.setSize(newSize)
+      deps.onResizeRef.current?.(info)
+    },
+    onUp(u: MouseUpEvent) {
+      if (!resizeStarted) return
+      const finalSize = deps.latestSizeRef.current
+      deps.onResizeEndRef.current?.({
+        size: finalSize,
+        startSize,
+        delta: { dw: u.col - startCol, dh: u.row - startRow },
+        direction: dir,
+      })
+    },
+  })
+}
+
+// ── pure helpers (exported for testing) ──────────────────────────────
+
+/**
+ * Clamp `value` to `[min, max]` inclusive. When max < min (degenerate
+ * bounds — e.g. minSize larger than maxSize), returns min so the
+ * resize pins at the lower bound rather than producing an inverted
+ * range. Local rather than reusing layout/geometry's clamp because
+ * that one doesn't define behavior for inverted ranges.
+ */
+function clampRange(value: number, min: number, max: number): number {
+  if (max < min) return min
+  if (value < min) return min
+  if (value > max) return max
+  return value
+}
+
+/** Default minimum size when caller doesn't supply one. (1, 1) is the
+ *  smallest meaningful box; smaller would mean "no visible chrome." */
+const DEFAULT_MIN: ResizeSize = { width: 1, height: 1 }
+
+/**
+ * Compute the new size for a resize given the start size, cursor start +
+ * current positions, the handle direction, and optional min/max bounds.
+ * Pure — drives both the live resize math and tests.
+ *
+ * Direction semantics:
+ *   - `e`  → only width changes (cursor delta in cols)
+ *   - `s`  → only height changes (cursor delta in rows)
+ *   - `se` → both change
+ *
+ * Each axis is clamped INDEPENDENTLY: dragging SE past max-width but
+ * within max-height pins width and continues to grow height freely.
+ */
+export function computeResizedSize(
+  startSize: ResizeSize,
+  startCol: number,
+  startRow: number,
+  curCol: number,
+  curRow: number,
+  dir: ResizeHandleDirection,
+  minSize?: ResizeSize,
+  maxSize?: ResizeSize,
+): ResizeSize {
+  const min = minSize ?? DEFAULT_MIN
+  let width = startSize.width
+  let height = startSize.height
+  if (dir === 'e' || dir === 'se') width = startSize.width + (curCol - startCol)
+  if (dir === 's' || dir === 'se') height = startSize.height + (curRow - startRow)
+  width = clampRange(width, min.width, maxSize?.width ?? Number.POSITIVE_INFINITY)
+  height = clampRange(height, min.height, maxSize?.height ?? Number.POSITIVE_INFINITY)
+  return { width, height }
+}

--- a/packages/renderer/src/components/Resizable.tsx
+++ b/packages/renderer/src/components/Resizable.tsx
@@ -1,7 +1,6 @@
 import type React from 'react'
-import { type PropsWithChildren, useCallback, useEffect, useRef, useState } from 'react'
+import { type PropsWithChildren, useCallback, useRef, useState } from 'react'
 import type { Except } from 'type-fest'
-import type { DOMElement } from '../dom.js'
 import type { MouseDownEvent, MouseMoveEvent, MouseUpEvent } from '../events/mouse-event.js'
 import type { Color } from '../styles.js'
 import Box, { type Props as BoxProps } from './Box.js'
@@ -58,19 +57,6 @@ export type ResizableProps = Except<BoxProps, 'width' | 'height' | 'onMouseDown'
   /** Background color of the handle when the cursor is over it. Hover
    *  affordance. Default `'white'`. */
   handleHoverColor?: Color
-  /**
-   * When true (default), the box's effective minimum height tracks its
-   * content's natural height — i.e. the user cannot shrink the box past
-   * the space its content needs to display. As the WIDTH shrinks, text
-   * wraps into more lines, and the box auto-grows in HEIGHT to keep
-   * everything visible. The user-supplied `minSize.height` still acts
-   * as a floor; effective min is `max(minSize.height, contentHeight)`.
-   *
-   * Set to false for raw size control (e.g. when content is itself
-   * scrollable / virtualised). The `overflow:'hidden'` default still
-   * keeps content from bleeding outside the box.
-   */
-  autoFit?: boolean
   /** Fires once at the FIRST motion of a resize (not on press). A press
    *  on a handle without subsequent motion is not a resize, so this won't
    *  fire — symmetrical with Draggable's onDragStart. */
@@ -125,7 +111,6 @@ export default function Resizable({
   handles = ['se'],
   handleColor = 'gray',
   handleHoverColor = 'white',
-  autoFit = true,
   onResizeStart,
   onResize,
   onResizeEnd,
@@ -134,68 +119,18 @@ export default function Resizable({
 }: PropsWithChildren<ResizableProps>): React.ReactNode {
   const [size, setSize] = useState<ResizeSize>(initialSize)
   const [hoveredHandle, setHoveredHandle] = useState<ResizeHandleDirection | null>(null)
-  const contentRef = useRef<DOMElement>(null)
-
-  // ── autoFit: read content's natural height from yoga ──────────────
-  //
-  // Yoga lays out the wrapper inside our outer Box. With overflow set
-  // to visible on the wrapper (default) and no fixed height on it,
-  // yoga gives the wrapper its content's intrinsic height for the
-  // current width — exactly the value we need to know "how tall must
-  // this box be to show all the text?"
-  //
-  // Timing caveat: ink calls calculateLayout AFTER React's commit, so
-  // at the moment THIS render runs, contentRef.yogaNode reflects the
-  // PREVIOUS frame's layout. That's stale-by-one-frame, but for
-  // continuous interactions (drag, resize) the lag is invisible: each
-  // motion event triggers a re-render, the next render reads the
-  // value we just measured, and within 1-2 frames the box converges.
-  // overflow:'hidden' on the outer Box hides the in-between state.
-  //
-  // First render: ref is null, returns 0 → effectiveMin falls back to
-  // user min. After mount the ref is populated and subsequent renders
-  // get real values.
-  const measuredHeight =
-    autoFit && contentRef.current?.yogaNode?.getComputedHeight()
-      ? contentRef.current.yogaNode.getComputedHeight()
-      : 0
-
-  // Effective min: width is user's (or 1); height is the larger of
-  // user min and the measured content height. Resize gesture clamps
-  // against this — the box refuses to shrink past content.
-  const effectiveMin: ResizeSize = {
-    width: minSize?.width ?? 1,
-    height: autoFit
-      ? Math.max(minSize?.height ?? 1, measuredHeight || 1)
-      : (minSize?.height ?? 1),
-  }
-
-  // Catch up state when measuredHeight reveals the box is currently
-  // smaller than effective min — happens when the user shrinks WIDTH
-  // and content suddenly needs more rows. useEffect (post-commit, not
-  // useLayoutEffect) so React commits the current render first; the
-  // next render then renders at the corrected size. Convergence in
-  // 1-2 frames; overflow:'hidden' hides the transient.
-  useEffect(() => {
-    if (!autoFit) return
-    if (size.height < effectiveMin.height) {
-      setSize((s) => ({ ...s, height: effectiveMin.height }))
-    }
-  }, [autoFit, effectiveMin.height, size.height])
 
   // Refs read at gesture time so mid-resize prop changes apply on the
-  // next motion event (mirrors Draggable's pattern). minSizeRef holds
-  // the EFFECTIVE min (post-autoFit) so the gesture clamp against it
-  // matches what the user can actually see.
+  // next motion event (mirrors Draggable's pattern).
   const onResizeStartRef = useRef(onResizeStart)
   const onResizeRef = useRef(onResize)
   const onResizeEndRef = useRef(onResizeEnd)
-  const minSizeRef = useRef(effectiveMin)
+  const minSizeRef = useRef(minSize)
   const maxSizeRef = useRef(maxSize)
   onResizeStartRef.current = onResizeStart
   onResizeRef.current = onResize
   onResizeEndRef.current = onResizeEnd
-  minSizeRef.current = effectiveMin
+  minSizeRef.current = minSize
   maxSizeRef.current = maxSize
 
   // Mirror of `size` accessible synchronously from gesture callbacks
@@ -244,14 +179,7 @@ export default function Resizable({
     // or always when autoFit is false). Spread boxProps after the
     // default so users can opt back into 'visible'.
     <Box overflow="hidden" {...boxProps} width={size.width} height={size.height}>
-      {/* Inner content wrapper exists solely so we have a stable yoga
-          node to measure for autoFit. Default alignSelf inherits
-          'stretch' from the column flex, so the wrapper takes the full
-          box width — its measured natural height then reflects how
-          content wraps at that width, which is the input we need.
-          Wrapper has no fixed size, no flex shrink override; layout-wise
-          it's transparent for typical column-of-content children. */}
-      <Box ref={contentRef}>{children}</Box>
+      {children}
       {/* Handles are absolute children so they paint on top of content
           without affecting flex layout inside the Resizable. zIndex on
           SE > E,S so the corner cell paints over the edge strips when

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -19,6 +19,13 @@ export type {
 } from './components/Draggable'
 export { default as DropTarget } from './components/DropTarget'
 export type { DropTargetProps, DropInfo } from './components/DropTarget'
+export { default as Resizable } from './components/Resizable'
+export type {
+  ResizableProps,
+  ResizeSize,
+  ResizeHandleDirection,
+  ResizeInfo,
+} from './components/Resizable'
 export { default as ScrollBox } from './components/ScrollBox'
 export type { ScrollBoxHandle } from './components/ScrollBox'
 export { AlternateScreen } from './components/AlternateScreen'

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -54,6 +54,19 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
 
+  examples/resizable:
+    dependencies:
+      '@yokai/renderer':
+        specifier: workspace:*
+        version: link:../../packages/renderer
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+    devDependencies:
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+
   packages/renderer:
     dependencies:
       '@alcalzone/ansi-tokenize':


### PR DESCRIPTION
## Summary

Adds `<Resizable>` — a polished resize primitive matching the build quality of `<Draggable>` and `<DropTarget>`. Wraps `<Box>`, paints visible edge handles, drags grow the box.

## API

```tsx
<Resizable
  initialSize={{ width: 30, height: 8 }}
  minSize={{ width: 10, height: 3 }}
  maxSize={{ width: 60, height: 16 }}
  handles={['s', 'e', 'se']}        // default: ['se']
  backgroundColor="#1a1a3a"
  onResizeEnd={({ size }) => persist(size)}
>
  <Text>I'm resizable.</Text>
</Resizable>
```

## What's baked in

- **Visible handle chrome** — 1-cell strip on each enabled edge, 1×1 corner marker for SE with a `◢` glyph. Default `gray` bg, `white` on hover. Per-handle hover state.
- **Min/max clamping per axis** — width and height clamp independently; default min is (1, 1), max is unbounded.
- **Lifecycle separation** — `onResizeStart` deferred to first motion; `onResizeEnd` fires only if the gesture became a resize.
- **Handle isolation** — handles call `stopImmediatePropagation` on mousedown so a Resizable nested inside a Draggable won't trigger a drag when the user grabs a resize handle.
- **Refs read at gesture time** — mid-resize prop changes apply on next motion.

## Mouse cursor shape

You asked about changing the cursor on hover — answered in-thread: not possible from a TUI. Terminal owns the pointer. We compensate with visible+highlight handle chrome instead.

## v1 scope

Only `s` / `e` / `se` handles. North / west / NW / SW / NE require shifting the layout origin during resize, which fights flexbox for in-flow elements; clean follow-up for absolute-positioned Resizables.

## Tests

27 new tests, 156 total, all green:

- **`computeResizedSize` math** — every direction, growth + shrink, default + user min/max, per-axis independent clamping, degenerate bounds (max < min), direction confinement.
- **`handleResizePress` protocol** — capture-on-press, deferred `onResizeStart`, fires once across many motions, `onResize` per motion, `setSize` per motion, `onResizeEnd` at release with final size + direction, no-motion releases fire nothing, min/max clamping during motion, mid-resize bounds change applies on next motion, every direction lifecycle.

## Demo

`examples/resizable/resizable.tsx` — two side-by-side panels, one with all three handles, one with the default SE-only. Live size readouts above each via `onResize`. Run with `pnpm demo:resizable`.

## Test plan

- [x] `npx vitest run` — 156 tests pass
- [x] `pnpm -r typecheck`
- [x] `pnpm --filter @yokai/renderer lint`
- [x] `pnpm build`
- [x] All four demos smoke-test cleanly (drag, constrained-drag, drag-and-drop, resizable)
- [ ] Manual: drag handles in the resizable demo, confirm clamping at min/max, hover highlight, SE corner does both axes