### PR TITLE
chore(release): v0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yokai",
-  "version": "0.1.0",
+  "version": "0.4.0",
   "private": true,
   "description": "React terminal renderer — pure TypeScript Yoga layout, diff-based rendering, ScrollBox",
   "license": "MIT",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yokai/renderer",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "React terminal renderer — reconciler + Yoga layout + TTY output",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yokai/shared",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "description": "Shared utilities — Yoga layout TS port, logger, env helpers",
   "license": "MIT",
   "main": "./dist/index.js",


### PR DESCRIPTION
First tagged release. Bumps everything to **0.4.0** (renderer + shared from `0.3.0`, root from `0.1.0`).

## Highlights since the fork

### New public components
- **`<Draggable>`** — gesture-captured drag primitive with raise-on-press, drag-time z boost, optional bounds clamping, lifecycle hooks (`onDragStart` / `onDrag` / `onDragEnd`). PR #22.
- **`<DropTarget>`** — receiver side of drag-and-drop with `accept` filter, hover lifecycle, topmost-wins drop dispatch. PR #23.
- **`<Resizable>`** — first-class resize primitive with `s`, `e`, `se` handles, hover-highlighted chrome, min/max clamping. PR #24.

### New events / API surface
- `onMouseDown` on `<Box>` with `event.captureGesture({ onMove, onUp })` — the gesture-capture protocol the new components are built on.
- `MouseDownEvent` / `MouseMoveEvent` / `MouseUpEvent` / `GestureHandlers` exported.
- Drag/drop coordination via the `drag-registry` module.

### Renderer correctness
- **z-index for `position: absolute`** — full paint-order suite, hit-test agrees with paint order. PR #10.
- **Hit-test fixes** — z-order honored on press; escape-bounds traversal so absolutes dragged outside their parent stay clickable. PR #20.
- **Notch fix** — tree-wide collection of dirty absolute rects so cross-subtree blits don't leave empty cells when an absolute moves. PR #21.
- **Drag trail fixes** — per-cell suppression of stale absolute paint; force-rerender of clean siblings overlapping a moving absolute (both in-flow and absolute siblings).

### Demos
- `pnpm demo:drag`
- `pnpm demo:constrained-drag`
- `pnpm demo:drag-and-drop`
- `pnpm demo:resizable`

### Tests
156 across 7 files. Pure-math tests for every new component's geometry, gesture-protocol tests via direct `handleXyzPress` invocation, integration tests for cross-component interactions (Draggable ↔ DropTarget).

## Consumption (claude-corp + others)

```jsonc
// package.json
"dependencies": {
  "@yokai/renderer": "github:re-marked/yokai#v0.4.0"
}
```

## Test plan

- [x] All 156 tests pass
- [x] Typecheck across all packages
- [x] Lint clean
- [x] All four demos smoke-test without errors
- [ ] Tag `v0.4.0` after merge