### PR TITLE
chore(release): v0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yokai",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "description": "React terminal renderer — pure TypeScript Yoga layout, diff-based rendering, ScrollBox",
   "license": "MIT",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yokai/renderer",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "React terminal renderer — reconciler + Yoga layout + TTY output",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yokai/shared",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "description": "Shared utilities — Yoga layout TS port, logger, env helpers",
   "license": "MIT",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Minor bump for the keyboard focus + arrow navigation work merged in #27.

## What's new

### Hooks (now actually exist — README had been lying)
- **`useFocus({ autoFocus? })`** → `{ ref, isFocused, focus }`
- **`useFocusManager()`** → `{ focused, focus, focusNext, focusPrevious, blur }`

### Components
- **`<FocusGroup direction="row|column|both" wrap?>`** — arrow-key navigation between focusable descendants without interfering with Tab.
- **`<FocusRing>`** — focusable Box with focus-visible border indicator.

### FocusManager additions
- `subscribeToFocus(node, listener)` — per-node subscription.
- `subscribe(listener)` — global subscription.
- Snapshot iteration so unsubscribe-during-dispatch is safe.
- Per-node listener cleanup on `handleNodeRemoved`.

### Demo
```bash
pnpm demo:focus-nav
```

## Tests

208 total, 52 new since v0.4.0.

## Consumption

```jsonc
"dependencies": {
  "@yokai/renderer": "github:re-marked/yokai#v0.5.0"
}
```

## Test plan

- [x] All 208 tests pass
- [x] `pnpm -r typecheck`
- [x] `pnpm --filter @yokai/renderer lint`
- [x] `pnpm build`
- [x] All five demos smoke-test cleanly
- [ ] Tag `v0.5.0` after merge