### PR TITLE
docs: comprehensive docs/ — Phase 2 (~20 more pages)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -7,6 +7,8 @@ docs/
 ├── README.md
 ├── AGENTS.md
 ├── troubleshooting.md
+├── faq.md
+├── changelog.md
 ├── getting-started/
 │   ├── install.md
 │   ├── your-first-app.md
@@ -61,14 +63,33 @@ docs/
 │   ├── kanban-board.md
 │   ├── modal.md
 │   ├── resizable-panes.md
-│   └── autocomplete.md
+│   ├── autocomplete.md
+│   ├── table.md
+│   ├── file-tree.md
+│   ├── log-viewer.md
+│   ├── chat-ui.md
+│   ├── confirmation-dialog.md
+│   └── indicators.md
 ├── guides/
 │   ├── migration-from-ink.md
 │   ├── testing.md
-│   └── debugging.md
-└── reference/
-    ├── types.md
-    └── styles.md
+│   ├── debugging.md
+│   ├── accessibility.md
+│   ├── streaming-content.md
+│   └── error-handling.md
+├── reference/
+│   ├── types.md
+│   ├── styles.md
+│   ├── events.md
+│   └── cli.md
+└── internals/
+    ├── architecture.md
+    ├── reconciler.md
+    ├── yoga-port.md
+    ├── render-pipeline.md
+    ├── selection-state-machine.md
+    ├── drag-registry.md
+    └── focus-manager.md
 ```
 
 ### Getting Started
@@ -135,19 +156,44 @@ docs/
 - [Modal](patterns/modal.md)
 - [Resizable panes](patterns/resizable-panes.md)
 - [Autocomplete](patterns/autocomplete.md)
+- [Table](patterns/table.md)
+- [File tree](patterns/file-tree.md)
+- [Log viewer](patterns/log-viewer.md)
+- [Chat UI](patterns/chat-ui.md)
+- [Confirmation dialog](patterns/confirmation-dialog.md)
+- [Indicators (spinners + progress bars)](patterns/indicators.md)
 
 ### Guides
 
 - [Migration from Ink](guides/migration-from-ink.md)
 - [Testing](guides/testing.md)
 - [Debugging](guides/debugging.md)
+- [Accessibility](guides/accessibility.md)
+- [Streaming content](guides/streaming-content.md)
+- [Error handling](guides/error-handling.md)
 
 ### Reference
 
 - [Types](reference/types.md)
 - [Styles](reference/styles.md)
+- [Events](reference/events.md)
+- [CLI / render APIs](reference/cli.md)
 
-### AI Agents
+### Internals
+
+For contributors to yokai itself, and consumers reasoning about renderer behavior.
+
+- [Architecture](internals/architecture.md)
+- [Reconciler](internals/reconciler.md)
+- [Yoga port](internals/yoga-port.md)
+- [Render pipeline](internals/render-pipeline.md)
+- [Selection state machine](internals/selection-state-machine.md)
+- [Drag registry](internals/drag-registry.md)
+- [Focus manager](internals/focus-manager.md)
+
+### Meta
 
 - [AGENTS.md](AGENTS.md) — guide for AI assistants writing code that uses yokai
 - [Troubleshooting](troubleshooting.md) — runtime failures and fixes
+- [FAQ](faq.md) — frequently asked questions
+- [Changelog](changelog.md) — versioned release notes

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,0 +1,58 @@
+# Changelog
+
+Tagged releases of `@yokai/renderer` and `@yokai/shared`. The full commit graph is preserved on `main` — `git log vPREV..vNEXT` shows everything between any two tags.
+
+## v0.5.0 — 2026-04-27
+
+Keyboard focus and arrow navigation. [GitHub release](https://github.com/re-marked/yokai/releases/tag/v0.5.0).
+
+**Added**
+
+- `useFocus(options?)` hook — per-element focus tracking. Returns `{ ref, isFocused, focus }`.
+- `useFocusManager()` hook — global focus actions: `focused`, `focus`, `focusNext`, `focusPrevious`, `blur`.
+- `<FocusGroup direction wrap isActive>` — arrow-key navigation across descendants. `direction` is `'row' | 'column' | 'both'`.
+- `<FocusRing borderColorFocus borderColorIdle autoFocus>` — focusable Box with built-in focus chrome.
+- `FocusManager.subscribe(...)` plumbing on `FocusContext` so external integrations can observe focus changes.
+- Type exports: `UseFocusOptions`, `UseFocusResult`, `UseFocusManagerResult`, `FocusGroupProps`, `FocusGroupDirection`, `FocusRingProps`.
+
+**Changed**
+
+- Focus state plumbing extended through context to support subscribe API; existing single-element focus behavior preserved.
+
+**Internal**
+
+- Biome formatting pass on focus-feature files.
+
+## v0.4.0 — 2026-04-27
+
+Drag, drop, resize, z-index, and the notch fix. [GitHub release](https://github.com/re-marked/yokai/releases/tag/v0.4.0).
+
+**Added**
+
+- `<Draggable initialPos bounds disabled onDragStart onDrag onDragEnd>` — first-class drag primitive.
+- `<DropTarget accept onDragEnter onDragOver onDragLeave onDrop>` — receiver side, wired through a coordination layer (`drag-registry.ts`).
+- `<Resizable initialSize minSize maxSize handles>` — resize primitive with `'s'`, `'e'`, `'se'` handles. Clips overflow; auto-fits min height to content.
+- Gesture capture API: `MouseDownEvent.captureGesture({ onMove, onUp })`. Claims subsequent motion + the eventual release for the lifetime of one drag, suppresses selection extension, and routes events to the captured handlers even when the cursor leaves the originally pressed element. Mirrors web `setPointerCapture`.
+- `onMouseDown` prop on `<Box>` and the `ink-box` JSX intrinsic.
+- `dispatchMouseDown` hit-test path with gesture-capture return value.
+- `Styles.zIndex` for `position: 'absolute'` nodes. Per-parent stacking; negative values paint under in-flow content. Dev-mode warning fires when set on a non-absolute node.
+- Public exports of mouse event types: `MouseDownEvent`, `MouseMoveEvent`, `MouseUpEvent`, `GestureHandlers`.
+- Type exports: `DraggableProps`, `DragPos`, `DragBounds`, `DragInfo`, `DropTargetProps`, `DropInfo`, `ResizableProps`, `ResizeSize`, `ResizeHandleDirection`, `ResizeInfo`.
+
+**Fixed**
+
+- Hit-test honors `zIndex` and follows escape-bounds absolutes — clicks on a positioned overlay no longer fall through to in-flow content underneath.
+- Tree-wide collection of dirty absolute rects for overlap-rerender. Cross-subtree absolute overlap (the "notch" repro) now repaints correctly when a moving absolute crosses a clean sibling absolute in another subtree.
+- In-flow children that overlap a moving absolute now force-rerender (no stale paint behind a moved overlay).
+- Per-cell suppression of blits over absolute clears — moving an absolute no longer leaves a trail of stale cells from the previous frame.
+- Text-node guard uses the `DOMNode` union instead of an asserted `DOMElement`, eliminating a class of incorrect type narrowing in render traversal.
+
+**Internal**
+
+- `drag-registry.ts` — coordination layer between `<Draggable>` and `<DropTarget>`.
+- Vitest config now includes `.tsx` test files.
+- Biome format drive-by on `render-node-to-output`.
+
+## Pre-v0.4.0
+
+Initial yokai fork from claude-code-kit, plus the work that landed before tagging began. The full history is on `main`; consult [GitHub releases](https://github.com/re-marked/yokai/releases) and `git log v0.4.0` for the rollup of everything that shipped in the first tagged version.

--- a/docs/faq.md
+++ b/docs/faq.md
@@ -1,0 +1,88 @@
+# FAQ
+
+Short answers to recurring questions. Each links to the canonical doc page when there's more depth.
+
+## General
+
+**What is yokai?**
+A React reconciler for the terminal. Pure-TS Yoga flexbox, diff-based screen output, ScrollBox with viewport culling. Mount React components, get ANSI on stdout. See [README](./README.md).
+
+**How is it different from Ink?**
+Forked from Ink via claude-code-kit. Pure-TypeScript Yoga (no WASM), per-cell frame diffing with DECSTBM scroll hints, native ScrollBox with viewport culling, mouse events with gesture capture, drag/drop/resize primitives, focus groups with arrow navigation, alt-screen, z-index for absolutes. `flexShrink` defaults to `0` (matches Yoga, not CSS or Ink).
+
+**When NOT to use yokai?**
+For one-shot CLI output (a `--help` screen, a single status line) reach for plain `console.log` or `chalk`. yokai's payoff is interactive trees and sustained renders.
+
+**Is it production-ready?**
+Used by claude-corp in production. Stability is a hard requirement of the project. See [CONTRIBUTING.md](../CONTRIBUTING.md).
+
+## Setup
+
+**How do I install?**
+`pnpm add @yokai/renderer @yokai/shared`. The renderer depends on the shared package; both must be installed.
+
+**What Node and React versions?**
+Node 20+. React 19 (the reconciler targets the React 19 host config).
+
+**How do I consume from a non-monorepo project?**
+Standard package install. The build artifacts are emitted by the workspace; no source-link required. If using TypeScript, ensure `moduleResolution` is `bundler` or `node16` so the `exports` map resolves.
+
+## Layout
+
+**Why is my Box empty?**
+A Box with no `width`/`height` and no children collapses to zero. Add `flexGrow={1}` to take available space, or set explicit dimensions. See [styles reference](./reference/styles.md).
+
+**Why does flexShrink behave differently from CSS?**
+Yokai inherits Yoga's default of `flexShrink: 0`. CSS and Ink default to `1`. To allow a child to shrink past content size, set `flexShrink={1}` explicitly. See [styles reference](./reference/styles.md).
+
+**Why is my absolute element not where I put it?**
+`top`/`left`/`right`/`bottom` are relative to the nearest positioned ancestor (the parent Box, in yokai). Percent strings are percent of parent. `zIndex` is honored only on `position: 'absolute'` and only sorts among siblings of the same parent. See [styles reference](./reference/styles.md).
+
+## Mouse and keyboard
+
+**Why don't mouse events fire?**
+Mouse tracking requires `<AlternateScreen mouseTracking>`. The alt-screen prop alone is not sufficient. See [troubleshooting](./troubleshooting.md).
+
+**Why doesn't Tab work?**
+`tabIndex` must be a non-negative number on a `<Box>`. `tabIndex="0"` (string) is ignored. `<Text>` does not accept `tabIndex`.
+
+**Why don't arrow keys move focus?**
+Tab cycling is global; arrow navigation is opt-in. Wrap the focusable region in `<FocusGroup direction="column" wrap>` (or `"row"`/`"both"`). `useFocusManager()` alone does not bind arrows. See [FocusGroup](./components/focus-group.md).
+
+## Performance
+
+**How big a tree is too big?**
+Frame diffing is per-cell, not per-node, so paint cost is `O(changed cells)`. Tree size matters for layout (Yoga) and reconciliation (React). A few thousand nodes is fine; tens of thousands wants ScrollBox + viewport culling.
+
+**When should I use ScrollBox?**
+Whenever the rendered content can exceed its container. ScrollBox culls offscreen children before paint and emits hardware scroll hints (DECSTBM) on append. See [ScrollBox](./components/scrollbox.md).
+
+**Does memoization help?**
+Yes for expensive child trees. The reconciler is standard React 19 — `React.memo`, `useMemo`, and stable child `key`s all behave normally and prevent re-render of unchanged subtrees.
+
+## Drag and drop
+
+**Why does my Draggable's onClick not fire?**
+A captured gesture suppresses the `onClick` for the release that ends it. If you `captureGesture` on every mousedown, you'll never see clicks. Capture conditionally — e.g. only after a motion threshold — or handle the click inside `onUp`. See [events reference](./reference/events.md).
+
+**How do I cancel a drag?**
+The capture cannot be released mid-flight (matches `setPointerCapture`). Track an `aborted` flag in your `onMove` and skip the work; the `onUp` will still fire and you can ignore it. The capture is also drained on `FOCUS_OUT` and lost-release recovery automatically.
+
+## Resize
+
+**Why does my content get clipped?**
+`<Resizable>` clips overflow by default — content larger than the resized box is hidden. Set the inner content to `flexShrink={1}` or use a ScrollBox inside.
+
+**Can I shrink past content size?**
+Yes — pass `minSize={{ width: 1, height: 1 }}` or whatever floor you want. The default min is content size.
+
+## Other
+
+**How do I print debug output?**
+Use `import { logForDebugging } from '@yokai/shared'`. Direct `console.log` is intercepted (when `patchConsole` is `true`) and routed to a buffer that prints above the rendered frame. See [debugging guide](./guides/debugging.md).
+
+**How do I test components?**
+Use `renderSync` with a fake `stdout`, then assert on the captured frame. See [testing guide](./guides/testing.md).
+
+**How do I handle terminal resize?**
+Read viewport reactively via `useTerminalViewport()`, or bind `onResize` on a Box. SIGWINCH can pulse rapidly during a window-drag-resize — debounce reactive reads. See [troubleshooting](./troubleshooting.md).

--- a/docs/guides/accessibility.md
+++ b/docs/guides/accessibility.md
@@ -1,0 +1,171 @@
+# Accessibility
+
+How to build yokai apps that work for users on screen readers, screen magnifiers, and keyboard-only input.
+
+Terminal UIs sit outside the assistive-tech stack that web apps inherit for free. There is no DOM accessibility tree, no ARIA, no role announcements. The TUI is a grid of cells; what reaches a screen reader is whatever the terminal emulator chooses to surface. Designing for accessibility in yokai means designing the surface itself.
+
+## Screen-reader and magnifier support
+
+By default, yokai hides the native terminal cursor while the app is mounted. Screen magnifiers and some screen readers track the cursor position to follow user focus, so hiding it breaks them.
+
+Set `CLAUDE_CODE_ACCESSIBILITY=1` (or `true`) in the environment to keep the native cursor visible. Source: `packages/renderer/src/components/App.tsx`.
+
+```bash
+CLAUDE_CODE_ACCESSIBILITY=1 node app.js
+```
+
+Behavior with the flag set:
+
+| Aspect | Default | Accessibility mode |
+|--------|---------|--------------------|
+| Native cursor | Hidden | Visible |
+| Cursor position | Undefined | Tracks `useDeclaredCursor` |
+| Mouse events | Captured | Captured |
+
+Pair this with [`useDeclaredCursor`](../hooks/use-declared-cursor.md) so the cursor lands on the focused input or the active item — that is the position the magnifier zooms to and the reader reads from.
+
+```tsx
+import { useDeclaredCursor } from '@yokai/renderer'
+
+function Prompt({ value, caret }: { value: string; caret: number }) {
+  useDeclaredCursor({ row: 0, col: caret })
+  return <Text>{value}</Text>
+}
+```
+
+## Keyboard-first interaction
+
+Treat the mouse as optional. Every interaction must have a keyboard equivalent.
+
+- Tab / Shift+Tab move focus between focusable elements. See [concepts/focus](../concepts/focus.md).
+- Arrow keys move focus inside a [`<FocusGroup>`](../components/focus-group.md).
+- Enter / Space activate the focused element.
+- Escape cancels modals, closes menus, returns focus to the previous landmark.
+
+```tsx
+import { FocusGroup, useFocus } from '@yokai/renderer'
+
+function Item({ label }: { label: string }) {
+  const { isFocused } = useFocus()
+  return (
+    <Box borderStyle={isFocused ? 'single' : undefined} paddingX={1}>
+      <Text>{label}</Text>
+    </Box>
+  )
+}
+
+function List() {
+  return (
+    <FocusGroup orientation="vertical">
+      <Item label="One" />
+      <Item label="Two" />
+      <Item label="Three" />
+    </FocusGroup>
+  )
+}
+```
+
+## Focus visibility
+
+Every focusable element needs a visible focus indicator. A sighted user navigating by keyboard cannot see a mouse hover state, so focus must be unambiguous.
+
+Two patterns:
+
+```tsx
+// 1. FocusRing — wraps the child and applies a border when focused
+import { FocusRing } from '@yokai/renderer'
+
+<FocusRing>
+  <Button onClick={submit}>Submit</Button>
+</FocusRing>
+
+// 2. Manual — read isFocused from useFocus and style yourself
+const { isFocused } = useFocus()
+<Box backgroundColor={isFocused ? 'blue' : undefined}>...</Box>
+```
+
+See [`<FocusRing>`](../components/focus-ring.md).
+
+## Skip-to-content and landmark navigation
+
+Long screens force keyboard users to tab past every element. Provide landmarks and a way to jump to them.
+
+```tsx
+import { useFocusManager, useFocus } from '@yokai/renderer'
+
+function App() {
+  const main = useFocus({ id: 'main' })
+  const sidebar = useFocus({ id: 'sidebar' })
+  const { focus } = useFocusManager()
+
+  useInput((input, key) => {
+    if (key.alt && input === '1') focus('main')
+    if (key.alt && input === '2') focus('sidebar')
+  })
+  // ...
+}
+```
+
+Document the landmark shortcuts somewhere the user can find them — a help overlay bound to `?` is the convention.
+
+## Color contrast and color-only signals
+
+Terminal themes vary wildly (light, dark, high-contrast, custom palettes). A color you picked on a dark background may be illegible on a light one.
+
+Rules:
+
+- Never encode meaning in color alone. Pair with bold, underline, or a glyph difference.
+- Avoid hex / RGB colors when a named ANSI color works; users remap named colors to fit their theme.
+- Test on at least one light and one dark theme.
+
+```tsx
+// Bad — error state encoded only in color
+<Text color="red">{message}</Text>
+
+// Good — color plus glyph plus bold
+<Text color="red" bold>{`✗ ${message}`}</Text>
+```
+
+## Hover affordances do not exist
+
+Yokai does not emit OSC 22 (mouse cursor shape changes). The terminal emulator owns the pointer; there is no way to say "this region is interactive, show a hand cursor here." Affordances must be visual chrome — a border, a background tint, a leading glyph — that is present without hovering.
+
+## No ARIA equivalent
+
+The yokai DOM-like tree (`Box`, `Text`, etc.) drives layout. It does not feed an accessibility tree. There is no `role`, no `aria-label`, no live region. Anything you want a screen reader to announce has to be in the visible cell grid.
+
+Practical implication: when state changes silently (a background job finishes, a notification arrives), surface it visibly in a position the user is likely to be reading. A toast in the corner is invisible if the user's attention — and their magnifier — is elsewhere.
+
+## Native cursor placement
+
+The native terminal cursor is the closest thing to a "current position" hint that assistive tech can follow. Use [`useDeclaredCursor`](../hooks/use-declared-cursor.md) to place it on:
+
+- The caret in a text input (essential for IME composition popups).
+- The currently selected list item.
+- The active cell in a grid.
+
+Without this, the cursor sits wherever the last write left it — usually the bottom-right corner — and a magnifier user sees nothing useful.
+
+## Shipping checklist
+
+- [ ] App reads and respects `CLAUDE_CODE_ACCESSIBILITY`.
+- [ ] Every interactive element is reachable by Tab or arrow keys.
+- [ ] Every focusable element has a visible focus indicator.
+- [ ] No state is encoded in color alone.
+- [ ] Tested on a light theme and a dark theme.
+- [ ] `useDeclaredCursor` placed at the logical input position.
+- [ ] Keyboard shortcuts documented in an in-app help overlay.
+- [ ] Background state changes surface visibly, not silently.
+- [ ] Modal traps focus and restores it on dismiss.
+- [ ] Text inputs work with IME (cursor placement correct during composition).
+
+## See also
+
+- [concepts/focus](../concepts/focus.md)
+- [components/focus-group](../components/focus-group.md)
+- [components/focus-ring](../components/focus-ring.md)
+- [hooks/use-focus](../hooks/use-focus.md)
+- [hooks/use-focus-manager](../hooks/use-focus-manager.md)
+- [hooks/use-declared-cursor](../hooks/use-declared-cursor.md)
+- [concepts/keyboard](../concepts/keyboard.md)
+- [concepts/colors](../concepts/colors.md)

--- a/docs/guides/error-handling.md
+++ b/docs/guides/error-handling.md
@@ -1,0 +1,201 @@
+# Error handling
+
+How yokai surfaces runtime failures, where the boundaries are, and what the consumer is responsible for.
+
+Yokai uses standard React error boundaries plus a few terminal-specific concerns: stdout is owned by the renderer, the alt-screen and mouse-tracking modes need to be torn down even on crash, and exit codes matter because yokai apps are usually CLIs.
+
+## Built-in error boundary
+
+The top-level `<App>` wraps its children in `<ErrorOverview>`. When a descendant throws during render, `<ErrorOverview>` catches it and renders the stack and component tree in place of the crashed subtree. The renderer keeps running.
+
+See [`<ErrorOverview>`](../components/error-overview.md).
+
+This is the default — you get it for free from `render()` and `createRoot()`.
+
+## Custom error boundaries
+
+For finer-grained recovery, write a React class component with `getDerivedStateFromError` and `componentDidCatch`. The same React API works inside yokai.
+
+```tsx
+import { Component, type ReactNode } from 'react'
+import { Box, Text } from '@yokai/renderer'
+
+class Boundary extends Component<
+  { fallback: ReactNode; children: ReactNode },
+  { error: Error | null }
+> {
+  state = { error: null as Error | null }
+
+  static getDerivedStateFromError(error: Error) {
+    return { error }
+  }
+
+  override componentDidCatch(error: Error, info: React.ErrorInfo) {
+    process.stderr.write(`[boundary] ${error.message}\n${info.componentStack}\n`)
+  }
+
+  override render() {
+    if (this.state.error) return this.props.fallback
+    return this.props.children
+  }
+}
+
+// Usage
+<Boundary fallback={<Text color="red">Sidebar unavailable</Text>}>
+  <Sidebar />
+</Boundary>
+```
+
+Place boundaries at the granularity where partial failure is acceptable: a sidebar, a modal, a single panel. Wrapping every leaf is overkill; wrapping only the root throws away the recovery story.
+
+## Async errors are not caught
+
+Error boundaries catch errors thrown during render, in lifecycle methods, and in constructors. They do not catch:
+
+- Errors in `setTimeout` / `setInterval` callbacks.
+- Rejected promises from `useEffect` async work.
+- Event handler errors (these surface to the host; in yokai's case, the input dispatcher).
+
+Wrap async work explicitly and route failure to state:
+
+```tsx
+function Loader({ load }: { load: () => Promise<Data> }) {
+  const [state, setState] = useState<
+    { kind: 'loading' } | { kind: 'data'; data: Data } | { kind: 'error'; error: Error }
+  >({ kind: 'loading' })
+
+  useEffect(() => {
+    load()
+      .then(data => setState({ kind: 'data', data }))
+      .catch(error => setState({ kind: 'error', error }))
+  }, [load])
+
+  if (state.kind === 'error') return <Text color="red">{state.error.message}</Text>
+  if (state.kind === 'loading') return <Text>Loading...</Text>
+  return <View data={state.data} />
+}
+```
+
+## Process-level errors
+
+`uncaughtException` and `unhandledRejection` are not auto-handled by yokai. The consumer owns this. Recommended pattern in a CLI entry point:
+
+```ts
+import { render } from '@yokai/renderer'
+
+const instance = render(<App />)
+
+const onFatal = (error: unknown) => {
+  process.stderr.write(`[fatal] ${error instanceof Error ? error.stack : String(error)}\n`)
+  instance.unmount()
+  process.exit(1)
+}
+
+process.on('uncaughtException', onFatal)
+process.on('unhandledRejection', onFatal)
+
+await instance.waitUntilExit()
+```
+
+`instance.unmount()` runs the cleanup path: alt-screen exit, mouse-tracking disable, cursor restore, listener removal.
+
+## `useApp().exit(error?)`
+
+Calling `exit()` with no argument unmounts cleanly and resolves the `waitUntilExit()` promise. Calling `exit(error)` rejects it with the supplied error.
+
+```tsx
+import { useApp } from '@yokai/renderer'
+
+function App() {
+  const { exit } = useApp()
+  useInput((input, key) => {
+    if (input === 'q') exit()
+    if (input === 'Q') exit(new Error('Quit with error'))
+  })
+  // ...
+}
+```
+
+CLI entry point catching the rejection:
+
+```ts
+try {
+  const instance = render(<App />)
+  await instance.waitUntilExit()
+  process.exit(0)
+} catch (error) {
+  process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`)
+  process.exit(1)
+}
+```
+
+## Mounting failures
+
+`createRoot` is async. Failures during initial render reject the `createRoot()` promise. Wrap the call:
+
+```ts
+import { createRoot } from '@yokai/renderer'
+
+try {
+  const root = await createRoot(<App />)
+  await root.waitUntilExit()
+} catch (error) {
+  process.stderr.write(`Failed to mount: ${error}\n`)
+  process.exit(1)
+}
+```
+
+This catches: invalid props that throw in a constructor, errors in module-load-time code reachable from the initial tree, terminal capability detection failures.
+
+## What yokai does on its own crashes
+
+On signal-exit (SIGINT, SIGTERM), yokai unconditionally:
+
+- Sends `?1049l` (exit alt-screen).
+- Sends `DISABLE_MOUSE_TRACKING`.
+- Restores the cursor.
+
+This runs even if the `altScreenActive` flag is stale, because terminal state can drift and a leaked alt-screen leaves the user's terminal unusable. The codes are no-ops when the terminal is already in the correct state, so the unconditional teardown is safe.
+
+This does not run on uncaught exceptions — install your own handler (above) to call `instance.unmount()`.
+
+## Logging from inside the app
+
+Stdout belongs to the renderer. Anything you write to stdout collides with the frame buffer and gets overwritten. Two options:
+
+```ts
+// Option 1: stderr
+process.stderr.write(`[debug] ${value}\n`)
+
+// Option 2: gated debug logger from @yokai/shared
+import { logForDebugging } from '@yokai/shared'
+logForDebugging('selected=' + selected, { level: 'debug' })
+```
+
+`logForDebugging` is a no-op unless `DEBUG=1` / `DEBUG=true` / `--debug` is set. See [debugging](./debugging.md).
+
+In a separate shell, tail the stderr stream:
+
+```bash
+DEBUG=1 node app.js 2> /tmp/yokai.log
+tail -f /tmp/yokai.log
+```
+
+## Shipping checklist
+
+- [ ] Error boundaries placed at panel granularity, not leaf or root.
+- [ ] All `useEffect` async work has `.catch` routing to state.
+- [ ] `uncaughtException` and `unhandledRejection` handlers installed in the entry point.
+- [ ] Fatal handler calls `instance.unmount()` before `process.exit`.
+- [ ] CLI entry catches `waitUntilExit()` rejection and exits non-zero.
+- [ ] Logging goes to stderr or `logForDebugging`, never stdout.
+- [ ] `useApp().exit(error)` used to surface app-level failures with non-zero exit codes.
+- [ ] `createRoot()` call wrapped in try/catch for mount-time failures.
+
+## See also
+
+- [components/error-overview](../components/error-overview.md)
+- [hooks/use-app](../hooks/use-app.md)
+- [guides/debugging](./debugging.md)
+- [concepts/rendering](../concepts/rendering.md)
+- [troubleshooting](../troubleshooting.md)

--- a/docs/guides/streaming-content.md
+++ b/docs/guides/streaming-content.md
@@ -1,0 +1,155 @@
+# Streaming content
+
+How to render incremental content — LLM token streams, log tails, build output — without burning CPU or losing frames.
+
+The yokai renderer diffs the screen cell-by-cell and emits only the ANSI patches needed to bring the terminal in sync with the new frame. Appending one character to a streamed response touches O(changed cells), not O(rows × cols). This makes the obvious approach — set state on every chunk, let React re-render, let yokai diff — viable up to surprisingly high update rates.
+
+This guide covers when that obvious approach is right, when to throttle, and the patterns that fall apart under streaming load.
+
+## Per-cell diffing pays off
+
+Do not pre-debounce or coalesce text content unless profiling proves you need to. The renderer will collapse rapid setState calls into a single frame anyway (yokai schedules at most one frame per tick), and the diff between adjacent frames is cheap.
+
+```tsx
+function StreamingResponse({ stream }: { stream: AsyncIterable<string> }) {
+  const [text, setText] = useState('')
+  useEffect(() => {
+    void (async () => {
+      for await (const chunk of stream) {
+        setText(prev => prev + chunk)
+      }
+    })()
+  }, [stream])
+  return <Text>{text}</Text>
+}
+```
+
+This works for typical LLM token rates (10 - 100 tokens/sec). Each setState commits, the reconciler walks the tree, the renderer diffs a few changed cells, stdout receives a short ANSI patch.
+
+## Sticky scroll
+
+For log tails, chat UIs, build output — anywhere new lines arrive at the bottom and the user usually wants to follow — wrap the stream in `<ScrollBox stickyScroll>`.
+
+```tsx
+import { ScrollBox } from '@yokai/renderer'
+
+<ScrollBox stickyScroll height={20}>
+  {lines.map((line, i) => <Text key={i}>{line}</Text>)}
+</ScrollBox>
+```
+
+Behavior:
+
+| User action | Sticky behavior |
+|-------------|-----------------|
+| At bottom, content arrives | Auto-scrolls to keep new content visible |
+| Manually scrolls up | Sticky pauses; new content does not steal viewport |
+| Scrolls back to bottom | Sticky resumes |
+
+See [`<ScrollBox>`](../components/scrollbox.md) and [patterns/log-viewer](../patterns/log-viewer.md).
+
+## Accumulator state, not component-per-token
+
+Append to one state slot. Do not mount a component per token.
+
+```tsx
+// Good — one state slot, append on each chunk
+const [text, setText] = useState('')
+setText(prev => prev + chunk)
+return <Text>{text}</Text>
+
+// Bad — mounts a new component per chunk
+const [tokens, setTokens] = useState<string[]>([])
+setTokens(prev => [...prev, chunk])
+return <>{tokens.map((t, i) => <Text key={i}>{t}</Text>)}</>
+```
+
+Mount cost is per-React-commit and walks the reconciler / Yoga tree. Per-cell diff cost is far lower. The component-per-token form also bloats the React tree, and reconciliation eventually dominates frame time.
+
+## Throttling when stream rate exceeds frame rate
+
+When a stream produces faster than the renderer can flush (rare for text, common for raw byte streams or noisy log sources), batch with a queue and flush on an animation frame.
+
+```tsx
+import { useAnimationFrame } from '@yokai/renderer'
+
+function ThrottledStream({ stream }: { stream: AsyncIterable<string> }) {
+  const [text, setText] = useState('')
+  const buffer = useRef('')
+
+  useEffect(() => {
+    void (async () => {
+      for await (const chunk of stream) {
+        buffer.current += chunk
+      }
+    })()
+  }, [stream])
+
+  useAnimationFrame(() => {
+    if (buffer.current.length === 0) return
+    const drained = buffer.current
+    buffer.current = ''
+    setText(prev => prev + drained)
+  })
+
+  return <Text>{text}</Text>
+}
+```
+
+This caps the React commit rate at the frame rate while keeping the visible text fully up to date.
+
+## Backpressure
+
+If rendering still cannot keep up — say the terminal itself is slow over SSH — yokai's renderer is throttled internally to avoid frame stacking. Frames produced faster than they can be written are coalesced; the latest committed React state is what reaches the screen on the next available tick. You do not need to drop frames manually.
+
+What you do need to manage: the stream source. If your accumulator grows without bound, memory is the problem, not framerate. See windowing below.
+
+## Search highlight on streamed content
+
+[`useSearchHighlight`](../hooks/use-search-highlight.md) scans every committed frame. Matches in newly-arrived content highlight on the first frame they appear. No special wiring needed — the scan runs against the post-layout cell grid, so streamed text is treated identically to static text.
+
+```tsx
+const { setQuery } = useSearchHighlight()
+// later
+setQuery('error')
+// every subsequent frame highlights 'error' wherever it appears,
+// including in streaming content
+```
+
+## Anti-patterns
+
+### Render-per-token in a deeply-nested tree
+
+Each setState walks the React tree from the source component. If the streaming `<Text>` lives 12 components deep, every chunk pays the full reconciliation cost on the path down. Hoist the streaming text up, or memoize the static parents with `React.memo`.
+
+### Unbounded state
+
+A 4-hour log tail in a single string is a memory leak. Cap the buffer:
+
+```tsx
+const MAX_LINES = 5000
+setLines(prev => {
+  const next = [...prev, ...newLines]
+  return next.length > MAX_LINES ? next.slice(-MAX_LINES) : next
+})
+```
+
+For chat-style UIs, window the visible range and load older history on scroll.
+
+### Pre-batching when you do not need to
+
+`setTimeout(() => setText(...), 16)` adds latency without buying anything — the renderer already coalesces. Batch only when profiling shows commits are the bottleneck.
+
+### Mounting a `<ScrollBox>` per message
+
+In a chat UI, one outer `<ScrollBox>` containing N message components. Not N ScrollBoxes. ScrollBox owns viewport-culling state; nesting them defeats the culling.
+
+## See also
+
+- [components/scrollbox](../components/scrollbox.md)
+- [concepts/rendering](../concepts/rendering.md)
+- [concepts/performance](../concepts/performance.md)
+- [hooks/use-animation-frame](../hooks/use-animation-frame.md)
+- [hooks/use-search-highlight](../hooks/use-search-highlight.md)
+- [patterns/log-viewer](../patterns/log-viewer.md)
+- [patterns/chat-ui](../patterns/chat-ui.md)

--- a/docs/internals/architecture.md
+++ b/docs/internals/architecture.md
@@ -1,0 +1,51 @@
+# Architecture
+
+Module-level layout of the yokai monorepo and the renderer's internal subsystems.
+
+## Responsibility
+
+Defines what each package owns, the dependency direction between them, and the named subsystems inside `@yokai/renderer`. Does NOT cover individual algorithms — see the per-subsystem pages.
+
+## Packages
+
+| Package | Owns |
+|---|---|
+| `@yokai/shared` | Pure-TS Yoga port (`shared/src/yoga-layout/`), logging (`logger.ts`, `log.ts`, `debug.ts`), env helpers (`env.ts`, `envUtils.ts`), `stringWidth`, `sliceAnsi`, grapheme segmenter, `intl`, `semver`. No React, no terminal I/O, no DOM. |
+| `@yokai/renderer` | React reconciler, virtual DOM, layout glue, render pipeline, terminal I/O, event system, components, hooks. |
+
+Dependency direction is one-way: `renderer → shared`. `shared` never imports from `renderer`. The shared package is a sibling, not a sub-tree.
+
+## Build order
+
+Shared first, then renderer. `pnpm build` at the workspace root resolves the order via the workspace dependency graph; running renderer's `tsup` against unbuilt shared types fails. CI (`.github/workflows/ci.yml`) preserves this order.
+
+## Renderer subsystems
+
+| Subsystem | File(s) | Purpose |
+|---|---|---|
+| Reconciler | `reconciler.ts` | React 19 host config — host instance lifecycle, commit phase hooks, event-priority resolution. |
+| DOM | `dom.ts` | Virtual element/text node graph, dirty propagation, attribute/style mutation. |
+| Yoga (in shared) | `shared/src/yoga-layout/index.ts` | Flexbox layout. Exposed to renderer via `layout/engine.ts`. |
+| Render-to-output | `render-node-to-output.ts` | DFS traversal, paint order, blit fast path, ScrollBox drain, viewport culling. |
+| Output | `output.ts` | Operation queue (write/clear/blit/clip/shift), two-pass commit, absolute-clear suppression. |
+| Screen | `screen.ts` | Packed cell grid (`Int32Array` / `BigInt64Array`), `CharPool`, `StylePool`, `HyperlinkPool`, `noSelect` and `softWrap` bitmaps. |
+| Log-update | `log-update.ts` | Frame-to-frame diff, ANSI patch generation, DECSTBM scroll hint, full-reset detection. |
+| Frame | `frame.ts` | Frame envelope (screen + viewport + cursor + scrollHint), `shouldClearScreen`, `Patch` types. |
+| Renderer | `renderer.ts` | One-shot factory that wires Output to renderNodeToOutput; produces a `Frame` from the live DOM. |
+| Focus | `focus.ts` | `FocusManager`, focus stack, per-node + global subscribers. See [focus-manager](./focus-manager.md). |
+| Hit-test | `hit-test.ts` | Cell → DOM-node lookup for mouse routing. |
+| Dispatch | `events/dispatcher.ts`, `events/*-event.ts` | Capture/bubble event dispatch, gesture capture, React update-priority bridge. |
+| Drag-registry | `drag-registry.ts` | Module-scope drop-target registry. See [drag-registry](./drag-registry.md). |
+| Selection | `selection.ts` | Text selection state machine (anchor/focus/virtual rows), drag-to-scroll capture, overlay paint. See [selection-state-machine](./selection-state-machine.md). |
+| Ink (entry) | `ink.tsx` | `Ink` class — frame lifecycle, alt-screen, signal handling, selection coordination, throttling. |
+
+## Public surface
+
+`packages/renderer/src/index.ts` is the only public entry point declared in `packages/renderer/package.json:14-19`. Anything not re-exported there is internal and unstable.
+
+## Source
+
+- `CLAUDE.md` (top-level) — load-bearing invariants and rationale.
+- `packages/renderer/src/index.ts`
+- `packages/renderer/package.json`
+- `packages/shared/src/index.ts`

--- a/docs/internals/drag-registry.md
+++ b/docs/internals/drag-registry.md
@@ -1,0 +1,125 @@
+# Drag Registry
+
+Module-scope coordinator for `<Draggable>` → `<DropTarget>` interactions, with one active drag at a time.
+
+## Responsibility
+
+Owns the registered drop-target set, the active-drag flag, the per-tick enter / over / leave dispatch against the cursor, and the topmost-wins drop selection. Does NOT own gesture capture (that's `App.activeGesture` in `ink.tsx`), the dragged data's payload semantics, or visual drag chrome.
+
+## Why module-scope
+
+The draggable / drop-target relationship is global to the App. A user dragging from container A can drop on a target in container B with no DOM-tree containment relating them. React context is therefore the wrong tool — there's no shared ancestor that captures both. The registry is a module-level `Map<symbol, DropTargetEntry>` plus an `activeDrag: { data } | null` slot.
+
+Gestures are exclusive at the App level (only one mouse, one pointer), so "one active drag at a time" is a hard limit, not a simplification.
+
+## Key types
+
+```ts
+type DropInfo = {
+  data: unknown
+  cursor: { col: number; row: number }   // screen-cell, 0-indexed
+  local:  { col: number; row: number }   // cursor minus target top-left
+}
+
+type DropTargetCallbacks = {
+  accept?:       (data: unknown) => boolean
+  onDragEnter?:  (info: DropInfo) => void
+  onDragOver?:   (info: DropInfo) => void
+  onDragLeave?:  () => void
+  onDrop?:       (info: DropInfo) => void
+}
+
+type DropTargetEntry = {
+  getNode:      () => DOMElement | null      // lazy ref read
+  getCallbacks: () => DropTargetCallbacks    // fresh-per-tick handlers
+}
+```
+
+The two getters are the load-bearing detail. `getNode` is lazy because refs are populated post-mount (registration runs in `useEffect`); it returns `null` during transient detach (reorder), and the registry skips null entries. `getCallbacks` returns the LATEST handler bundle on each tick — the registered entry holds a stable identity for the registration's lifetime, but the values it returns track the component's most recent props.
+
+## Module state
+
+| Variable | Source | Purpose |
+|---|---|---|
+| `targets: Map<symbol, DropTargetEntry>` | `drag-registry.ts:60` | All registered drop targets, keyed by an opaque symbol. |
+| `activeDrag: { data } | null` | `:61` | The currently-dragged payload, or null. |
+| `containingPrev: Set<symbol>` | `:62` | Targets the cursor was inside on the previous tick — used to compute leave deltas. |
+
+## Public API
+
+| Function | Source | Purpose |
+|---|---|---|
+| `registerDropTarget(entry)` | `:66` | Returns an opaque `symbol` id. Called from `<DropTarget>` mount effect. |
+| `unregisterDropTarget(id)` | `:72` | Cleanup. Removes from `targets` AND `containingPrev`. |
+| `startDrag(data)` | `:89` | Begin tracking. Called by `<Draggable>` on the FIRST motion of a press (not at press time — a press without motion does not engage targets). |
+| `isDragActive()` | `:95` | True iff `activeDrag !== null`. |
+| `tickDrag(col, row)` | `:107` | Per-motion. Walks targets, fires enter / over / leave deltas. |
+| `dispatchDrop(col, row)` | `:149` | At release. Fires `onDrop` on the topmost containing target that accepts. Returns true iff any target received the drop. |
+| `endDrag()` | `:190` | Idempotent end. Fires `onDragLeave` on remaining containing targets. |
+| `_resetDragRegistryForTesting()` | `:79` | Test-only state reset. Not public API. |
+
+## Lifecycle
+
+```
+press                          (no registry call — gesture not yet a drag)
+  │
+  │ first motion
+  v
+startDrag(data)                 activeDrag = { data }, containingPrev = ∅
+  │
+  │ each subsequent motion
+  v
+tickDrag(col, row)              for each target: in-rect + accept(data)?
+                                  → enter (if not in prev), over
+                                for each in prev not in now: leave
+                                containingPrev = containingNow
+  │
+  │ release
+  v
+dispatchDrop(col, row)          collect candidates → sort by (z, depth) DESC
+                                → fire onDrop on top.
+endDrag()                       fire onDragLeave on stragglers, activeDrag = null
+```
+
+`startDrag` MUST happen before any `tickDrag`. `tickDrag` and `dispatchDrop` early-return when `!activeDrag`. `endDrag` is idempotent.
+
+## Topmost-wins drop dispatch
+
+`dispatchDrop` (`:149`) collects all in-rect, accepting candidates, then sorts by `(z DESC, depth DESC)`:
+
+- `z = node.style.position === 'absolute' ? (node.style.zIndex ?? 0) : 0` — matches the renderer's `effectiveZ` in `render-node-to-output.ts`.
+- `depth = nodeDepth(node)` — walks `parentNode` to root.
+
+Highest z wins; on tie, deeper-in-tree wins. Mirrors the renderer's paint order so the user's eye and the drop target see the same winner.
+
+## Snapshot iteration
+
+`tickDrag` iterates `targets` (a Map) directly — Map's iterator handles concurrent deletion in modern JS. The leave loop iterates `containingPrev` (a Set) which is then cleared and repopulated. A target unsubscribing via `onDragLeave` removes itself from `targets` mid-iteration; the Map iterator skips it cleanly.
+
+`endDrag` fires `onDragLeave` on remaining `containingPrev` entries by reading callbacks fresh from `targets.get(id)?.getCallbacks()` — handles the case where the target unmounted between the last tick and the release.
+
+## Hit testing
+
+Per-target rect lookup: `nodeCache.get(node)` reads the rect cached on the previous frame. The cursor-in-rect check is `col >= rect.x && col < rect.x + rect.width` (and same for row). `nodeCache` is populated by the render pipeline; `<DropTarget>` re-renders on data change keep the cache fresh. A target whose node has not yet been rendered (no cache entry) is silently skipped — first frame after mount may miss enter events; `<DropTarget>` accepts this rather than synchronously laying out.
+
+## Invariants
+
+- Only one drag active at a time. Calling `startDrag` while another is active overwrites `activeDrag.data` and clears `containingPrev` — caller is responsible for not doing this. `<Draggable>` enforces it via `App.activeGesture` exclusivity at the App level.
+- `containingPrev` must mirror the most recent `tickDrag`'s "containing now" set. Skipping `containingPrev` updates produces stuck-hover state.
+- Callbacks read via `entry.getCallbacks()` MUST be re-read each tick. Capturing the bundle once at registration freezes handlers — the subscribing component's re-renders are then ignored.
+- `getNode()` may return null. The registry MUST handle null gracefully (skip the entry); throwing on null leaks dead targets across reorder cycles.
+
+## Common pitfalls
+
+- Calling `startDrag` on press instead of first-motion. A press-then-release with no motion will then fire `endDrag`'s leave callbacks against any target the cursor happens to be over, even though the user never dragged anything.
+- Forgetting to call `endDrag` in error / cancel paths. `activeDrag` stays set; the next press's first motion enters a stuck state.
+- Reading `nodeCache.get(node)` when node is mid-mount. Returns `undefined` — the registry's null-check covers it but custom code might not.
+- Computing z-index without checking `position === 'absolute'`. The `Styles.zIndex` field is silently ignored on non-absolute nodes (see [render-pipeline](./render-pipeline.md)) — `dispatchDrop` mirrors that exactly.
+
+## Source
+
+- Primary: `packages/renderer/src/drag-registry.ts`
+- Tests: `packages/renderer/src/drag-registry.test.ts`
+- Components: `packages/renderer/src/components/Draggable.tsx`, `packages/renderer/src/components/DropTarget.tsx`
+- Rect source: `packages/renderer/src/node-cache.ts` (`nodeCache`)
+- Gesture exclusivity: `packages/renderer/src/ink.tsx` (`App.activeGesture`, `App.handleMouseEvent`)

--- a/docs/internals/focus-manager.md
+++ b/docs/internals/focus-manager.md
@@ -1,0 +1,121 @@
+# Focus Manager
+
+DOM-like focus coordinator: tracks `activeElement`, a focus stack for restoration, and per-node + global subscribers.
+
+## Responsibility
+
+Owns focus state (`activeElement`, focus stack), tab-order traversal (`focusNext` / `focusPrevious`), restoration on node removal, click-to-focus dispatch, autoFocus handling, and listener notification. Does NOT own the focus visual (`<FocusRing>` is a consumer), keyboard event routing (the dispatcher routes; this just decides what `activeElement` is), or per-`useFocus` React state (hooks subscribe and re-render themselves).
+
+## Why on the root DOM element
+
+`FocusManager` is stored on the `ink-root` `DOMElement`. Any node reaches it by walking `parentNode` to the root — analogous to browser `node.ownerDocument`. The two helpers:
+
+```
+getRootNode(node)      → walks parentNode until focusManager is set
+getFocusManager(node)  → getRootNode(node).focusManager!
+```
+
+Source: `focus.ts:239-254`. This avoids passing the manager through React context (which would force re-renders on focus change for every consumer of the context).
+
+## Key types
+
+| Symbol | Source | Purpose |
+|---|---|---|
+| `FocusManager` | `focus.ts:15` | Class. One instance per ink-root. |
+| `activeElement: DOMElement | null` | `:16` | Currently focused node, or null. |
+| `focusStack: DOMElement[]` | `:19` | LRU history of previously-focused nodes for restoration. Bounded at `MAX_FOCUS_STACK = 32`. |
+| `nodeListeners: Map<DOMElement, Set<Listener>>` | `:26` | Per-node focus subscribers (used by `useFocus`). |
+| `globalListeners: Set<() => void>` | `:31` | Any-focus-change subscribers (used by `useFocusManager`). |
+| `MAX_FOCUS_STACK = 32` | `:4` | Stack depth cap. Tab cycling dedupes (push removes prior occurrence first), so the cap protects against pathological churn rather than normal cycling. |
+
+## Public API
+
+| Method | Source | Purpose |
+|---|---|---|
+| `focus(node)` | `:87` | Make `node` the active element. No-op if already active or `enabled === false`. Pushes previous active onto stack (deduped). Dispatches `blur` on previous, `focus` on new, then notifies node listeners (previous → false, new → true) then global. |
+| `blur()` | `:110` | Drop focus to null. Dispatches `blur`, notifies. |
+| `focusNext(root)` | `:177` | Move to next tabbable in document order. |
+| `focusPrevious(root)` | `:181` | Move to previous tabbable. |
+| `handleNodeRemoved(node, root)` | `:125` | React removal hook — removes node + descendants from stack, blurs if active, restores most recent still-mounted from stack. |
+| `handleAutoFocus(node)` | `:159` | Called by reconciler `commitMount` when `autoFocus` was set. Just calls `focus(node)`. |
+| `handleClickFocus(node)` | `:163` | Click hit on a node — focuses it iff `attributes.tabIndex` is a number. |
+| `enable()` / `disable()` | `:169-175` | Suspend focus changes (used during certain modal flows). `focus()` and `moveFocus()` early-return when disabled. `blur()` is NOT gated. |
+| `subscribeToFocus(node, listener)` | `:47` | Per-node subscription. Listener fires `(focused: boolean)`. Returns unsubscribe. Auto-cleans empty Sets. |
+| `subscribe(listener)` | `:67` | Global subscription. Listener fires on any focus change. Returns unsubscribe. |
+
+Module-level helpers: `getRootNode(node)` (`:239`), `getFocusManager(node)` (`:252`).
+
+## Lifecycle
+
+### focus(node)
+
+```
+focus(node):
+  if node === activeElement OR not enabled: return
+  if previous = activeElement:
+    dedup previous in focusStack (splice if present)
+    push previous
+    truncate stack from front if length > MAX_FOCUS_STACK
+    dispatchFocusEvent(previous, FocusEvent('blur', node))
+  activeElement = node
+  dispatchFocusEvent(node, FocusEvent('focus', previous))
+  if previous: notifyNode(previous, false)
+  notifyNode(node, true)
+  notifyGlobal()
+```
+
+Notification order matches browser: focus event handler runs BEFORE hook subscribers see the change, so handlers observing `focusManager.activeElement` see the new element.
+
+### handleNodeRemoved
+
+`focus.ts:125`. Called by `reconciler.removeChild` / `removeChildFromContainer`.
+
+1. Filter `focusStack`: drop the removed node and any node no longer in the tree (covers descendant unmounts that didn't get individual remove calls).
+2. If `activeElement` is null, or in the tree but not the removed node — no-op.
+3. Otherwise: blur active, drop its node listeners (the React component is gone; lingering listeners would prevent GC of the freed yoga subtree).
+4. Pop the focus stack until a still-in-tree candidate is found, focus it. If stack exhausts, fire `notifyGlobal` so subscribers see "no focus."
+
+### moveFocus(direction, root)
+
+`focus.ts:185`. Walks the tree via `collectTabbable(root)` (`:207`) which DFS-collects every node where `attributes.tabIndex >= 0`. Wraps cyclically. `tabIndex === -1` is programmatic-focus-only — focusable via `focus()` but not via tab cycling.
+
+## Listener notification
+
+Both `nodeListeners` and `globalListeners` iterate via `[...set]` snapshot copy (`focus.ts:80, 84`). A listener that unsubscribes during dispatch doesn't perturb the iteration. Modern JS Set iterators tolerate concurrent deletion, but the explicit copy is unambiguous and cheap (subscriber count is bounded by focusable element count).
+
+`notifyNode(node, focused)` looks up the per-node Set; if the node has no listeners (the common case for non-focused nodes), early-returns.
+
+## tabIndex semantics
+
+| Value | Tab-cycle | Programmatic `focus()` | Click-focus via `handleClickFocus` |
+|---|---|---|---|
+| `>= 0` | Yes (in document order) | Yes | Yes |
+| `-1` | No | Yes | Yes (any number triggers focus) |
+| undefined | No | Yes (any node can be focused) | No (only typed numbers focus) |
+
+`collectTabbable` requires `typeof tabIndex === 'number' && tabIndex >= 0` (`focus.ts:215`). `handleClickFocus` requires `typeof tabIndex === 'number'` only (`:165`) — `-1` IS click-focusable.
+
+## Invariants
+
+- `FocusManager` is owned by the root `DOMElement` only. `getRootNode` throws if called on a node not in a tree with a `focusManager`.
+- `focusStack` MUST dedup before pushing. Tab cycling without dedup would grow the stack unboundedly; the `MAX_FOCUS_STACK` truncation would then start dropping legitimate restoration targets.
+- Listener iteration MUST snapshot. Listeners that unsubscribe-during-dispatch are common (a `useEffect` cleanup running because focus moved away from its component).
+- `handleNodeRemoved` MUST drop `nodeListeners.get(removed)`. The owning React component is gone; a stale listener still referencing the freed yoga subtree blocks GC of the entire subtree.
+- Notification order: focus events first, then per-node listeners, then global. Handlers that read `activeElement` see the new state.
+
+## Common pitfalls
+
+- Storing `activeElement` in React state. Forces re-render of every consumer on every focus change, defeats the per-node listener split.
+- Calling `focus(node)` from inside a per-node listener for a different node. The listener fires during `focus()`'s notification phase; reentering `focus()` mid-notification works but reorders the stack confusingly. Defer with `queueMicrotask` if you need it.
+- Forgetting to set `tabIndex` on a node you want tab-cycle reachable. `useFocus` handles this; manual `focus()` calls don't require it but tab cycling silently skips the node.
+- Calling `getFocusManager(node)` on a node before it's been appended to the tree. Throws — check `node.parentNode` chain first or use `commitMount` timing.
+- Reading `focusStack` from outside `focus.ts`. Private. Iterate `nodeListeners` keys or subscribe globally if you need to observe focusable set membership.
+
+## Source
+
+- Primary: `packages/renderer/src/focus.ts`
+- Tests: `packages/renderer/src/focus.test.ts` (subscribeToFocus, global subscribe)
+- Hooks: `packages/renderer/src/hooks/use-focus.ts`, `packages/renderer/src/hooks/use-focus-manager.ts`
+- Reconciler integration: `packages/renderer/src/reconciler.ts:356` (`commitMount` → `handleAutoFocus`), `:378, :418` (removal → `handleNodeRemoved`)
+- Click integration: `packages/renderer/src/events/dispatcher.ts` (calls `handleClickFocus` on hit)
+- Focus event type: `packages/renderer/src/events/focus-event.ts`

--- a/docs/internals/reconciler.md
+++ b/docs/internals/reconciler.md
@@ -1,0 +1,69 @@
+# Reconciler
+
+React 19 host config that translates fiber commits into virtual-DOM mutations and schedules frames.
+
+## Responsibility
+
+Owns the `react-reconciler` host config: instance creation, child mounts, prop diffing on update, removal + cleanup, focus-on-mount, and update-priority bridging into the event dispatcher. Does NOT own layout, painting, or terminal I/O — those are downstream of `resetAfterCommit`'s call to `rootNode.onComputeLayout()` and `onRender()`.
+
+## Key types
+
+| Symbol | Source | Purpose |
+|---|---|---|
+| `reconciler` | `reconciler.ts:198` | The configured `react-reconciler` instance. Default export. |
+| `dispatcher` | `reconciler.ts:161` | The renderer-wide `Dispatcher`. Owned here so `setCurrentUpdatePriority` / `resolveUpdatePriority` can read/write it without import cycles. |
+| `applyProp(node, key, value)` | `reconciler.ts:95` | Routes a prop to `setStyle`, `textStyles` field, `setEventHandler`, or `setAttribute` based on key. |
+| `cleanupYogaNode(node)` | `reconciler.ts:69` | `unsetMeasureFunc` → `clearYogaNodeReferences` (recursive null) → `freeRecursive`. The reference-clearing pass is critical (see invariants). |
+| `getOwnerChain(fiber)` | `reconciler.ts:132` | Walks `_debugOwner ?? return` up to 50 frames; populated onto `node.debugOwnerChain` when `CLAUDE_CODE_DEBUG_REPAINTS` is set. |
+| `HostContext` | `reconciler.ts:84` | `{ isInsideText: boolean }` — promotes `ink-text` to `ink-virtual-text` when nested. |
+
+## Lifecycle / pipeline
+
+Per commit:
+
+1. `prepareForCommit` — records `_prepareAt` for instrumentation; returns `null`.
+2. React calls `createInstance` / `createTextInstance` / `appendInitialChild` / `appendChild` / `insertBefore` / `commitUpdate` / `commitTextUpdate` / `removeChild` / `removeChildFromContainer` as it walks the work-in-progress tree.
+   - `createInstance` (`reconciler.ts:298`): asserts no `<Box>` inside `<Text>`, promotes `ink-text` → `ink-virtual-text` inside text context, calls `createNode`, then iterates props through `applyProp`. Records owner chain when debug-repaints enabled.
+   - `createTextInstance` (`reconciler.ts:325`): asserts inside text context, calls `createTextNode`.
+   - `commitUpdate` (`reconciler.ts:381`): React 19 receives `(node, type, oldProps, newProps)` directly — no updatePayload. Diffs both `props` and `style` shallowly via local `diff()` helper. Style → `setStyle` (DOM mutation) and `applyStyles(yogaNode, …)` (yoga mutation) when style diff is non-empty. `textStyles` → `setTextStyles`. Event handlers → `setEventHandler` (does not mark dirty — handler identity changes shouldn't defeat the blit fast path; see `dom.ts:48-52`). Other keys → `setAttribute`.
+   - `removeChild` / `removeChildFromContainer` (`reconciler.ts:413`, `:375`): `removeChildNode` → `cleanupYogaNode` → `focusManager.handleNodeRemoved`.
+3. `finalizeInitialChildren` returns `props.autoFocus === true` to request a `commitMount` callback (`reconciler.ts:353`).
+4. `commitMount` (`reconciler.ts:356`): calls `getFocusManager(node).handleAutoFocus(node)`. Fires once per node when first mounted with `autoFocus`.
+5. `resetAfterCommit` (`reconciler.ts:221`):
+   - Calls `rootNode.onComputeLayout()` — yoga `calculateLayout` from `ink.tsx`.
+   - In `NODE_ENV === 'test'`, calls `rootNode.onImmediateRender()` and returns.
+   - Otherwise calls `rootNode.onRender()` — the throttled `scheduleRender` from `ink.tsx`.
+   - Records phase timings into `_lastCommitMs` / `_lastYogaMs`.
+
+`hideInstance` / `unhideInstance` (`reconciler.ts:340-349`) toggle `node.isHidden` and the yoga node's `Display` between `None` and `Flex`, then `markDirty(node)`. Used by React's offscreen / Suspense.
+
+## Update-priority bridge
+
+The reconciler's discrete-event channel is wired to the dispatcher at module scope:
+
+```
+dispatcher.discreteUpdates = reconciler.discreteUpdates.bind(reconciler)  // reconciler.ts:460
+```
+
+`getCurrentUpdatePriority` / `setCurrentUpdatePriority` / `resolveUpdatePriority` proxy to `dispatcher.currentUpdatePriority` and `dispatcher.resolveEventPriority()`. `resolveEventType` / `resolveEventTimeStamp` read `dispatcher.currentEvent`. This breaks an otherwise-circular import (`dispatcher.ts` doesn't import `reconciler.ts`).
+
+## Invariants
+
+- `cleanupYogaNode` MUST clear all subtree `yogaNode` references BEFORE calling `freeRecursive()`. If freed memory is read later (concurrent measure), the WASM-style accessor can crash. The pure-TS port doesn't crash on reads of freed objects, but the invariant is preserved for parity and to help GC.
+- Removal path runs `removeChildNode` → `cleanupYogaNode` → focus restoration in that order. Reordering leaves a freed yoga node referenced from the focus manager's restoration path.
+- `_eventHandlers` is stored separately from `attributes` (`dom.ts:50-52`) so handler-identity churn (a new arrow function each render) does not call `markDirty`. Defeating this would defeat the blit fast path on every event-handler-bearing node.
+- `commitUpdate`'s style diff calls `applyStyles(yogaNode, style, newProps.style)` only when the diff is non-empty AND `node.yogaNode` exists. Some node types (`ink-virtual-text`, `ink-link`, `ink-progress`) have no yoga node — see `dom.ts:112-113`.
+
+## Common pitfalls
+
+- Adding a new prop that should NOT trigger re-layout: route it through `_eventHandlers` or a dedicated field, not `setAttribute` — `setAttribute` calls `markDirty` (`dom.ts:242`).
+- Reading `node.yogaNode.getComputedX()` immediately after `commitUpdate` — yoga is not recomputed until `resetAfterCommit` calls `onComputeLayout`. Reads inside the commit phase return stale values.
+- Removing a node with focused descendants: `handleNodeRemoved` walks the focus stack to restore. If you bypass `removeChildFromContainer` / `removeChild`, focus is left dangling on a freed subtree.
+
+## Source
+
+- Primary: `packages/renderer/src/reconciler.ts`
+- DOM mutation: `packages/renderer/src/dom.ts` (`createNode`, `appendChildNode`, `insertBeforeNode`, `removeChildNode`, `setAttribute`, `setStyle`, `setTextStyles`, `markDirty`, `clearYogaNodeReferences`)
+- Style apply: `packages/renderer/src/styles.ts`
+- Event-handler key set: `packages/renderer/src/events/event-handlers.ts`
+- Focus integration: `packages/renderer/src/focus.ts` (`getFocusManager`, `getRootNode`, `handleAutoFocus`, `handleNodeRemoved`)

--- a/docs/internals/render-pipeline.md
+++ b/docs/internals/render-pipeline.md
@@ -1,0 +1,119 @@
+# Render Pipeline
+
+DFS traversal of the layouted DOM into a `Frame`, frame-to-frame diff, and ANSI patch emission.
+
+## Responsibility
+
+Owns the path from "yoga has computed layout" to "ANSI bytes are queued for stdout." This covers tree traversal, paint order, the blit fast path, the `Output` operation queue, the `Screen` cell grid, and the `LogUpdate` diff engine. Does NOT own layout (yoga), event dispatch, or the actual `stdout.write` (that's `ink.tsx` consuming the patch list).
+
+## Pipeline stages
+
+```
+DOM (post-layout)
+  → renderNodeToOutput()             render-node-to-output.ts
+      DFS, paint order, blit fast path, ScrollBox drain, viewport culling
+  → Output operation queue           output.ts
+      write / clear / blit / clip / shift / noSelect ops
+  → Output.get() → Screen            output.ts (two-pass commit), screen.ts
+      Pass 1: collect clears + damage
+      Pass 2: apply non-clear ops with absoluteClears suppression
+  → applySelectionOverlay()          selection.ts (mutates Screen post-render)
+  → LogUpdate.render(prev, next)     log-update.ts
+      Optional DECSTBM scroll hint fast path
+      diffEach over damage region
+      ANSI Patch[] emission
+  → Patch[] → ink.tsx → stdout
+```
+
+Front/back screen buffers are double-buffered. `Renderer` (`renderer.ts:31`) holds one `Output` instance across frames so its `charCache` (tokenize + grapheme cluster cache) persists.
+
+## Key types
+
+| Type | Source | Purpose |
+|---|---|---|
+| `Frame` | `frame.ts:12` | `{ screen, viewport, cursor, scrollHint?, scrollDrainPending? }`. The unit produced by the renderer and consumed by log-update. |
+| `Operation` | `output.ts:60` | Tagged union of `write` / `clip` / `unclip` / `blit` / `clear` / `noSelect` / `shift`. Queued in DFS order, drained in `Output.get()`. |
+| `Screen` | `screen.ts:347` | Packed cell grid: one `ArrayBuffer` viewed as `Int32Array` (per-word) + `BigInt64Array` (bulk fill). 2 Int32s per cell — `[charId, packed(styleId, hyperlinkId, width)]`. Holds `damage`, `noSelect`, `softWrap`. |
+| `CharPool` / `StylePool` / `HyperlinkPool` | `screen.ts:12,103,48` | Session-lived interning. `StylePool.intern` packs a "visible-on-space" bit into bit 0 of the returned ID so the renderer can skip invisible spaces with one bitmask check. |
+| `ScrollHint` | `render-node-to-output.ts:46` | `{ top, bottom, delta }` — emitted by ScrollBox when only its scrollTop changed; consumed by log-update for the DECSTBM fast path. |
+| `Patch` | `frame.ts:73` | The diff output unit: `stdout` / `clear` / `clearTerminal` / `cursorHide` / `cursorShow` / `cursorMove` / `cursorTo` / `carriageReturn` / `hyperlink` / `styleStr`. |
+
+## renderNodeToOutput (DFS)
+
+`render-node-to-output.ts:391`. Per node, in tree order:
+
+1. If `display: none`, clear cached rect and return (`:425`).
+2. Compute screen-space `(x, y, width, height)` from yoga + parent offset. Absolute nodes with negative `y` clamp to 0 (`:461`).
+3. Blit fast path (`:467`): if node is clean, has no `pendingScrollDelta`, has a cached rect that matches current bounds, AND `prevScreen` is available, copy cells from `prevScreen` and skip the subtree. The cached rect comes from `nodeCache.get(node)`; it was written on the previous frame's full-render pass.
+4. Otherwise full-render: paint borders / background → recurse into children via `renderChildren`.
+5. After render, write fresh `nodeCache` entry for this rect.
+
+### Tree-wide dirty-absolute collection
+
+At ink-root entry, `collectDirtyAbsoluteRects` walks the WHOLE tree once and stores rects of every dirty `position: absolute` node into `globalDirtyAbsoluteRects` (`:70`, populated `:418-421`). `renderChildren` reads this at every level. Tree-wide rather than per-level because `output.ts`'s `absoluteClears` apply globally — a clean child's blit cells could be zeroed by a moving absolute COUSIN's clear, in a different subtree from any per-level overlap check. This was the constrained-drag notch fix; see comments at `render-node-to-output.ts:57-70`.
+
+### Paint order
+
+`renderChildren` (`:1237`) sorts children by effective z-index when ANY absolute child has non-zero `zIndex`. Stable sort preserves DOM order for equal-z ties — the no-zIndex case stays bit-for-bit identical to pre-feature behavior. `effectiveZ(node)` (`:1230`) returns 0 for non-absolute nodes (the `Styles.zIndex` property is silently ignored on relative / in-flow nodes; a dev-mode warning fires from `setStyle` via `warn.ifZIndexWithoutAbsolute`).
+
+Stacking is flat per parent's render group, NOT CSS-stacking-context-global: a nested z-indexed absolute sorts among its siblings inside its parent, not against arbitrary cousins. Recursion gives this for free — each `renderChildren` sorts only direct children.
+
+### Per-cell suppression of stale absolute paint
+
+`output.ts` collects `absoluteClears` (rects from clear ops with `fromAbsolute: true`) in pass 1 (`:280`). In pass 2, every `blit` operation splits its rows into x-segments, skipping the segments covered by any absolute clear (`:371-389`). This stops moving absolutes from leaving stale paint trails when a clean sibling's blit partially overlaps the cleared old rect.
+
+## Output (operation queue)
+
+`output.ts`. Operations are pushed in DFS order during render. `Output.get()` runs the two-pass commit:
+
+- **Pass 1** (`:281`): walks `operations`, picks out `clear` ops, computes their clipped rect, unions into `screen.damage`, and pushes onto `absoluteClears` if `fromAbsolute`. Clears do NOT zero cells — the screen was already zeroed by `resetScreen`. They only widen the damage region so the diff checks those cells.
+- **Pass 2** (`:302`): walks `operations` again, processing `clip` / `unclip` / `blit` / `write` / `noSelect` / `shift`. `clip` intersects with the parent clip on the stack (`:316`); `blit` honors active clip + skips per-row segments covered by any active `absoluteClear` (`:354-389`).
+
+`absoluteRectsPrev` / `absoluteRectsCur` (`:54-55`) hold absolute rects across frames for the ScrollBox blit+shift third-pass repair. `prevFrameContaminated` (consumed in `renderer.ts:113`) disables blit when the previous screen was post-mutated (selection overlay, alt-screen reset, force redraw, absolute removal) — blits would copy stale cells.
+
+## Screen (cell grid)
+
+`screen.ts`. Packed Int32Array layout: word0 = `charId`, word1 = `styleId[31:17] | hyperlinkId[16:2] | width[1:0]`. Two views over one `ArrayBuffer`: `Int32Array cells` for per-word access, `BigInt64Array cells64` for bulk fill (`createScreen` at `:432`). Unwritten cells are exactly zero in both words, indistinguishable from explicitly-cleared cells — intentional, so `diffEach` compares raw integers without normalization.
+
+`noSelect: Uint8Array` (1 byte per cell) marks gutters that should be excluded from text selection. `softWrap: Int32Array` (1 entry per row) encodes word-wrap continuation: `softWrap[r] = N > 0` means row r is a continuation of row r-1 and row r-1's content ends at absolute column N. The encoding is chosen so `shiftRows` preserves continuation semantics across scrolls (`:386-394`).
+
+## LogUpdate (diff)
+
+`log-update.ts`. `render(prev, next, altScreen, decstbmSafe)` returns a `Diff = Patch[]`.
+
+1. **Resize / shrink-from-scrollback short-circuits** (`:133-205`): if viewport shrunk, content shrunk from above-viewport into viewport, or scrollback rows changed — emit `fullResetSequence_CAUSES_FLICKER` (the function name encodes the consequence).
+2. **DECSTBM scroll hint** (`:156-172`): when `altScreen && next.scrollHint && decstbmSafe`, emit `setScrollRegion(top+1, bottom+1) + (csiScrollUp(delta) | csiScrollDown(-delta)) + RESET_SCROLL_REGION + CURSOR_HOME`. Mutates `prev.screen` via `shiftRows` so the diff loop below naturally finds only the scrolled-in rows. Skipped when `decstbmSafe === false` (no DEC 2026 / BSU/ESU available — would render an intermediate state).
+3. **Diff loop** (`:286`): `diffEach(prev.screen, next.screen, callback)` walks the damage region; per changed cell, the callback emits cursor moves, hyperlink transitions, style transitions (via `stylePool.transition(fromId, toId)` cached pre-serialized strings), and the cell text. Spacers (`SpacerTail`, `SpacerHead`) are skipped — the terminal advances 2 cols on the wide head. Empty cells with no removed content are skipped to avoid trailing-space wraps.
+4. **Cursor restore** (`:368-405`): alt-screen no-ops (next frame's CSI H anchors); main screen emits CR + LF rows to advance to `next.cursor.y` since cursor moves can't create lines.
+
+## prevFrameContaminated
+
+`renderer.ts:23-27`. Set true after:
+- Selection overlay mutated the returned screen buffer (`ink.tsx`, post-render).
+- `resetFramesForAltScreen()` replaced screens with blanks.
+- `forceRedraw()` reset to 0×0.
+- An absolute-positioned node was removed (consumed via `consumeAbsoluteRemovedFlag` at `renderer.ts:112`).
+
+When true, `prevScreen` is NOT passed to `renderNodeToOutput` — every node full-renders. This is the cost of the selection overlay mutating a buffer the next frame would otherwise blit from.
+
+## Invariants
+
+- `prevScreen` passed to `renderNodeToOutput` MUST be the front buffer from the prior frame, untouched by any post-render mutation. Violations corrupt blits silently.
+- `nodeCache.get(node)` returns the rect FROM THE PREVIOUS RENDER. A node renders, writes its cache, and on the NEXT frame the blit-fast-path checks current-bounds against this cached rect. Don't read it expecting current-frame bounds.
+- `globalDirtyAbsoluteRects` is reset at every ink-root entry (`render-node-to-output.ts:418`). It must be populated BEFORE any `renderChildren` call descends, otherwise per-level overlap checks miss cross-subtree contamination.
+- The `Output` two-pass commit MUST run pass 1 to completion before pass 2 starts. Interleaving causes blits to escape clears that hadn't been collected yet.
+- `Screen.cells` and `Screen.cells64` MUST be views over the same `ArrayBuffer`. Any reallocation in `resetScreen` must update both (`screen.ts:494-496`).
+
+## Common pitfalls
+
+- Mutating the screen buffer after `Renderer` returned the frame, without setting `prevFrameContaminated` for the next frame. Next frame blits from contaminated cells.
+- Adding a node-level cache or memo without invalidating it on `markDirty`. The renderer already gates on `node.dirty` for blit; a parallel cache must follow the same dirty signal or it'll go stale within one frame.
+- Calling `output.write` / `output.clear` outside the DFS pass. Operations after `Output.get()` is called are silently dropped; operations before the right `clip` / `unclip` boundary land in the wrong clip context.
+- Reading `cell.char` directly off the packed array — go through `cellAt(screen, x, y)` so the `CharPool.get(charId)` lookup happens.
+- Treating `softWrap[r]` as boolean. It's an Int32 with the content-end column encoded; `> 0` is the continuation predicate.
+
+## Source
+
+- Primary: `packages/renderer/src/render-node-to-output.ts`, `output.ts`, `screen.ts`, `log-update.ts`, `frame.ts`, `renderer.ts`
+- Tests: `packages/renderer/src/render-node-to-output.test.ts` (paint order, z-index, overlap)
+- Related: `packages/renderer/src/node-cache.ts` (`nodeCache`, `pendingClears`, `consumeAbsoluteRemovedFlag`), `packages/renderer/src/ink.tsx` (frame loop, selection overlay site)

--- a/docs/internals/selection-state-machine.md
+++ b/docs/internals/selection-state-machine.md
@@ -1,0 +1,142 @@
+# Selection State Machine
+
+Text-selection state for fullscreen mode — anchor / focus / virtual rows tracked outside React, with drag-to-scroll capture and post-render overlay paint.
+
+## Responsibility
+
+Owns selection state across mouse-down → drag → up, drag-to-scroll row capture, keyboard-scroll selection translation, copy-text extraction, and the per-frame overlay paint into the screen buffer. Does NOT own mouse-event routing (that's `App.handleMouseEvent` in `ink.tsx`), clipboard write (consumer responsibility — `useSelection().copy` returns the selected text; consumers write to the system clipboard themselves), or the visual selection style (themed via `StylePool.setSelectionBg`).
+
+## Why state lives outside React
+
+Selection state is mutated directly by mouse-event handlers and read by `applySelectionOverlay` after every render. Storing it in React state would (a) trigger a re-render per drag motion (60+/sec), and (b) lose state on any concurrent React update that re-mounts the owning component. The state object is created once on `Ink` construction and mutated in place; React subscribers (`useHasSelection`) are notified via a separate listener channel.
+
+## Key types
+
+```ts
+type SelectionState = {
+  anchor: Point | null            // mouse-down position
+  focus: Point | null             // current drag position; null = bare click
+  isDragging: boolean             // between mouse-down and mouse-up
+  anchorSpan: { lo, hi, kind: 'word' | 'line' } | null  // word/line extend mode
+  scrolledOffAbove: string[]      // captured rows above viewport (drag down)
+  scrolledOffBelow: string[]      // captured rows below viewport (drag up)
+  scrolledOffAboveSW: boolean[]   // soft-wrap bits, parallel to ↑
+  scrolledOffBelowSW: boolean[]
+  virtualAnchorRow?: number       // pre-clamp anchor row
+  virtualFocusRow?: number        // pre-clamp focus row
+  lastPressHadAlt: boolean        // SGR alt-modifier on press
+}
+```
+
+`Point = { col: number; row: number }`. Coordinates are screen-buffer cells, 0-indexed.
+
+## Public API
+
+| Function | Source | Purpose |
+|---|---|---|
+| `createSelectionState()` | `selection.ts:65` | Initial state. |
+| `startSelection(s, col, row)` | `:79` | Mouse-down. Sets `anchor`, leaves `focus = null` (so a bare click doesn't highlight). |
+| `updateSelection(s, col, row)` | `:96` | Mouse-move while dragging. First-motion-at-anchor is a no-op (filters mode-1002 jitter). |
+| `finishSelection(s)` | `:110` | Mouse-up. Keeps `anchor`/`focus` so highlight persists for copy. |
+| `clearSelection(s)` | `:116` | Esc / explicit clear. |
+| `selectWordAt(s, screen, col, row)` | `:230` | Double-click — expands to same-class char run. |
+| `selectLineAt(s, screen, row)` | `:351` | Triple-click — full row span. |
+| `extendSelection(s, screen, col, row)` | `:368` | Word/line drag-extend respecting `anchorSpan`. |
+| `moveFocus(s, col, row)` | `:410` | Keyboard nudge — clears `anchorSpan` and `virtualFocusRow`. |
+| `shiftSelection(s, dRow, minRow, maxRow, width)` | `:438` | Keyboard scroll — moves anchor + focus, virtual-row tracked. |
+| `shiftAnchor(s, dRow, minRow, maxRow)` | `:529` | Drag-to-scroll — moves only anchor (focus stays at mouse). |
+| `shiftSelectionForFollow(s, dRow, minRow, maxRow)` | `:576` | Sticky/auto-follow scroll — moves both ends, clears if both go above viewport. Returns `true` if cleared. |
+| `hasSelection(s)` | `:622` | `s.anchor && s.focus`. |
+| `selectionBounds(s)` | `:630` | Normalized `{ start, end }` with `start ≤ end`. |
+| `isCellSelected(s, col, row)` | `:644` | Per-cell hit test for overlay. |
+| `getSelectedText(s, screen)` | `:703` | Copy-text. Joins `scrolledOffAbove` + on-screen rows + `scrolledOffBelow`, respecting `softWrap` continuations. |
+| `captureScrolledRows(s, screen, firstRow, lastRow, side)` | `:743` | Capture rows about to scroll out, BEFORE `scrollBy` overwrites them. |
+| `applySelectionOverlay(screen, selection, stylePool)` | `:823` | Mutate cell styles in-place to paint the highlight. |
+
+## State transitions
+
+```
+                    ┌──────────────────────────────────┐
+                    │            (no selection)         │
+                    └──┬─────────────────────┬─────────┘
+        startSelection │                     │ clearSelection
+                       v                     │
+       ┌──────────────────────┐              │
+       │ anchor set, focus=∅  │              │
+       │   isDragging=true    │              │
+       └──────┬───────────────┘              │
+       update │ (col,row ≠ anchor)           │
+              v                              │
+       ┌──────────────────────┐              │
+       │ anchor + focus set   │──────────────┤
+       │   isDragging=true    │ finishSel    │
+       └──┬───────────────────┘              │
+          │ scroll during drag               │
+          v                                  │
+       ┌──────────────────────┐              │
+       │ + scrolledOff*       │              │
+       │ + virtualAnchorRow   │              │
+       └──┬───────────────────┘              │
+          │ finishSelection                  │
+          v                                  │
+       ┌──────────────────────┐              │
+       │ anchor + focus set   │──────────────┤
+       │   isDragging=false   │  clearSel    │
+       └──────────────────────┘              │
+                                             v
+```
+
+Bare click (no motion) sets `anchor` then `finishSelection` with `focus = null` — `hasSelection()` returns false, no highlight, no copy.
+
+## Virtual rows (the pre-clamp tracker)
+
+`virtualAnchorRow` / `virtualFocusRow` exist because clamp is destructive. When `shiftSelection` clamps anchor from row 5 to row 0, a subsequent reverse scroll of `+10` would compute `0 + 10 = 10` instead of the true `5 + 10 = 15`. The accumulator (`scrolledOffAbove`) would also stay populated past the row it should have been popped from — so the highlight (which clamps) and the copy text (which reads the accumulator) disagree.
+
+Fix: store the pre-clamp row in `virtualAnchorRow` whenever clamp fires; the next shift reads `virtualAnchorRow ?? anchor.row` as the true position. Both axes are needed because the drag → follow transition hands off to `shiftSelectionForFollow`, which reads both.
+
+The accumulator pop logic in `shiftSelection` (`:455-475`) computes `oldDebt` and `newDebt` against virtual rows; when `newDebt < oldDebt`, the rows are back on-screen and pop from the accumulator end nearest the viewport (newest at end for `above`, newest at front for `below`).
+
+## Drag-to-scroll capture
+
+When the ScrollBox scrolls during a drag, rows about to scroll out of the viewport are captured BEFORE the scroll mutates them:
+
+1. ScrollBox decides to scroll by `delta`.
+2. `ink.tsx` calls `captureScrolledRows(s, frontScreen, firstRow, lastRow, 'above' | 'below')` — `frontScreen` still holds pre-scroll content.
+3. Rows are intersected with the selection and pushed into `scrolledOffAbove` / `scrolledOffBelow` along with their soft-wrap bit.
+4. The anchor's col is reset to `0` (above) or `width-1` (below) so subsequent captures and final `getSelectedText` don't re-apply a stale col bound. `anchorSpan` BOTH cols are reset (not just the near side) to handle drag-direction reversal after a blocked scroll (`:735-738`).
+5. `shiftAnchor` translates the anchor row.
+
+`scrolledOffAbove` pushes newest at END (closest to on-screen). `scrolledOffBelow` unshifts newest at FRONT. `getSelectedText` then reads `above + on-screen + below` in that order.
+
+## applySelectionOverlay
+
+`selection.ts:823`. Called from `ink.tsx` AFTER `Renderer` produces a frame, BEFORE `LogUpdate.render`. Walks the selection rect and calls `setCellStyleId(screen, col, row, stylePool.withSelectionBg(cell.styleId))` per cell. Skips `noSelect` cells so gutters stay visually unchanged (clear they're not part of copy).
+
+This MUTATES the screen buffer that the renderer just produced. Consequence: that buffer cannot be used as `prevScreen` for the next frame's blit — `prevFrameContaminated` is set true. The diff loop in log-update treats the restyled cells as ordinary changes; LogUpdate stays a pure diff engine with no selection awareness.
+
+`StylePool.withSelectionBg` (`screen.ts:229`) interns `base + selection-bg` once per base styleId; the cache is keyed by base only and cleared when `setSelectionBg` is called with a new color (theme change). On drag, the per-cell work is one Map lookup + one packed-int write.
+
+## Invariants
+
+- `focus = null` means "no extent" — `hasSelection`, `selectionBounds`, `isCellSelected` all early-return on `!s.focus`. `anchor` alone never highlights.
+- After clamp, `virtualAnchorRow` (or `virtualFocusRow`) MUST be set to the pre-clamp row. Skipping this leaves the next reverse-shift computing from the clamped row → off-by-N → highlight diverges from copy.
+- Accumulator length ≤ debt at any point. `shiftSelection` truncates if length exceeds debt (`:484-493`) — handles the case where `moveFocus` cleared `virtualFocusRow` without trimming.
+- `captureScrolledRows` MUST run against the PRE-SCROLL screen buffer. Running after `scrollBy` mutates the buffer captures rows that have already been overwritten.
+- `applySelectionOverlay` MUST run after `Renderer` and before `LogUpdate.render`. Running before is overwritten by full-render writes; running after is irrelevant (the diff already shipped).
+- `prevFrameContaminated` MUST be set after `applySelectionOverlay` mutates the front buffer, otherwise next frame's blits copy inverted cells.
+
+## Common pitfalls
+
+- Treating `anchor.row` / `focus.row` as the source of truth for "where the selection is now." Use `virtualAnchorRow ?? anchor.row` if you're computing offsets across scrolls.
+- Forgetting that `scrolledOffAbove` and `scrolledOffAboveSW` are PARALLEL arrays. Mutating one without the other corrupts soft-wrap detection in `getSelectedText`.
+- Reading `selectionBounds()` and assuming `start.col` is always ≤ `end.col`. Normalization is by row first, then col within the row — a top-right-to-bottom-left selection has `start.col > end.col` on the start row.
+- Calling `clearSelection` from inside `applySelectionOverlay`. The overlay is structural; clearing during it leaves the next frame's first read seeing `null` mid-paint.
+- Adding a new field to `SelectionState` and forgetting to reset it in `startSelection` AND `clearSelection`. Stale state across selection cycles is the most common selection bug.
+
+## Source
+
+- Primary: `packages/renderer/src/selection.ts`
+- Tests: `packages/renderer/src/selection.test.ts` (lifecycle, normalization, shift round-trips)
+- Coordination: `packages/renderer/src/ink.tsx` (mouse routing, capture call site, overlay invocation)
+- Style interning: `packages/renderer/src/screen.ts` (`StylePool.withSelectionBg`, `setSelectionBg`)
+- Hook: `packages/renderer/src/hooks/use-selection.ts` (React subscribers)

--- a/docs/internals/yoga-port.md
+++ b/docs/internals/yoga-port.md
@@ -1,0 +1,74 @@
+# Yoga Port
+
+Pure-TypeScript reimplementation of Meta's Yoga flexbox engine, sized to the subset yokai uses.
+
+## Responsibility
+
+Owns flexbox layout: style storage, dirty propagation, `calculateLayout` traversal with multi-pass clamping, and per-node measurement caches. Does NOT own painting, terminal I/O, React, or text wrapping (text wrapping happens via `measureFunc` callbacks the renderer installs, not inside the layout engine).
+
+## Why pure TS
+
+- Boot cost. The WASM Yoga build adds ~1ms+ to startup and a non-trivial binary chunk; yokai targets sub-tick startup.
+- Single-binary distribution. No native loader, no `wasm` MIME, no Node version coupling.
+- Debuggability. The dirty-cache machinery (`_cGen`, `_fbGen`, `_hasL`) is hot enough that being able to step into TS — and grep `_cIn` writes — has paid for itself repeatedly.
+
+The port is at `packages/shared/src/yoga-layout/index.ts`. Top-of-file comments enumerate features implemented for spec parity but not used by Ink (margin: auto, multi-pass clamping, flex-wrap, align-content, display: contents, baseline) and features not implemented (aspect-ratio, content-box box-sizing, RTL).
+
+## Deviations from upstream
+
+| Property | Upstream default | Yokai default | Why |
+|---|---|---|---|
+| `flexShrink` | `1` (web), `0` (yoga C++) | `0` | Matches yoga C++ (the upstream this is a port of), not CSS. Means children don't shrink below their basis unless explicitly given `flexShrink > 0`. |
+| `flexDirection` | `Row` (web) | `Column` | Matches yoga C++ default. Terminal UIs are vertical-by-default. |
+| `alignContent` | `Stretch` (web) | `FlexStart` | Matches yoga C++ default. |
+
+See `defaultStyle()` at `packages/shared/src/yoga-layout/index.ts:169`.
+
+## Layout calculation
+
+`calculateLayout(width, height, direction)` is invoked once per commit. Call site:
+
+- `packages/renderer/src/ink.tsx` → `onComputeLayout` → calls `node.yogaNode.calculateLayout(...)` on the root.
+- The reconciler invokes `onComputeLayout` from `resetAfterCommit` (`reconciler.ts:251`).
+
+Dirty propagation: `markDirty()` (`yoga-layout/index.ts:579`) sets `isDirty_` on `this` and walks `parent` chain until it finds an already-dirty ancestor. Every style mutator on `Node` calls `markDirty()` (the `markDirty()` calls in setters at `:655` onward). The reconciler's `setStyle` / `setAttribute` separately call `dom.markDirty(node)` to bubble the renderer's dirty bit up the DOM, which is independent of the yoga dirty bit (yoga's bit gates layout cache; the DOM's bit gates the blit fast path).
+
+## Caches
+
+Three layered caches. All keyed by INPUTS to the call so different parents asking the same node different questions don't collide.
+
+| Cache | Slots | Fields | Purpose |
+|---|---|---|---|
+| Layout single-slot (`_hasL`) | 1 | `_lW`, `_lH`, `_lWM`, `_lHM`, `_lOW`, `_lOH`, `_lFW`, `_lFH`, `_lOutW`, `_lOutH` | Hot single-slot for layout passes. Stores BOTH inputs and outputs because `layout.width/height` get mutated by the multi-entry cache. The `_lOut*` outputs were added after the "scrollbox vpH=33→2624" bug — without them a hit returned whatever was last written to `layout`. (`yoga-layout/index.ts:444-459`) |
+| Multi-entry layout (`_cIn` / `_cOut`) | 4 | Packed `Float64Array` — 8 inputs + 2 outputs per slot | Ring of additional layout-call answers. Upstream uses 16 slots; 4 covers Ink's dirty-chain depth. Generation-gated via `_cGen`. (`:489-498`) |
+| Flex-basis (`_fbBasis`) | 1 | `_fbBasis`, `_fbOwnerW`, `_fbOwnerH`, `_fbAvailMain`, `_fbAvailCross`, `_fbCrossMode` | Cached `computeFlexBasis` result for clean children. The basis only depends on container inner dimensions; if those haven't changed the recursive measure pass is skipped. Generation-gated via `_fbGen`. (`:469-488`) |
+
+### Generation gating
+
+`_cGen` and `_fbGen` are stamped to a module-scope `_generation` counter that increments per `calculateLayout` call. A cached entry from a previous generation is treated as stale — the subtree may have changed (e.g. virtual-scroll mounted new items). Within one generation the cache is fresh because the dirty chain's measure → layout cascade invokes `computeFlexBasis` ≥ 2^depth times per call on fresh-mounted items and the subtree doesn't change between those internal calls. Gating on generation rather than `isDirty_` lets fresh mounts cache-hit after first compute (the comment cites a 105k → 10k visit reduction at `:486-487`).
+
+### Profiling counters
+
+`getYogaCounters()` (`yoga-layout/index.ts:1039`) returns `{ visited, measured, cacheHits, live }`. Reset per `calculateLayout`, except `live` which tracks `_yogaLiveNodes` (constructor `++`, `free()` `--`). Read by `reconciler.ts:257` to log `SLOW_YOGA` events when a layout exceeds 20ms with `CLAUDE_CODE_COMMIT_LOG` set.
+
+## Invariants
+
+- Every style setter MUST call `markDirty()`. If a setter forgets, the dirty cache returns stale results and a layout regression follows that's hard to attribute.
+- `_hasL` and `_cIn` MUST store outputs alongside inputs. The `layout.width/height` fields are scratch space — multi-entry cache writes restore them, but a hit on `_hasL` without restored outputs returns whatever the last unrelated call left there.
+- `freeRecursive()` is only safe AFTER all references to subtree nodes are nulled. The reconciler enforces this via `clearYogaNodeReferences` before `freeRecursive` (`reconciler.ts:69-78`). Don't call `freeRecursive()` directly — go through `cleanupYogaNode`.
+- `_yogaLiveNodes` is the leak detector. Steady-state apps should plateau; monotonic growth means the reconciler's removal path isn't reaching `cleanupYogaNode`.
+
+## Common pitfalls
+
+- Setting `flexShrink: 1` everywhere "to match CSS." This ports a layout bug — children silently collapse under containers that were sized for their natural width.
+- Reading `getComputedWidth()` / `getComputedHeight()` before the first `calculateLayout`. Returns NaN. `renderer.ts:48-67` short-circuits to an empty frame in this case.
+- Holding a reference to a `Node` after its DOM element was removed. The node's children array is cleared by `free()` but the object itself can linger; reads will return stale layout. Treat the node as opaque after removal.
+- Mutating style during a measure callback. The measure pass holds a snapshot of inputs; mid-pass mutation creates a generation skew where some descendants see old style and some see new.
+
+## Source
+
+- Primary: `packages/shared/src/yoga-layout/index.ts` (~2460 lines)
+- Enums: `packages/shared/src/yoga-layout/enums.ts`
+- Renderer glue: `packages/renderer/src/layout/engine.ts`, `packages/renderer/src/layout/node.ts`, `packages/renderer/src/styles.ts`
+- Call sites: `packages/renderer/src/ink.tsx` (`onComputeLayout`), `packages/renderer/src/reconciler.ts:251`
+- Counters consumer: `packages/renderer/src/reconciler.ts:257`

--- a/docs/patterns/chat-ui.md
+++ b/docs/patterns/chat-ui.md
@@ -1,0 +1,183 @@
+# Chat UI
+
+A scrollable message list above an input row. Reach for this when building Slack-shaped or claude-corp-shaped conversational interfaces: streaming chat, log viewers with reply, agent transcripts.
+
+## Code
+
+```tsx
+import {
+  AlternateScreen,
+  Box,
+  FocusGroup,
+  FocusRing,
+  ScrollBox,
+  Text,
+  render,
+  useApp,
+  useFocusManager,
+  useInput,
+} from '@yokai/renderer'
+import type React from 'react'
+import { useState } from 'react'
+
+type Message = {
+  id: string
+  sender: string
+  content: string
+  timestamp: string
+  expanded?: boolean
+}
+
+const COLLAPSE_LINES = 3
+
+function MessageBubble({
+  message,
+  onToggle,
+}: {
+  message: Message
+  onToggle: (id: string) => void
+}): React.ReactNode {
+  const lines = message.content.split('\n')
+  const truncated = !message.expanded && lines.length > COLLAPSE_LINES
+  const shown = truncated ? lines.slice(0, COLLAPSE_LINES).join('\n') : message.content
+
+  return (
+    <FocusRing
+      paddingX={1}
+      label={message.id}
+      flexDirection="column"
+      marginBottom={1}
+      onClick={() => onToggle(message.id)}
+    >
+      <Box>
+        <Text bold color="cyan">{message.sender}</Text>
+        <Text dim>  {message.timestamp}</Text>
+      </Box>
+      <Text>{shown}</Text>
+      {truncated && (
+        <Text dim>… +{lines.length - COLLAPSE_LINES} more lines (Enter to expand)</Text>
+      )}
+    </FocusRing>
+  )
+}
+
+function App(): React.ReactNode {
+  const { exit } = useApp()
+  const { focused } = useFocusManager()
+  const [draft, setDraft] = useState('')
+  const [messages, setMessages] = useState<Message[]>([
+    {
+      id: 'm1',
+      sender: 'alice',
+      content: 'have you seen the new renderer diff?',
+      timestamp: '09:14',
+    },
+    {
+      id: 'm2',
+      sender: 'bob',
+      content:
+        'yeah — per-cell ANSI patches.\nmuch tighter than redraw-all.\ni measured 4ms/frame on a streaming log.\nold path was 22ms.',
+      timestamp: '09:15',
+    },
+    {
+      id: 'm3',
+      sender: 'alice',
+      content: 'nice. shipping it?',
+      timestamp: '09:16',
+    },
+  ])
+
+  function send(): void {
+    const text = draft.trim()
+    if (!text) return
+    setMessages((prev) => [
+      ...prev,
+      {
+        id: `m${prev.length + 1}`,
+        sender: 'you',
+        content: text,
+        timestamp: new Date().toTimeString().slice(0, 5),
+      },
+    ])
+    setDraft('')
+  }
+
+  function toggleExpand(id: string): void {
+    setMessages((prev) =>
+      prev.map((m) => (m.id === id ? { ...m, expanded: !m.expanded } : m)),
+    )
+  }
+
+  useInput((input, key) => {
+    if (key.ctrl && input === 'c') exit()
+    if (key.return) {
+      if (focused?.attributes.label) {
+        toggleExpand(String(focused.attributes.label))
+      } else {
+        send()
+      }
+      return
+    }
+    if (key.backspace || key.delete) {
+      setDraft((d) => d.slice(0, -1))
+      return
+    }
+    if (input && !key.ctrl && !key.meta) setDraft((d) => d + input)
+  })
+
+  return (
+    <AlternateScreen mouseTracking>
+      <Box flexDirection="column" height="100%" padding={1}>
+        <Box flexGrow={1}>
+          <ScrollBox stickyScroll flexDirection="column" width="100%">
+            <FocusGroup direction="column" flexDirection="column">
+              {messages.map((m) => (
+                <MessageBubble key={m.id} message={m} onToggle={toggleExpand} />
+              ))}
+            </FocusGroup>
+          </ScrollBox>
+        </Box>
+
+        <Box
+          borderStyle="round"
+          borderColor="cyan"
+          paddingX={1}
+          marginTop={1}
+        >
+          <Text>{'> '}</Text>
+          <Text>{draft}</Text>
+          <Text inverse> </Text>
+        </Box>
+      </Box>
+    </AlternateScreen>
+  )
+}
+
+render(<App />)
+```
+
+## How it works
+
+1. **Two-region layout**: outer column with `height="100%"`. The list region uses `flexGrow={1}` to take all leftover space; the input row sits at natural height below it.
+2. **`stickyScroll` on `<ScrollBox>`**: when the user is at the bottom, new messages auto-scroll into view. As soon as the user scrolls up, sticky pauses — the viewport stays put while later messages append offscreen, and a manual scroll back to the bottom re-arms sticky.
+3. **Per-message focus**: `<FocusGroup direction="column">` claims ↑/↓ to walk between bubbles. Each `<FocusRing>` carries the message id via the `label` attribute so the Enter handler knows which bubble to expand.
+4. **Collapsed bubbles**: messages over `COLLAPSE_LINES` truncate visually; the `expanded` flag flips on Enter (when a bubble is focused) or on click. The truncation hint shows the hidden line count.
+5. **Enter routing**: the host's `useInput` checks `focused?.attributes.label` first — if a bubble owns focus, Enter expands it; otherwise Enter sends the draft. Same key, two contextual meanings.
+6. **Plain-text input**: `useInput` accumulates printable chars into `draft` and handles backspace. The cursor block is a single `<Text inverse> </Text>` — no real cursor, no escape codes to manage.
+7. **Streaming**: when content arrives token-by-token, mutate the last message's `content` in state. The frame diff in `log-update.ts` only emits ANSI for the cells whose chars actually changed — appending one token to a long bubble touches a handful of cells, not the whole screen.
+
+## Variations
+
+- **Per-message timestamps on hover**: hide the timestamp by default, show it only on the focused bubble.
+- **Threaded replies**: nest a second `<ScrollBox>` inside an expanded bubble for a child thread.
+- **Scroll-to-latest button**: when sticky pauses, render a floating absolute-positioned button that calls `scrollBoxRef.current?.scrollToBottom()` and re-arms sticky.
+- **Multi-line input**: swap the single-line draft for a wrapping `<Box>` plus Shift+Enter to insert a newline; Enter alone sends.
+- **Markdown bubbles**: parse `content` into styled `<Text>` runs (bold, code, links via `<Link>`).
+- **Sender colors from a hash**: derive `color` from `hash(sender) % palette.length` so each participant gets a stable hue.
+
+## Related
+
+- [`ScrollBox`](../components/scrollbox.md) — `stickyScroll`, viewport culling, imperative scroll API.
+- [`FocusGroup`](../components/focus-group.md), `FocusRing`
+- [`useInput`](../hooks/use-input.md), [`useFocusManager`](../hooks/use-focus-manager.md)
+- [Modal pattern](./modal.md) — for confirmation prompts (e.g. "delete message?") on top of a chat.

--- a/docs/patterns/confirmation-dialog.md
+++ b/docs/patterns/confirmation-dialog.md
@@ -1,0 +1,180 @@
+# Confirmation Dialog
+
+A modal with two or three buttons that returns a discrete answer. Reach for this when an action is destructive, irreversible, or otherwise needs explicit consent: file deletion, force-push, sign-out.
+
+## Code
+
+```tsx
+import {
+  AlternateScreen,
+  Box,
+  FocusGroup,
+  FocusRing,
+  Text,
+  render,
+  useApp,
+  useFocusManager,
+  useInput,
+} from '@yokai/renderer'
+import type React from 'react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+
+type Answer = 'yes' | 'no' | 'cancel'
+
+function ConfirmDialog({
+  message,
+  onAnswer,
+}: {
+  message: string
+  onAnswer: (answer: Answer) => void
+}): React.ReactNode {
+  const { focused } = useFocusManager()
+
+  useInput((input, key) => {
+    if (key.escape) {
+      onAnswer('cancel')
+      return
+    }
+    if (key.return) {
+      const label = focused?.attributes.label
+      if (label === 'yes' || label === 'no' || label === 'cancel') {
+        onAnswer(label)
+      }
+    }
+  })
+
+  return (
+    <>
+      <Box
+        position="absolute"
+        top={0}
+        left={0}
+        width="100%"
+        height="100%"
+        backgroundColor="#000000"
+        zIndex={100}
+      />
+      <Box
+        position="absolute"
+        top={5}
+        left={18}
+        width={48}
+        height={9}
+        backgroundColor="#1a1a3a"
+        borderStyle="round"
+        borderColor="cyan"
+        flexDirection="column"
+        padding={1}
+        zIndex={101}
+      >
+        <Text bold>Confirm</Text>
+        <Text>{message}</Text>
+
+        <Box marginTop={1}>
+          <FocusGroup direction="row" wrap flexDirection="row" gap={2}>
+            <FocusRing paddingX={2} label="yes" onClick={() => onAnswer('yes')}>
+              <Text>Yes</Text>
+            </FocusRing>
+            <FocusRing paddingX={2} label="no" onClick={() => onAnswer('no')}>
+              <Text>No</Text>
+            </FocusRing>
+            <FocusRing
+              autoFocus
+              paddingX={2}
+              label="cancel"
+              onClick={() => onAnswer('cancel')}
+            >
+              <Text>Cancel</Text>
+            </FocusRing>
+          </FocusGroup>
+        </Box>
+      </Box>
+    </>
+  )
+}
+
+// Promise-based API. Wires a single dialog into a host component
+// and returns a function that resolves with the user's choice.
+function useConfirm(): {
+  node: React.ReactNode
+  confirm: (message: string) => Promise<Answer>
+} {
+  const [pending, setPending] = useState<{
+    message: string
+    resolve: (a: Answer) => void
+  } | null>(null)
+  const pendingRef = useRef(pending)
+  pendingRef.current = pending
+
+  const confirm = useCallback((message: string): Promise<Answer> => {
+    return new Promise<Answer>((resolve) => {
+      setPending({ message, resolve })
+    })
+  }, [])
+
+  const node = pending ? (
+    <ConfirmDialog
+      message={pending.message}
+      onAnswer={(answer) => {
+        pending.resolve(answer)
+        setPending(null)
+      }}
+    />
+  ) : null
+
+  return { node, confirm }
+}
+
+function App(): React.ReactNode {
+  const { exit } = useApp()
+  const { node: dialog, confirm } = useConfirm()
+  const [last, setLast] = useState<string>('—')
+
+  useInput((input, key) => {
+    if (input === 'q' || (key.ctrl && input === 'c')) exit()
+    if (input === 'd' && !dialog) {
+      void (async () => {
+        const answer = await confirm('Delete file foo.ts?')
+        setLast(answer)
+      })()
+    }
+  })
+
+  return (
+    <AlternateScreen mouseTracking>
+      <Box flexDirection="column" padding={1}>
+        <Text bold>files</Text>
+        <Text dim>press <Text bold>d</Text> to delete, <Text bold>q</Text> to quit</Text>
+        <Text>last answer: <Text bold>{last}</Text></Text>
+        {dialog}
+      </Box>
+    </AlternateScreen>
+  )
+}
+
+render(<App />)
+```
+
+## How it works
+
+1. **Three labelled buttons in a row**: `<FocusGroup direction="row">` claims ←/→. Each `<FocusRing>` carries its answer via `label` so the Enter handler can dispatch off the focused element with no per-button refs.
+2. **`autoFocus` on the safe default**: Cancel mounts focused, so a reflexive Enter doesn't perform the destructive action. For non-destructive prompts ("Save changes?") `autoFocus` would move to Yes instead.
+3. **Esc cancels universally**: the dialog's own `useInput` catches `key.escape` and resolves with `'cancel'`. The host's `useInput` runs in parallel but treats Esc as a no-op while the dialog is mounted.
+4. **Modal stacking**: full-viewport backdrop at `zIndex={100}`, panel at `zIndex={101}`. Both must be `position: 'absolute'` — `zIndex` is silently ignored on in-flow nodes.
+5. **Promise-based `useConfirm`**: holds a single `{ message, resolve }` pending slot in state. `confirm(message)` returns a `Promise<Answer>`; mounting the `<ConfirmDialog>` is a side effect of that state. `onAnswer` resolves the promise and clears the slot, which unmounts the dialog.
+6. **Focus stack on unmount**: when the dialog unmounts, `FocusManager` pops the focus stack and restores the host's previously-focused element — the consumer never has to track who had focus before opening.
+7. **Click also dispatches**: each `<FocusRing>` has `onClick` wired to the same answer, so mouse clicks bypass the keyboard and resolve directly.
+
+## Variations
+
+- **Yes / No only**: drop the Cancel button and treat Esc as No. Two-button confirmations are common for binary save prompts.
+- **Destructive styling**: color the Yes button red (`<Text color="red" bold>Yes</Text>`) when the action is irreversible.
+- **Typed confirmation**: replace the button row with a text input that requires the user to type the resource name before Yes enables. Good for force-pushes and DROP TABLE prompts.
+- **Countdown auto-cancel**: render a second `<Text>` below the buttons showing seconds until auto-cancel; a `useEffect` + `setTimeout` resolves with `'cancel'` if no answer arrives.
+- **Stacked confirms**: `confirm()` is reentrant in spirit but the `useConfirm` hook above only holds one pending answer at a time. For nested confirms inside a confirm, store an array of pending entries instead and render the top of the stack.
+
+## Related
+
+- [Modal pattern](./modal.md) — base layer this builds on.
+- [`FocusGroup`](../components/focus-group.md), `FocusRing`
+- [`useFocusManager`](../hooks/use-focus-manager.md), [`useInput`](../hooks/use-input.md)

--- a/docs/patterns/file-tree.md
+++ b/docs/patterns/file-tree.md
@@ -1,0 +1,166 @@
+# File Tree
+
+Collapsible nested tree of files and folders. Reach for this when building a file picker, a project explorer, or any hierarchical browser.
+
+## Code
+
+```tsx
+import {
+  AlternateScreen,
+  Box,
+  FocusGroup,
+  FocusRing,
+  Text,
+  render,
+  useApp,
+  useFocusManager,
+  useInput,
+} from '@yokai/renderer'
+import type React from 'react'
+import { useMemo, useState } from 'react'
+
+type Node = { name: string; path: string; children?: Node[] }
+
+const ROOT: Node = {
+  name: 'project',
+  path: '/project',
+  children: [
+    {
+      name: 'src',
+      path: '/project/src',
+      children: [
+        { name: 'index.ts', path: '/project/src/index.ts' },
+        {
+          name: 'components',
+          path: '/project/src/components',
+          children: [
+            { name: 'Box.tsx', path: '/project/src/components/Box.tsx' },
+            { name: 'Text.tsx', path: '/project/src/components/Text.tsx' },
+          ],
+        },
+      ],
+    },
+    {
+      name: 'tests',
+      path: '/project/tests',
+      children: [{ name: 'box.test.ts', path: '/project/tests/box.test.ts' }],
+    },
+    { name: 'package.json', path: '/project/package.json' },
+    { name: 'README.md', path: '/project/README.md' },
+  ],
+}
+
+type Visible = { node: Node; depth: number; isDir: boolean; isOpen: boolean }
+
+function flatten(node: Node, depth: number, expanded: Map<string, boolean>, out: Visible[]): void {
+  const isDir = !!node.children
+  const isOpen = isDir && expanded.get(node.path) === true
+  out.push({ node, depth, isDir, isOpen })
+  if (isOpen && node.children) {
+    for (const c of node.children) flatten(c, depth + 1, expanded, out)
+  }
+}
+
+function App(): React.ReactNode {
+  const { exit } = useApp()
+  const { focused } = useFocusManager()
+  const [expanded, setExpanded] = useState<Map<string, boolean>>(
+    () => new Map([[ROOT.path, true]]),
+  )
+  const [chosen, setChosen] = useState<string | null>(null)
+
+  const visible = useMemo(() => {
+    const out: Visible[] = []
+    flatten(ROOT, 0, expanded, out)
+    return out
+  }, [expanded])
+
+  function toggle(path: string, open: boolean): void {
+    setExpanded((prev) => {
+      const next = new Map(prev)
+      next.set(path, open)
+      return next
+    })
+  }
+
+  useInput((input, key) => {
+    if (input === 'q' || key.escape || (key.ctrl && input === 'c')) exit()
+    const label = focused?.attributes.label
+    if (typeof label !== 'string') return
+    const row = visible.find((v) => v.node.path === label)
+    if (!row) return
+    if (key.rightArrow && row.isDir && !row.isOpen) toggle(row.node.path, true)
+    if (key.leftArrow && row.isDir && row.isOpen) toggle(row.node.path, false)
+    if (key.return) {
+      if (row.isDir) toggle(row.node.path, !row.isOpen)
+      else setChosen(row.node.path)
+    }
+  })
+
+  return (
+    <AlternateScreen mouseTracking>
+      <Box flexDirection="column" padding={1}>
+        <Text bold>file tree</Text>
+        <Text dim>Tab/arrows to move, →/← expand/collapse, Enter selects, q quits</Text>
+
+        <Box marginTop={1}>
+          <FocusGroup direction="column" wrap flexDirection="column">
+            {visible.map((row) => {
+              const indent = '  '.repeat(row.depth)
+              const glyph = row.isDir ? (row.isOpen ? 'v' : '>') : ' '
+              const icon = row.isDir ? '/' : ''
+              return (
+                <FocusRing key={row.node.path} label={row.node.path}>
+                  <Box paddingX={1}>
+                    <Text>
+                      {indent}
+                      <Text dim>{glyph} </Text>
+                      <Text color={row.isDir ? 'cyan' : undefined}>
+                        {row.node.name}
+                        {icon}
+                      </Text>
+                    </Text>
+                  </Box>
+                </FocusRing>
+              )
+            })}
+          </FocusGroup>
+        </Box>
+
+        <Box marginTop={1}>
+          <Text>opened: <Text bold>{chosen ?? '—'}</Text></Text>
+        </Box>
+      </Box>
+    </AlternateScreen>
+  )
+}
+
+render(<App />)
+```
+
+## How it works
+
+1. **Tree is data, view is flat**: `flatten` walks the tree depth-first and emits one `Visible` row per currently-shown node, carrying its `depth` so indentation falls out of `'  '.repeat(depth)`. Collapsed subtrees never enter the array.
+2. **Expansion state as a Map keyed by path**: `Map<string, boolean>` survives unrelated re-renders and keeps a closed branch closed when its parent re-opens. Mutating via copy-and-set keeps React's identity check honest.
+3. **One `<FocusGroup direction="column" wrap>` over the flattened list**: ↑/↓ moves between visible rows regardless of depth. Wrapping ends the loop at top/bottom. Tab also walks the same set in tree order.
+4. **`<FocusRing label={path}>` carries identity**: the keyboard handler looks the focused path up in `visible` to know whether the row is a directory and whether it's open — no separate ref map.
+5. **Right/left split from Enter**: → expands a closed dir, ← collapses an open one; Enter toggles dirs and selects files. Matches conventions from VS Code's explorer and `tree -L`.
+6. **Glyph + icon**: `>`/`v` shows expand state for dirs, trailing `/` marks dir names, `cyan` tints them. Files render plain — no clutter on the common case.
+7. **Mouse clicks focus a row**: re-pressing Enter (or re-clicking) toggles a dir or selects a file. Same dispatch path as the keyboard.
+
+## Variations
+
+- **Lazy children**: replace `node.children?: Node[]` with `loadChildren?: () => Promise<Node[]>`. On first expand, kick the loader and stash results in a `Map<string, Node[]>`; render a `loading...` placeholder row in the meantime.
+- **Multi-select**: track a `Set<string>` of checked paths; Space toggles; render `[x]` before the glyph.
+- **Filter / search**: take a query and prune `flatten` to nodes whose path matches or whose subtree contains a match. Auto-expand ancestors of matches.
+- **Drag to move**: wrap each row in `<Draggable>` and each directory in `<DropTarget>` with an `accept` filter; on drop, splice the node into its new parent.
+- **Long trees**: wrap the row list in `<ScrollBox height={N}>` and `scrollToElement` on the focused row when it leaves the viewport.
+- **Icons by extension**: branch on `node.name.split('.').pop()` for file glyphs (`.ts`, `.md`, `.json`).
+
+## Related
+
+- [`FocusGroup`](../components/focus-group.md)
+- [`FocusRing`](../components/focus-ring.md)
+- [`useFocusManager`](../hooks/use-focus-manager.md)
+- [`useInput`](../hooks/use-input.md)
+- [Keyboard menu pattern](./keyboard-menu.md) — flat-list precursor to this tree.

--- a/docs/patterns/indicators.md
+++ b/docs/patterns/indicators.md
@@ -1,0 +1,145 @@
+# Indicators
+
+Spinners and progress bars built on `useAnimationFrame`. Reach for these when work is in flight: loading states, file transfers, agent runs, build pipelines.
+
+## Spinner
+
+A rotating glyph cycling through a fixed frame set.
+
+```tsx
+import { Box, Text, render, useAnimationFrame } from '@yokai/renderer'
+import type React from 'react'
+
+const FRAMES = ['⠋', '⠙', '⠹', '⠸']
+
+function Spinner({ label }: { label: string }): React.ReactNode {
+  const [ref, time] = useAnimationFrame(80)
+  const frame = Math.floor(time / 80) % FRAMES.length
+
+  return (
+    <Box ref={ref} gap={1}>
+      <Text color="cyan">{FRAMES[frame]}</Text>
+      <Text>{label}</Text>
+    </Box>
+  )
+}
+
+render(<Spinner label="loading…" />)
+```
+
+### How it works
+
+1. `useAnimationFrame(80)` ticks every 80ms and returns `[ref, time]`. `time` is the shared clock value in ms.
+2. `frame = Math.floor(time / 80) % FRAMES.length` selects which glyph to render. Multiple spinners on screen stay in lockstep because the clock is shared.
+3. The returned `ref` attaches to the spinner's `<Box>`. When the box scrolls offscreen (inside a `<ScrollBox>`) or the terminal tab loses focus, `useAnimationFrame` unsubscribes from the clock and the spinner freezes — no wasted ticks, no per-frame diffs that produce nothing.
+4. Resuming is automatic: the moment the box re-enters the viewport, the hook resubscribes and `time` jumps to the current clock value.
+
+## Progress bar
+
+A determinate bar with a width-scaled fill and an optional percent label.
+
+```tsx
+import { Box, Text, render, useInput } from '@yokai/renderer'
+import type React from 'react'
+import { useState } from 'react'
+
+function ProgressBar({
+  progress,
+  width = 30,
+  showPercent = true,
+}: {
+  progress: number // 0..1
+  width?: number
+  showPercent?: boolean
+}): React.ReactNode {
+  const clamped = Math.max(0, Math.min(1, progress))
+  const filled = Math.round(clamped * width)
+  const empty = width - filled
+
+  return (
+    <Box gap={1}>
+      <Text backgroundColor="green">{' '.repeat(filled)}</Text>
+      <Text dim>{'─'.repeat(empty)}</Text>
+      {showPercent && <Text>{Math.round(clamped * 100)}%</Text>}
+    </Box>
+  )
+}
+
+function Demo(): React.ReactNode {
+  const [p, setP] = useState(0.42)
+  useInput((input) => {
+    if (input === '+') setP((v) => Math.min(1, v + 0.05))
+    if (input === '-') setP((v) => Math.max(0, v - 0.05))
+  })
+  return (
+    <Box flexDirection="column" padding={1}>
+      <ProgressBar progress={p} />
+      <Text dim>+/- to adjust</Text>
+    </Box>
+  )
+}
+
+render(<Demo />)
+```
+
+### How it works
+
+1. **Scale to width**: `filled = Math.round(progress * width)`. The bar's total cell count is fixed; only the split between filled and empty changes.
+2. **Two adjacent `<Text>` runs**: filled cells use `backgroundColor` for a solid block; empty cells use a `─` glyph dimmed. Diff-based output means changing the split touches only the cells that flipped — typically 1 cell per percent.
+3. **Clamp before render**: `Math.max(0, Math.min(1, progress))` keeps a runaway upstream value from rendering a bar wider than `width`.
+4. **No animation hook needed**: progress is driven by the consumer's state. Re-render whenever the underlying work reports.
+
+## Indeterminate progress
+
+A bouncing block for work with no measurable completion.
+
+```tsx
+import { Box, Text, render, useAnimationFrame } from '@yokai/renderer'
+import type React from 'react'
+
+function IndeterminateBar({
+  width = 30,
+  blockSize = 6,
+}: {
+  width?: number
+  blockSize?: number
+}): React.ReactNode {
+  const [ref, time] = useAnimationFrame(60)
+  const span = width - blockSize
+  // Triangle wave: 0 → span → 0 over 2 * span frames.
+  const cycle = span * 2
+  const phase = Math.floor(time / 60) % cycle
+  const pos = phase <= span ? phase : cycle - phase
+
+  return (
+    <Box ref={ref}>
+      <Text dim>{'─'.repeat(pos)}</Text>
+      <Text backgroundColor="cyan">{' '.repeat(blockSize)}</Text>
+      <Text dim>{'─'.repeat(span - pos)}</Text>
+    </Box>
+  )
+}
+
+render(<IndeterminateBar />)
+```
+
+### How it works
+
+1. **Triangle wave on the clock**: `phase` walks `0 → 2*span` and folds back on itself, giving a position that bounces between `0` and `span` without easing.
+2. **Three runs**: leading dim `─` (left padding), the cyan-bg block, trailing dim `─` (right padding). All three widths sum to `width`.
+3. **Same offscreen-pause behaviour as the spinner**: the `ref` from `useAnimationFrame` ties the animation lifecycle to viewport visibility.
+
+## Variations
+
+- **Braille spinner**: swap `FRAMES` for the full 8-frame braille set `['⠋','⠙','⠹','⠸','⠼','⠴','⠦','⠧']` for smoother rotation.
+- **Multi-spinner status list**: render N `<Spinner>` instances stacked; they all share the clock, so the visual rhythm stays coherent.
+- **Stepped progress**: render N filled blocks instead of cells (e.g. `[██░░░]` over 5 steps) for a chunky low-res bar.
+- **Coloured-by-progress bar**: red below 30%, yellow below 70%, green above — derive `backgroundColor` from `progress`.
+- **ETA suffix**: alongside the percent label, render a remaining-time estimate computed from `progress` and elapsed wall time.
+- **Pulsing block**: instead of bouncing, modulate the block's brightness via alternating `backgroundColor` values keyed off `time`.
+
+## Related
+
+- [`useAnimationFrame`](../hooks/use-animation-frame.md) — shared clock, viewport-aware pause.
+- [`useTerminalViewport`](../hooks/use-terminal-viewport.md) — the visibility primitive `useAnimationFrame` is built on.
+- [`Box`](../components/box.md), [`Text`](../components/text.md)

--- a/docs/patterns/log-viewer.md
+++ b/docs/patterns/log-viewer.md
@@ -1,0 +1,154 @@
+# Log Viewer
+
+Streaming log output with sticky-scroll auto-follow, level coloring, and inline search highlight. Reach for this in dev tools, build output panes, and any tail-style readout.
+
+## Code
+
+```tsx
+import {
+  AlternateScreen,
+  Box,
+  Button,
+  ScrollBox,
+  Text,
+  render,
+  useApp,
+  useInput,
+  useInterval,
+  useSearchHighlight,
+  type ScrollBoxHandle,
+} from '@yokai/renderer'
+import type React from 'react'
+import { useEffect, useRef, useState } from 'react'
+
+type Level = 'info' | 'warn' | 'error' | 'debug'
+type Line = { id: number; ts: string; level: Level; text: string }
+
+const LEVEL_COLOR: Record<Level, string> = {
+  info: 'green',
+  warn: 'yellow',
+  error: 'red',
+  debug: 'gray',
+}
+
+const SAMPLES: { level: Level; text: string }[] = [
+  { level: 'info', text: 'server listening on :4000' },
+  { level: 'debug', text: 'cache hit for key user:42' },
+  { level: 'info', text: 'GET /api/jobs 200 12ms' },
+  { level: 'warn', text: 'slow query: SELECT * FROM events (812ms)' },
+  { level: 'error', text: 'unhandled rejection in worker pool' },
+  { level: 'info', text: 'job 8a3 enqueued' },
+  { level: 'debug', text: 'reaper swept 0 expired sessions' },
+]
+
+function tsNow(): string {
+  return new Date().toISOString().slice(11, 23)
+}
+
+function App(): React.ReactNode {
+  const { exit } = useApp()
+  const scrollRef = useRef<ScrollBoxHandle>(null)
+  const [lines, setLines] = useState<Line[]>([])
+  const [paused, setPaused] = useState(false)
+  const [query, setQuery] = useState('')
+  const { setQuery: pushQuery } = useSearchHighlight()
+  const idRef = useRef(0)
+
+  useInterval(() => {
+    const sample = SAMPLES[Math.floor(Math.random() * SAMPLES.length)]!
+    setLines((prev) => {
+      const next = prev.concat({ id: idRef.current++, ts: tsNow(), ...sample })
+      return next.length > 5000 ? next.slice(-5000) : next
+    })
+  }, 250)
+
+  useEffect(() => {
+    pushQuery(query)
+    return () => pushQuery('')
+  }, [query, pushQuery])
+
+  useInput((input, key) => {
+    if (key.escape || (key.ctrl && input === 'c')) exit()
+    if (key.backspace || key.delete) setQuery((q) => q.slice(0, -1))
+    else if (input && !key.ctrl && !key.meta && input.length === 1) setQuery((q) => q + input)
+  })
+
+  function togglePause(): void {
+    if (paused) {
+      // Resume: jump to bottom and let stickyScroll re-engage.
+      scrollRef.current?.scrollToBottom()
+      setPaused(false)
+    } else {
+      // Pause: detach sticky by scrolling to current position.
+      const top = scrollRef.current?.getScrollTop() ?? 0
+      scrollRef.current?.scrollTo(top)
+      setPaused(true)
+    }
+  }
+
+  return (
+    <AlternateScreen mouseTracking>
+      <Box flexDirection="column" padding={1}>
+        <Box flexDirection="row" justifyContent="space-between">
+          <Text bold>logs</Text>
+          <Box flexDirection="row">
+            <Text dim>filter: </Text>
+            <Text>{query || '(none)'}</Text>
+            <Box marginLeft={2}>
+              <Button onPress={togglePause}>
+                <Text>{paused ? '[ resume ]' : '[ pause ]'}</Text>
+              </Button>
+            </Box>
+          </Box>
+        </Box>
+
+        <Box marginTop={1} borderStyle="single" height={20} flexDirection="column">
+          <ScrollBox ref={scrollRef} stickyScroll={!paused} flexDirection="column">
+            {lines.map((l) => (
+              <Box key={l.id} flexDirection="row">
+                <Text dim>{l.ts} </Text>
+                <Text color={LEVEL_COLOR[l.level]}>{l.level.padEnd(5)} </Text>
+                <Text>{l.text}</Text>
+              </Box>
+            ))}
+          </ScrollBox>
+        </Box>
+
+        <Box marginTop={1}>
+          <Text dim>type to filter, Backspace to delete, Esc quits</Text>
+        </Box>
+      </Box>
+    </AlternateScreen>
+  )
+}
+
+render(<App />)
+```
+
+## How it works
+
+1. **`useInterval` produces fake lines at 250ms**: stand-in for whatever real source you'd attach (subprocess stdout, websocket, file tail). Lines are immutable and id-keyed so React diffs cheaply.
+2. **Bounded buffer**: the producer caps `lines` at 5000 entries by slicing the tail. Without this, a long-lived viewer grows the React tree unbounded; viewport culling makes it cheap to render but the tree itself still costs memory.
+3. **`<ScrollBox stickyScroll>` auto-follows**: while sticky, every new line pushes the viewport down so the latest entry stays visible. Manual `scrollBy` from the wheel detaches sticky automatically — the user scrolls up to inspect, the tail pauses on its own, scrolling back to the bottom re-pins.
+4. **Pause / resume is imperative**: `togglePause` calls `scrollTo(getScrollTop())` to break stickiness without moving the view, and `scrollToBottom()` to re-engage it. The `stickyScroll={!paused}` prop reflects state so the prop and the imperative call agree.
+5. **Level color via lookup**: `LEVEL_COLOR` keeps the row branch-free; padding the level name to 5 chars keeps columns aligned without a fixed-width Box.
+6. **`useSearchHighlight().setQuery` inverts matches**: every visible occurrence of the current query is highlighted via SGR 7 on the next frame. Empty string clears. Effect cleanup clears on unmount so the highlight doesn't outlive the viewer.
+7. **Search input via `useInput`**: printable single-character input appends to `query`, Backspace pops. No focus management needed because the viewer has no other text input.
+8. **Viewport culling does the heavy lifting**: only lines intersecting the visible window reach the screen buffer. With 5000 entries and a 20-row viewport, each frame emits ~20 row-paints regardless of buffer size.
+
+## Variations
+
+- **Per-level filter**: keep a `Set<Level>` of enabled levels and filter `lines` before rendering. Buttons across the top toggle each level.
+- **Jump to match**: pair `setQuery` with `setPositions` and a hotkey (n/N) that walks `currentIdx` through the position list, calling `scrollToElement` on the matching line.
+- **Multi-source**: tag each line with `source: string` and render a colored prefix; filter by source the same way as level.
+- **Persisted scrollback**: on mount, hydrate `lines` from disk; on every Nth append, debounce-write the tail back.
+- **Word wrap vs truncate**: long lines wrap by default; switch to `wrap="truncate-end"` on the inner `<Text>` to keep one line per entry and trade detail for density.
+- **Click-to-pin**: replace `<Text>` rows with `<Button>` rows whose `onPress` opens a detail modal with the full structured payload.
+
+## Related
+
+- [`ScrollBox`](../components/scrollbox.md)
+- [`useSearchHighlight`](../hooks/use-search-highlight.md)
+- [`useInterval`](../hooks/use-interval.md)
+- [`useInput`](../hooks/use-input.md)
+- [`Button`](../components/button.md)

--- a/docs/patterns/table.md
+++ b/docs/patterns/table.md
@@ -1,0 +1,167 @@
+# Table
+
+Tabular data with column headers and rows. Reach for this when you need to show records: process lists, query results, file listings.
+
+## Code
+
+```tsx
+import {
+  AlternateScreen,
+  Box,
+  FocusGroup,
+  FocusRing,
+  Text,
+  render,
+  useApp,
+  useFocusManager,
+  useInput,
+} from '@yokai/renderer'
+import type React from 'react'
+import { useMemo, useState } from 'react'
+
+type Row = { id: string; name: string; status: 'open' | 'merged' | 'closed'; size: number }
+
+const COLS: { key: keyof Row; label: string; width: number; align?: 'right' }[] = [
+  { key: 'id', label: 'id', width: 6 },
+  { key: 'name', label: 'name', width: 28 },
+  { key: 'status', label: 'status', width: 10 },
+  { key: 'size', label: 'size', width: 8, align: 'right' },
+]
+
+const STATUS_COLOR: Record<Row['status'], string> = {
+  open: 'green',
+  merged: 'magenta',
+  closed: 'red',
+}
+
+const ROWS: Row[] = [
+  { id: '#42', name: 'fix scrollbox clamp race', status: 'open', size: 124 },
+  { id: '#43', name: 'rework yoga free path', status: 'merged', size: 980 },
+  { id: '#44', name: 'add z-index sort', status: 'merged', size: 312 },
+  { id: '#45', name: 'wheel events in alt-screen', status: 'open', size: 88 },
+  { id: '#46', name: 'drop double-render on resize', status: 'closed', size: 41 },
+]
+
+function Cell({
+  value,
+  width,
+  align,
+}: {
+  value: string
+  width: number
+  align?: 'right'
+}): React.ReactNode {
+  return (
+    <Box width={width} paddingX={1} justifyContent={align === 'right' ? 'flex-end' : 'flex-start'}>
+      <Text>{value}</Text>
+    </Box>
+  )
+}
+
+function App(): React.ReactNode {
+  const { exit } = useApp()
+  const { focused } = useFocusManager()
+  const [sortKey, setSortKey] = useState<keyof Row>('id')
+  const [sortDir, setSortDir] = useState<1 | -1>(1)
+  const [chosen, setChosen] = useState<string | null>(null)
+
+  const sorted = useMemo(() => {
+    return ROWS.slice().sort((a, b) => {
+      const av = a[sortKey]
+      const bv = b[sortKey]
+      if (av < bv) return -1 * sortDir
+      if (av > bv) return 1 * sortDir
+      return 0
+    })
+  }, [sortKey, sortDir])
+
+  useInput((input, key) => {
+    if (input === 'q' || key.escape || (key.ctrl && input === 'c')) exit()
+    if (key.return && focused?.attributes.label) {
+      const label = String(focused.attributes.label)
+      if (label.startsWith('row:')) setChosen(label.slice(4))
+      if (label.startsWith('hdr:')) {
+        const k = label.slice(4) as keyof Row
+        if (k === sortKey) setSortDir((d) => (d === 1 ? -1 : 1))
+        else {
+          setSortKey(k)
+          setSortDir(1)
+        }
+      }
+    }
+  })
+
+  return (
+    <AlternateScreen mouseTracking>
+      <Box flexDirection="column" padding={1}>
+        <Text bold>pull requests</Text>
+        <Text dim>Tab to move, Enter on header to sort, Enter on row to select, q quits</Text>
+
+        <Box marginTop={1} flexDirection="column">
+          <FocusGroup direction="row" flexDirection="row">
+            {COLS.map((c) => (
+              <FocusRing key={c.key} label={`hdr:${c.key}`}>
+                <Box width={c.width} paddingX={1}>
+                  <Text bold>
+                    {c.label}
+                    {sortKey === c.key ? (sortDir === 1 ? ' ^' : ' v') : ''}
+                  </Text>
+                </Box>
+              </FocusRing>
+            ))}
+          </FocusGroup>
+
+          <FocusGroup direction="column" wrap flexDirection="column">
+            {sorted.map((r) => (
+              <FocusRing key={r.id} label={`row:${r.id}`}>
+                <Box flexDirection="row">
+                  <Cell value={r.id} width={COLS[0]!.width} />
+                  <Cell value={r.name} width={COLS[1]!.width} />
+                  <Box width={COLS[2]!.width} paddingX={1}>
+                    <Text color={STATUS_COLOR[r.status]}>{r.status}</Text>
+                  </Box>
+                  <Cell value={String(r.size)} width={COLS[3]!.width} align="right" />
+                </Box>
+              </FocusRing>
+            ))}
+          </FocusGroup>
+        </Box>
+
+        <Box marginTop={1}>
+          <Text>selected: <Text bold>{chosen ?? '—'}</Text></Text>
+        </Box>
+      </Box>
+    </AlternateScreen>
+  )
+}
+
+render(<App />)
+```
+
+## How it works
+
+1. **Column schema as data**: `COLS` declares key, label, width, and optional alignment. Headers and rows both walk the same schema, so widths stay aligned without magic numbers in two places.
+2. **Fixed widths via `<Box width={n}>`**: each cell is a Box with a hard width and `paddingX={1}` for breathing room. `flexBasis` works too, but fixed widths give predictable terminal columns and cheaper layout.
+3. **Two `<FocusGroup>`s, one tree**: header group uses `direction="row"` (←/→ between header buttons); row group uses `direction="column"` with `wrap` (↑/↓ cycles rows). Tab still walks both groups linearly.
+4. **`<FocusRing label="...">` tags identity**: the Enter handler reads `focused.attributes.label` and dispatches on the `hdr:` / `row:` prefix. No per-cell callbacks, no ref maps.
+5. **Sort state lives outside the row list**: `useMemo` sorts a copy on `(sortKey, sortDir)` change. Repeated Enter on the same header flips direction; pressing a new header resets to ascending.
+6. **Status color**: `STATUS_COLOR` lookup keeps row rendering branch-free; new statuses extend the table without a switch.
+7. **Mouse clicks on a row or header focus it**: the same Enter dispatch then runs naturally — table is keyboard- and mouse-driven from one code path.
+
+## Variations
+
+- **Selectable multi-row** (checkbox column): add a `Set<string>` of selected ids; render `[x]` / `[ ]` in the first cell; Space toggles instead of Enter.
+- **Resizable columns**: wrap each header `<Box>` in `<Resizable axis="x">` and lift `width` into state keyed by column id.
+- **Long tables**: wrap the row group in `<ScrollBox height={20}>`. Yokai doesn't ship a virtualisation hook — all rows are still in the React tree, but viewport culling means only visible rows reach the screen buffer. Scales to a few thousand rows because the diff is per-cell.
+- **Per-row actions menu**: on Enter, mount a `<Modal>` with row-specific actions instead of just recording the id.
+- **Dynamic columns**: derive `COLS` from the first row's keys; use `flexGrow: 1` on a single "name" column to let it stretch and keep the rest fixed.
+- **Striped rows**: alternate `backgroundColor` per row index for legibility on dense tables.
+
+## Related
+
+- [`FocusGroup`](../components/focus-group.md)
+- [`FocusRing`](../components/focus-ring.md)
+- [`useFocusManager`](../hooks/use-focus-manager.md)
+- [`useInput`](../hooks/use-input.md)
+- [`ScrollBox`](../components/scrollbox.md) — for long tables.
+- [Keyboard menu pattern](./keyboard-menu.md) — same focus-and-Enter mechanism in one column.

--- a/docs/reference/cli.md
+++ b/docs/reference/cli.md
@@ -1,0 +1,147 @@
+# Render API reference
+
+The three entry points for mounting a yokai tree, plus the shapes they return. Source: `packages/renderer/src/root.ts`.
+
+## render
+
+Default export. Async; mounts a node and returns an `Instance` once the first render boundary settles.
+
+```ts
+import render from '@yokai/renderer'
+// or: import { render } from '@yokai/renderer'
+
+const instance = await render(<App />, options?)
+```
+
+**Signature**
+
+```ts
+function render(
+  node: ReactNode,
+  options?: NodeJS.WriteStream | RenderOptions,
+): Promise<Instance>
+```
+
+**Parameters**
+
+| Param | Type | Description |
+|-------|------|-------------|
+| `node` | `ReactNode` | Root element to mount. |
+| `options` | `WriteStream \| RenderOptions` | If a `WriteStream` is passed, used as `stdout` with defaults for the rest. |
+
+**Returns**: `Promise<Instance>`. The `await` boundary preserves a microtask tick before the first render so async startup work (e.g. notification state) settles before the first frame writes scrollback.
+
+**When to use**: the common path. Standard apps, scripts, REPLs.
+
+## renderSync
+
+Synchronous variant. Mounts immediately and returns an `Instance` without awaiting a microtask.
+
+**Signature**
+
+```ts
+function renderSync(
+  node: ReactNode,
+  options?: NodeJS.WriteStream | RenderOptions,
+): Instance
+```
+
+**When to use**: tests, and callers that need the `Instance` reference before the first paint completes. Reuses an existing `Ink` instance for the same `stdout` if one is already registered (the `instances` registry maps `stdout` → `Ink`).
+
+## createRoot
+
+Async; constructs an `Ink` instance with no tree mounted. Call `root.render(node)` to mount.
+
+**Signature**
+
+```ts
+function createRoot(options?: RenderOptions): Promise<Root>
+```
+
+**When to use**: pre-mount setup that needs to run after the renderer exists but before any React tree is committed — wiring listeners, registering external editor pause/resume, multi-screen apps that swap the root tree across phases.
+
+The created instance is registered in the `instances` map so that lookups by `stdout` (e.g. external editor pause/resume) find it.
+
+## RenderOptions
+
+Accepted by all three entry points.
+
+| Option | Type | Default | Description |
+|--------|------|---------|-------------|
+| `stdout` | `NodeJS.WriteStream` | `process.stdout` | Where the app renders. |
+| `stdin` | `NodeJS.ReadStream` | `process.stdin` | Where input is read from. |
+| `stderr` | `NodeJS.WriteStream` | `process.stderr` | Error stream. |
+| `exitOnCtrlC` | `boolean` | `true` | Listen for Ctrl+C and exit. Required when stdin is in raw mode (Ctrl+C is otherwise consumed by the app). |
+| `patchConsole` | `boolean` | `true` | Patch `console.*` so direct console output doesn't tear the rendered frame. |
+| `onFrame` | `(event: FrameEvent) => void` | `undefined` | Called after each composed frame with timing and flicker info. |
+
+## Instance (from `render` / `renderSync`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `rerender` | `(node: ReactNode) => void` | Replace the root or update root props. Same as the `Ink#render` method. |
+| `unmount` | `() => void` | Tear down the tree, restore the screen, exit alt-screen and mouse tracking, release Yoga nodes. |
+| `waitUntilExit` | `() => Promise<void>` | Resolves when the app unmounts. Rejects if the app exits with an error via `useApp().exit(error)`. |
+| `cleanup` | `() => void` | Remove this instance from the global `instances` registry. Call after `unmount` to free the `stdout` slot for a future `renderSync` to construct a new instance. |
+
+## Root (from `createRoot`)
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `render` | `(node: ReactNode) => void` | Mount or replace the root tree. Call multiple times to swap trees. |
+| `unmount` | `() => void` | Tear down. |
+| `waitUntilExit` | `() => Promise<void>` | Resolves on unmount; rejects on `useApp().exit(error)`. |
+
+## Lifecycle
+
+`waitUntilExit` resolves when:
+
+- `useApp().exit()` is called with no argument.
+- `instance.unmount()` is called externally.
+- Ctrl+C is received and `exitOnCtrlC` is `true`.
+- A fatal signal (`SIGTERM`, `SIGHUP`) terminates the process.
+
+It rejects when `useApp().exit(error)` is called with an `Error`.
+
+Alt-screen and mouse-tracking cleanup runs unconditionally on signal-exit: `EXIT_ALT_SCREEN` and `DISABLE_MOUSE_TRACKING` are emitted every time because the `altScreenActive` flag can be stale. `?1049l` is a no-op when already on the main screen, so the unconditional path is safe.
+
+## Examples
+
+### Standard app
+
+```tsx
+import render, { Box, Text } from '@yokai/renderer'
+
+const { waitUntilExit } = await render(
+  <Box>
+    <Text>hello</Text>
+  </Box>,
+)
+await waitUntilExit()
+```
+
+### Test
+
+```tsx
+import { renderSync } from '@yokai/renderer'
+
+const instance = renderSync(<MyComponent />, { stdout: fakeStdout })
+// assertions on fakeStdout.lastFrame()
+instance.unmount()
+instance.cleanup()
+```
+
+### Pre-mount wiring
+
+```tsx
+import { createRoot } from '@yokai/renderer'
+
+const root = await createRoot({ onFrame: recordFrameMetrics })
+attachExternalEditorBridge(root)
+root.render(<App />)
+await root.waitUntilExit()
+```
+
+## Re-exports
+
+`render`, `renderSync`, `createRoot`, and the types `RenderOptions`, `Instance`, `Root` are re-exported from the package root (`@yokai/renderer`).

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -1,0 +1,239 @@
+# Events reference
+
+Every event class dispatched by yokai, with shape, propagation behavior, and trigger.
+
+All events extend a common base. Two base classes exist:
+
+| Base | Source | Purpose |
+|------|--------|---------|
+| `Event` | `events/event.ts` | Minimal: `stopImmediatePropagation()` only. Used by mouse/click/input events that don't go through the DOM dispatcher. |
+| `TerminalEvent extends Event` | `events/terminal-event.ts` | DOM-style: `target`, `currentTarget`, `eventPhase`, `bubbles`, `cancelable`, `timeStamp`, `stopPropagation()`, `preventDefault()`. Used by `KeyboardEvent`, `FocusEvent`. |
+
+## Common methods
+
+| Method | Available on | Effect |
+|--------|--------------|--------|
+| `stopImmediatePropagation()` | All events | Halts further handler invocation, including remaining handlers on the same node. |
+| `stopPropagation()` | `TerminalEvent` subclasses | Halts after current node finishes; sibling handlers on the same node still fire. |
+| `preventDefault()` | `TerminalEvent` subclasses (when `cancelable`) | Sets `defaultPrevented`. The dispatcher's return value (`!defaultPrevented`) reports it; default actions are subclass-specific. |
+
+## ClickEvent
+
+Left-button release without intervening drag. Source: `events/click-event.ts`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `col` | `number` | 0-indexed screen column of the click. |
+| `row` | `number` | 0-indexed screen row. |
+| `localCol` | `number` | `col - box.x` for the current handler's Box. Recomputed before each handler. |
+| `localRow` | `number` | `row - box.y` for the current handler's Box. |
+| `cellIsBlank` | `boolean` | True when the clicked cell has no painted content. Use to ignore clicks on empty whitespace right of text. |
+
+**Methods**: `stopImmediatePropagation()`.
+
+**Fires when**: left mouse release without drag motion, while mouse tracking is active (i.e. inside `<AlternateScreen mouseTracking>`).
+
+**Propagation**: bubbles from deepest hit node up via `parentNode`. No capture phase.
+
+## MouseDownEvent
+
+Mouse press over an element. Source: `events/mouse-event.ts`.
+
+Inherits from internal `MouseEvent` base.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `col` | `number` | 0-indexed press column. |
+| `row` | `number` | 0-indexed press row. |
+| `button` | `number` | Raw SGR button byte. Low 2 bits = button (0 left, 1 mid, 2 right). Motion bit (0x20) masked off. |
+| `shiftKey` | `boolean` (getter) | `(button & 0x04) !== 0`. |
+| `altKey` | `boolean` (getter) | `(button & 0x08) !== 0`. |
+| `ctrlKey` | `boolean` (getter) | `(button & 0x10) !== 0`. |
+| `localCol` | `number` | Press column relative to current handler's Box. |
+| `localRow` | `number` | Press row relative to current handler's Box. |
+
+**Methods**:
+
+- `stopImmediatePropagation()`.
+- `captureGesture(handlers: GestureHandlers): void` — claim subsequent mouse-motion events and the eventual release for this drag. After capture, motion routes to `handlers.onMove` even when the cursor leaves the originally pressed element; release fires `handlers.onUp` and clears the capture. The normal release path (onClick, selection finish) is skipped for that release. Selection extension is suppressed for the gesture's lifetime. Calling multiple times within one dispatch overwrites — last call wins. Cannot be retargeted mid-flight.
+
+**Fires when**: mouse press, while mouse tracking is active.
+
+**Propagation**: bubbles from deepest hit node up via `parentNode`.
+
+## MouseMoveEvent
+
+Mouse motion during a captured gesture. Source: `events/mouse-event.ts`.
+
+Same fields as `MouseDownEvent` (`col`, `row`, `button`, modifier getters). No `localCol`/`localRow`, no `captureGesture`.
+
+**Methods**: `stopImmediatePropagation()`.
+
+**Fires when**: mouse moves, after a `MouseDownEvent` handler called `event.captureGesture(...)`. Typically one event per cell crossed.
+
+**Propagation**: does NOT bubble through the DOM tree. Routes directly to the gesture handler installed via `MouseDownEvent.captureGesture`. The active gesture lives on `App.activeGesture`.
+
+## MouseUpEvent
+
+Mouse release that closes a captured gesture. Source: `events/mouse-event.ts`.
+
+Same fields as `MouseMoveEvent`. The `(col, row)` at release identifies the drop position.
+
+**Methods**: `stopImmediatePropagation()`.
+
+**Fires when**: next mouse release after a captured `MouseDownEvent` gesture started. Fires exactly once and clears the capture. Also drained on `FOCUS_OUT` and lost-release recovery so that aborted drags can't leave a dangling handler.
+
+**Propagation**: does NOT bubble. Routes directly to the captured `onUp`.
+
+## GestureHandlers
+
+Type passed to `MouseDownEvent.captureGesture`.
+
+```ts
+type GestureHandlers = {
+  onMove?: (event: MouseMoveEvent) => void
+  onUp?: (event: MouseUpEvent) => void
+}
+```
+
+## KeyboardEvent
+
+Bubbling key event, follows browser `KeyboardEvent` semantics. Source: `events/keyboard-event.ts`. Extends `TerminalEvent`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `'keydown'` | Always `'keydown'`. |
+| `key` | `string` | Literal char for printable keys (`'a'`, `'3'`, `' '`, `'/'`); multi-char name for special keys (`'down'`, `'return'`, `'escape'`, `'f1'`). The idiomatic printable check is `e.key.length === 1`. |
+| `ctrl` | `boolean` | Ctrl held. |
+| `shift` | `boolean` | Shift held. |
+| `meta` | `boolean` | Meta or Option/Alt held. |
+| `superKey` | `boolean` | Super (Cmd / Win key). Only delivered via kitty keyboard protocol CSI u sequences. |
+| `fn` | `boolean` | Fn key held. |
+| `bubbles` | `true` | Inherited. |
+| `cancelable` | `true` | Inherited. |
+| `target`, `currentTarget`, `eventPhase`, `timeStamp`, `defaultPrevented` | inherited from `TerminalEvent` | |
+
+**Methods**: `stopPropagation()`, `stopImmediatePropagation()`, `preventDefault()`.
+
+**Fires when**: each parsed keypress on stdin, dispatched at the focused element (or the root when nothing is focused).
+
+**Propagation**: capture from root → target, then bubble target → root. Bound via `onKeyDown` / `onKeyDownCapture` props on `<Box>`.
+
+## FocusEvent
+
+Component focus change. Source: `events/focus-event.ts`. Extends `TerminalEvent`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `'focus' \| 'blur'` | `'focus'` on the newly focused node; `'blur'` on the previously focused node. |
+| `relatedTarget` | `EventTarget \| null` | The other side of the focus transition. |
+| `bubbles` | `true` | Matches react-dom's focusin/focusout — parents observe descendant focus changes. |
+| `cancelable` | `false` | `preventDefault()` is a no-op. |
+
+**Methods**: `stopPropagation()`, `stopImmediatePropagation()`.
+
+**Fires when**: focus moves between elements via `useFocusManager`, `<FocusGroup>` arrow nav, `<Tab>`, or imperative `focus()`.
+
+**Propagation**: capture, then bubble. Bound via `onFocus` / `onFocusCapture` / `onBlur` / `onBlurCapture`.
+
+## InputEvent
+
+Lower-level keypress wrapper used by `useInput`. Source: `events/input-event.ts`. Extends `Event` (not `TerminalEvent`).
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `keypress` | `ParsedKey` | Raw parsed-keypress shape from `parse-keypress.ts`. |
+| `key` | `Key` | Bag of booleans (see below). |
+| `input` | `string` | Printable text payload, if any. Empty string for special keys. |
+
+**Methods**: `stopImmediatePropagation()`.
+
+**Fires when**: each parsed keypress, before `KeyboardEvent` dispatch. Delivered to `useInput(handler)` subscribers.
+
+**Propagation**: not DOM-routed. Subscriber list runs in registration order.
+
+### Key
+
+Booleans on `InputEvent.key`. Source: `events/input-event.ts`.
+
+| Field | Trigger |
+|-------|---------|
+| `upArrow`, `downArrow`, `leftArrow`, `rightArrow` | Arrow keys. |
+| `pageUp`, `pageDown` | PgUp / PgDn. |
+| `wheelUp`, `wheelDown` | Mouse wheel scroll (when mouse tracking active). |
+| `home`, `end` | Home / End. |
+| `return` | Enter. |
+| `escape` | Esc. |
+| `tab` | Tab. |
+| `backspace`, `delete` | Backspace / Delete. |
+| `ctrl`, `shift`, `meta`, `super`, `fn` | Modifier flags. `meta` covers Alt/Option; `super` covers Cmd/Win (kitty protocol only). |
+
+## TerminalFocusEvent
+
+Terminal window focus change via DECSET 1004 reporting. Source: `events/terminal-focus-event.ts`. Extends `Event`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `type` | `'terminalfocus' \| 'terminalblur'` | Window-level focus state. |
+
+**Methods**: `stopImmediatePropagation()`.
+
+**Fires when**: terminal sends `CSI I` (focus, `\x1b[I`) or `CSI O` (blur, `\x1b[O`). Requires DECSET 1004 enabled — typically inside `<AlternateScreen>` or via `useTerminalFocus`.
+
+**Propagation**: not DOM-routed. Delivered via `useTerminalFocus`.
+
+## PasteEvent
+
+Bracketed-paste payload. Source: `events/paste-event.ts`. Extends `Event`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `text` | `string` | Pasted text, with bracket markers stripped. |
+
+**Methods**: `stopImmediatePropagation()`.
+
+**Fires when**: terminal sends a bracketed-paste sequence (`\x1b[200~ … \x1b[201~`).
+
+**Propagation**: bound on `<Box>` via `onPaste` / `onPasteCapture`. Capture then bubble through the focused subtree.
+
+## ResizeEvent
+
+Terminal resize. Source: `events/resize-event.ts`. Extends `Event`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `columns` | `number` | New terminal column count. |
+| `rows` | `number` | New terminal row count. |
+
+**Methods**: `stopImmediatePropagation()`.
+
+**Fires when**: SIGWINCH on the controlling stdout. Bound via `onResize` on `<Box>` (bubble only) or read reactively via `useTerminalViewport`.
+
+**Propagation**: bubble only.
+
+## Dispatcher and priority
+
+The dispatcher (`events/dispatcher.ts`) collects listeners in capture-then-bubble order, walking `parentNode` from target to root. Capture handlers are unshifted (root first), bubble handlers appended (target first).
+
+Event types map to React scheduling priorities:
+
+| Priority | Events |
+|----------|--------|
+| Discrete (sync) | `keydown`, `keyup`, `click`, `focus`, `blur`, `paste` |
+| Continuous | `resize`, `scroll`, `mousemove` |
+| Default | everything else |
+
+## Handler props on `<Box>`
+
+Source: `events/event-handlers.ts`.
+
+| Prop | Phase | Event |
+|------|-------|-------|
+| `onKeyDown` / `onKeyDownCapture` | bubble / capture | `KeyboardEvent` |
+| `onFocus` / `onFocusCapture` | bubble / capture | `FocusEvent` |
+| `onBlur` / `onBlurCapture` | bubble / capture | `FocusEvent` |
+| `onPaste` / `onPasteCapture` | bubble / capture | `PasteEvent` |
+| `onResize` | bubble | `ResizeEvent` |
+| `onClick` | bubble | `ClickEvent` |
+| `onMouseDown` | bubble | `MouseDownEvent` |
+| `onMouseEnter`, `onMouseLeave` | — | `() => void` (no event arg) |


### PR DESCRIPTION
Phase 2 of the docs build-out. Adds 20 pages, bringing docs/ to 78 total.

## What's added

- **`internals/`** (7) — renderer subsystem deep-dives for contributors and advanced consumers: architecture, reconciler, yoga-port, render-pipeline, selection-state-machine, drag-registry, focus-manager.
- **`patterns/`** (6 more) — table, file-tree, log-viewer, chat-ui, confirmation-dialog, indicators (spinners + progress bars). Doubles pattern count to 12.
- **`guides/`** (3 more) — accessibility, streaming-content, error-handling. Doubles guide count to 6.
- **`reference/`** (2 more) — events.md (every event class with full shape), cli.md (render / renderSync / createRoot + Root API).
- **Meta** (2) — faq.md, changelog.md.
- **`docs/README.md`** updated to index the new pages.

## How it was written

Same playbook as Phase 1: 5 sub-agents in parallel under the strict style guide (terse, no marketing prose, no emojis, no "TL;DR" sections, banned word list enforced, source-grounded).

Manual review pass:
- Banned words: zero hits in new content.
- Cross-links: 2 case-mismatches fixed (`components/FocusGroup.md` → `focus-group.md`; `components/ScrollBox.md` → `scrollbox.md`).
- Made-up APIs: 1 stale reference fixed (`useCopyOnSelect` is not a yokai export — it's a consumer pattern; corrected to point at `useSelection().copy`).

## Granular commits (5)

1. `docs(internals): renderer subsystem deep-dives`
2. `docs(patterns): six more recipes`
3. `docs(guides): accessibility, streaming-content, error-handling`
4. `docs(reference+meta): events, cli, faq, changelog`
5. `docs(README): index Phase 2 additions`

## What's still deferred

- `terminals.md` matrix expansion — needs real testing across terminals (vscode, iTerm2, Kitty, Windows Terminal, tmux, conhost). I haven't run yokai across all of them; expanding without testing would invent compatibility claims.

## Test plan

- [x] All 20 expected files present
- [x] Banned words audited
- [x] Cross-links resolve (2 fixed)
- [x] No made-up APIs (1 stale ref fixed)
- [x] docs/README.md indexes everything
- [ ] Skim review by you for tone / accuracy