### PR TITLE
chore(release): v0.5.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Each demo lives in `examples/` and is a small `.tsx` file you can read top-to-bo
 ```jsonc
 // package.json
 "dependencies": {
-  "@yokai/renderer": "github:re-marked/yokai#v0.5.0"
+  "@yokai/renderer": "github:re-marked/yokai#v0.5.1"
 }
 ```
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,16 @@
 
 Tagged releases of `@yokai/renderer` and `@yokai/shared`. The full commit graph is preserved on `main` — `git log vPREV..vNEXT` shows everything between any two tags.
 
+## v0.5.1 — 2026-04-27
+
+Documentation. No code changes.
+
+**Added**
+
+- `docs/` build-out: 78 pages covering install, concepts, components, hooks, patterns, guides, internals, reference, plus `AGENTS.md`, `troubleshooting.md`, `faq.md`, this changelog.
+- README gains a Keyboard navigation section with `<FocusGroup>` + `<FocusRing>` example and pointers at `useFocus` / `useFocusManager`.
+- Main README links to `docs/` for full reference.
+
 ## v0.5.0 — 2026-04-27
 
 Keyboard focus and arrow navigation. [GitHub release](https://github.com/re-marked/yokai/releases/tag/v0.5.0).

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yokai",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "private": true,
   "description": "React terminal renderer — pure TypeScript Yoga layout, diff-based rendering, ScrollBox",
   "license": "MIT",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yokai/renderer",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "React terminal renderer — reconciler + Yoga layout + TTY output",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yokai/shared",
-  "version": "0.5.0",
+  "version": "0.5.1",
   "description": "Shared utilities — Yoga layout TS port, logger, env helpers",
   "license": "MIT",
   "main": "./dist/index.js",


### PR DESCRIPTION
Patch bump. No code changes since v0.5.0.

Exists to tag the documentation build-out (PRs #29, #30, #31) so consumers can pin against a version whose docs match the source — `github:re-marked/yokai#v0.5.1` now resolves to a tag with 78 pages of `docs/` covering everything shipped through v0.5.x.

## Changes

- `@yokai/renderer`, `@yokai/shared`, root: `0.5.0` → `0.5.1`
- README consumption pin: `v0.5.0` → `v0.5.1`
- `docs/changelog.md`: new `v0.5.1` entry summarising the docs work

## Test plan

- [x] All tests still pass (no code changes)
- [x] `pnpm -r typecheck`
- [ ] Tag `v0.5.1` after merge