### PR TITLE
feat(TextInput): scroll polish + chore(release): v0.6.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,5 @@ yarn.lock
 .turbo/
 .env
 .env.*
+
+/roadmap.md

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ render(<App />)
 
 **`<FocusRing>`** — focusable Box with built-in focus-visible border indicator (default `cyan` border on focus). Pair with `<FocusGroup>` for keyboard-navigable lists / menus.
 
-**`<TextInput>`** — editable text. Single-line or multiline. Caret via the real terminal cursor (IME / a11y correct). Smart bracketed paste, undo/redo, word nav, selection, password masking. See [docs/components/text-input.md](./docs/components/text-input.md).
+**`<TextInput>`** — editable text. Single-line or multiline. Caret via the real terminal cursor (IME / a11y correct). Smart bracketed paste, undo/redo, word nav, selection, password masking. Focus-color border by default (configurable via `borderColorFocus`). See [docs/components/text-input.md](./docs/components/text-input.md).
 
 ## ScrollBox API
 

--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ Each demo lives in `examples/` and is a small `.tsx` file you can read top-to-bo
 ```jsonc
 // package.json
 "dependencies": {
-  "@yokai/renderer": "github:re-marked/yokai#v0.5.1"
+  "@yokai/renderer": "github:re-marked/yokai#v0.6.0"
 }
 ```
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -2,6 +2,28 @@
 
 Tagged releases of `@yokai/renderer` and `@yokai/shared`. The full commit graph is preserved on `main` — `git log vPREV..vNEXT` shows everything between any two tags.
 
+## v0.6.0 — 2026-04-27
+
+`<TextInput>` and smart bracketed paste — closes the largest missing primitive in yokai. [GitHub release](https://github.com/re-marked/yokai/releases/tag/v0.6.0).
+
+**Added**
+
+- **`<TextInput>`** — editable text. Single-line and multiline modes; controlled and uncontrolled value; placeholder, password, maxLength, disabled, autoFocus, selectionColor, historyCap props. Caret positioned via `useDeclaredCursor` (real terminal cursor — IME / a11y correct). Editing keybindings: type / Backspace / Delete / arrows / Home/End / Ctrl+arrows (word nav) / Ctrl+W / Ctrl+U / Ctrl+K / Ctrl+A / Ctrl+Z / Ctrl+Y / Ctrl+Shift+Z. Selection via Shift+arrows or mouse drag. `onSubmit` (Enter / Ctrl+Enter), `onCancel` (Escape).
+- **`PasteEvent`** — bubbling, cancelable terminal event upgraded from a stub `Event` subclass to full `TerminalEvent` shape. `onPaste` / `onPasteCapture` props on `<Box>`.
+- **Smart bracketed-paste split** — `App.handleParsedInput` splits pastes by length: ≤ threshold dispatches per-character keypresses (short pastes feel like typing); > threshold fires once as `PasteEvent` plus once via `useInput` (backwards compat).
+- **`<AlternateScreen pasteThreshold>`** — configurable threshold, default 32 characters.
+- **`scrollToKeepCaretVisible` + `sliceRowByCells`** — pure scroll helpers used by TextInput's horizontal/vertical scroll.
+
+**Changed**
+
+- `<FocusGroup>` switched from `useInput` to `onKeyDown` so a focused descendant (e.g. `<TextInput>`) can `preventDefault()` arrow keys to consume them for caret movement instead of focus navigation.
+- `<TextInput>` (within v0.6.0): horizontal scroll for single-line content longer than the box width; vertical scroll for multiline content taller than the box height. Caret stays visible after every edit.
+
+**Internal**
+
+- New module structure under `packages/renderer/src/components/TextInput/` — pure state machine (`state.ts`), pure caret math (`caret-math.ts`), pure scroll math (`scroll-math.ts`), thin React shell (`TextInput.tsx`).
+- `PasteContext` lets `<AlternateScreen>` push the paste threshold into App's instance field outside React's render flow.
+
 ## v0.5.1 — 2026-04-27
 
 Documentation. No code changes.

--- a/docs/components/text-input.md
+++ b/docs/components/text-input.md
@@ -88,13 +88,17 @@ const [name, setName] = useState('')
 - **Undo grouping.** Consecutive same-kind insertions or deletions merge into one undo step (a typed word is one Ctrl+Z, not N). Pastes are always their own step.
 - **Wide chars.** Caret math counts CJK / wide chars as 2 cells, combining marks as 0. Click positioning snaps to the LEFT edge of a wide char if the click lands mid-glyph.
 
+## Scrolling
+
+- **Single-line**: when content exceeds the box width, the visible window scrolls horizontally so the caret stays in view. Wide chars at the visible edges render as spaces to keep cell layout stable; selection highlight on a horizontally-scrolled wide char is rendered approximately.
+- **Multiline**: when content exceeds the box height, the visible window scrolls vertically so the caret line stays in view. Each visible line truncates if it exceeds the inner width.
+- The inner content area is read from yoga's computed size minus padding + border, so `width` / `height` props refer to the OUTER box. If you don't pass `width` / `height`, no scrolling — content fills the box's natural size.
+
 ## Known limitations
 
-Slated for the follow-up PR:
-- No horizontal scroll for single-line content longer than the box width (truncates).
-- No vertical scroll for multiline content taller than the box (overflows).
-- IME composition is not yet handled — multi-byte composition sequences from CJK / Korean IMEs may produce intermediate state.
-- `disabled` is honored for keystrokes but not for paste / mouse drag.
+- IME composition is not yet handled — multi-byte composition sequences from CJK / Korean IMEs may produce intermediate state. Committed text works correctly.
+- Selection highlight may render approximately when it crosses a horizontally-scrolled wide character boundary.
+- Click positioning doesn't subtract padding/border from the click coordinates — clicks within padding may snap to the wrong char by the padding amount.
 
 ## Related
 - [Keyboard concept](../concepts/keyboard.md)

--- a/docs/components/text-input.md
+++ b/docs/components/text-input.md
@@ -25,6 +25,7 @@ Component-specific props. All `<Box>` props are accepted EXCEPT `onKeyDown`, `on
 | `passwordChar` | `string` | `'•'` | Mask character for `password` mode. |
 | `disabled` | `boolean` | `false` | Ignore keystrokes. The input still claims focus. |
 | `selectionColor` | `Color` | `'cyan'` | Background of the selection highlight. |
+| `borderColorFocus` | `Color` | `'cyan'` | Border color while focused. Swaps `borderColor` on focus, reverts on blur. No-op when no `borderStyle` is set. To opt out, pass the same value as `borderColor`. |
 | `autoFocus` | `boolean` | `false` | Focus on mount. |
 | `historyCap` | `number` | `100` | Max undo entries. Older entries drop. |
 
@@ -54,6 +55,28 @@ const [name, setName] = useState('')
 ### Password
 ```tsx
 <TextInput value={pw} onChange={setPw} password />
+```
+
+### Custom focus color
+```tsx
+<TextInput
+  value={query}
+  onChange={setQuery}
+  borderStyle="round"
+  borderColor="gray"      // idle
+  borderColorFocus="green" // focused
+/>
+```
+
+### Disable focus chrome (use a sibling indicator instead)
+```tsx
+<TextInput
+  value={x}
+  onChange={setX}
+  borderStyle="round"
+  borderColor="gray"
+  borderColorFocus="gray" // same as idle → no swap
+/>
 ```
 
 ## Key bindings

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yokai",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "private": true,
   "description": "React terminal renderer — pure TypeScript Yoga layout, diff-based rendering, ScrollBox",
   "license": "MIT",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yokai/renderer",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "React terminal renderer — reconciler + Yoga layout + TTY output",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/packages/renderer/src/components/App.tsx
+++ b/packages/renderer/src/components/App.tsx
@@ -620,7 +620,12 @@ function processKeysInBatch(
       // createPasteKey in parse-keypress.ts; the union-side undefined
       // is for non-paste keys. Default to '' for total safety.
       const text = item.sequence ?? ''
-      if (text.length <= app.pasteThreshold) {
+      // Short pastes (1..threshold cells) split into per-char keypresses
+      // so they feel like typing. Empty pastes (text === '') skip this
+      // branch — a zero-iteration for-loop would emit no events at all,
+      // and a parser-emitted explicit empty paste should still surface
+      // through the paste pipeline so consumers can detect it.
+      if (text.length > 0 && text.length <= app.pasteThreshold) {
         for (const char of text) {
           // Each char becomes a regular keypress with isPasted=false so
           // downstream code can't tell it apart from typed input.
@@ -643,9 +648,11 @@ function processKeysInBatch(
         }
         continue
       }
+      // Long-paste branch (also taken by empty pastes): one PasteEvent
+      // through the DOM and one InputEvent for useInput backwards
+      // compat. PasteEvent.text is '' on empty so subscribers can
+      // observe the paste action without receiving spurious content.
       app.props.dispatchPasteEvent(text)
-      // Backwards compat: useInput consumers still see the full paste
-      // string in one shot, with `key.isPasted` set so they can branch.
       app.handleInput(sequence)
       app.internal_eventEmitter.emit('input', new InputEvent(item))
       continue

--- a/packages/renderer/src/components/FocusGroup.tsx
+++ b/packages/renderer/src/components/FocusGroup.tsx
@@ -80,8 +80,20 @@ export default function FocusGroup({
   const ref = useRef<DOMElement>(null)
   const { focused, focus } = useFocusManager()
 
+  // Extract the user's onKeyDown so we can chain it. The previous
+  // version spread `{...boxProps}` and then unconditionally set
+  // `onKeyDown={onKeyDown}`, silently dropping any user-supplied
+  // handler. That broke shortcut handlers, analytics, etc. that
+  // expected Box's full prop surface to pass through.
+  const { onKeyDown: userOnKeyDown, ...restBoxProps } = boxProps
+
   const onKeyDown = useCallback(
     (e: KeyboardEvent) => {
+      // User handler runs first so a shortcut can preventDefault and
+      // suppress nav (mirrors how a focused descendant preempts us
+      // via preventDefault — same convention).
+      userOnKeyDown?.(e)
+
       if (!isActive) return
       if (e.defaultPrevented) return // a focused descendant claimed the key
       const node = ref.current
@@ -119,11 +131,11 @@ export default function FocusGroup({
         focus(target)
       }
     },
-    [direction, wrap, isActive, focused, focus],
+    [direction, wrap, isActive, focused, focus, userOnKeyDown],
   )
 
   return (
-    <Box ref={ref} {...boxProps} onKeyDown={onKeyDown}>
+    <Box ref={ref} {...restBoxProps} onKeyDown={onKeyDown}>
       {children}
     </Box>
   )

--- a/packages/renderer/src/components/TextInput/TextInput.tsx
+++ b/packages/renderer/src/components/TextInput/TextInput.tsx
@@ -71,6 +71,21 @@ export type TextInputProps = Except<
   /** Selection background color. Default the renderer's terminal-default
    *  selection background (typically inverse). */
   selectionColor?: Color
+  /**
+   * Border color when the input is focused. Default `'cyan'`.
+   *
+   * The input swaps its `borderColor` for this value while focused,
+   * and reverts to the idle color (whatever was passed via
+   * `borderColor`, or the terminal default) on blur. Requires a
+   * `borderStyle` to be set — without a border there's nothing to
+   * color, so the swap is a no-op.
+   *
+   * To opt out of the focus-color swap (e.g. when focus is indicated
+   * elsewhere — a status bar, a sibling chrome element), pass the
+   * same value as `borderColor`. Setting both to the same value
+   * keeps the border static across focus transitions.
+   */
+  borderColorFocus?: Color
   /** Auto-focus on mount. */
   autoFocus?: boolean
   /** Maximum history entries kept for undo/redo. Default 100. */
@@ -116,6 +131,7 @@ export default function TextInput({
   passwordChar = '•',
   disabled = false,
   selectionColor = 'cyan',
+  borderColorFocus = 'cyan',
   autoFocus = false,
   historyCap,
   ...boxProps
@@ -458,16 +474,26 @@ export default function TextInput({
     ],
   )
 
+  // Focus-aware border color. Extract idle borderColor from boxProps so
+  // we can compute the swapped value cleanly (avoids passing both via
+  // spread + override). When focused, paint with `borderColorFocus`;
+  // otherwise fall through to whatever the consumer provided as the
+  // idle `borderColor` (or terminal default if undefined). The swap is
+  // a no-op when no `borderStyle` is set — there's no border to color.
+  const { borderColor: idleBorderColor, ...restBoxProps } = boxProps
+  const renderedBorderColor = isFocused ? borderColorFocus : idleBorderColor
+
   return (
     <Box
-      {...boxProps}
+      {...restBoxProps}
       ref={setRef}
-      tabIndex={boxProps.tabIndex ?? 0}
+      tabIndex={restBoxProps.tabIndex ?? 0}
       autoFocus={autoFocus}
       onKeyDown={handleKeyDown}
       onPaste={handlePaste}
       onMouseDown={handleMouseDown}
       flexDirection="column"
+      borderColor={renderedBorderColor}
     >
       {renderedLines}
     </Box>

--- a/packages/renderer/src/components/TextInput/TextInput.tsx
+++ b/packages/renderer/src/components/TextInput/TextInput.tsx
@@ -119,27 +119,30 @@ export default function TextInput({
   ...boxProps
 }: PropsWithChildren<TextInputProps>): React.ReactNode {
   const isControlled = value !== undefined
+
+  // optsRef MUST be declared before useReducer. On a render that has
+  // queued dispatches, useReducer drains them by calling the reducer
+  // immediately — which reads optsRef.current. With the ref declared
+  // AFTER useReducer in render order, the reducer would hit a TDZ
+  // ("Cannot access 'optsRef' before initialization") when the React
+  // Compiler-transformed code re-enters this scope.
+  const optsRef = useRef<ReducerOptions>({ multiline, maxLength, historyCap })
+  // Mutate inline so the next dispatch sees the latest options without
+  // a re-renders-update-state-before-effects round trip.
+  optsRef.current = { multiline, maxLength, historyCap }
+
+  // Reducer bridge — the React-shape (state, action) => state, closing
+  // over the ref so opts changes propagate to the next dispatch.
+  const reducerWithOpts = useCallback(
+    (s: TextInputState, a: Action): TextInputState => reduce(s, a, optsRef.current),
+    [],
+  )
+
   const [state, dispatch] = useReducer(
     reducerWithOpts,
     isControlled ? value : (defaultValue ?? ''),
     initialState,
   )
-
-  // Keep reducer options stable per-render so the dispatcher and
-  // event handlers see consistent multiline/maxLength even mid-event.
-  const opts: ReducerOptions = useMemo(
-    () => ({ multiline, maxLength, historyCap }),
-    [multiline, maxLength, historyCap],
-  )
-  const optsRef = useRef(opts)
-  optsRef.current = opts
-
-  // Bridge: dispatch invokes reduce with the current opts ref.
-  // The reducer signature React expects is (state, action) => state,
-  // so we close over the latest opts via the ref.
-  function reducerWithOpts(s: TextInputState, a: Action): TextInputState {
-    return reduce(s, a, optsRef.current)
-  }
 
   // Controlled mode: when external `value` differs from internal,
   // reset state to the new value. Clearing history is intentional —

--- a/packages/renderer/src/components/TextInput/TextInput.tsx
+++ b/packages/renderer/src/components/TextInput/TextInput.tsx
@@ -160,9 +160,7 @@ export default function TextInput({
   // from THAT — meaning the parent set value externally, not just
   // hasn't echoed yet. onChange skips if state matches the ref —
   // meaning the change came FROM a sync, not a user edit.
-  const lastReportedValue = useRef<string>(
-    isControlled ? value! : (defaultValue ?? ''),
-  )
+  const lastReportedValue = useRef<string>(isControlled ? value! : (defaultValue ?? ''))
 
   // Sync internal state when the parent SETS value to something we
   // didn't just report. Deps are [value] only — state.value would
@@ -170,6 +168,7 @@ export default function TextInput({
   // The closure-captured state.value is fine for the no-op skip
   // because if state.value already matches the new prop value, we
   // don't need to dispatch.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: state.value is read for an idempotency check only — including it would re-fire the sync on every keystroke and break the controlled-mode loop guard above.
   useEffect(() => {
     if (!isControlled) return
     if (value === lastReportedValue.current) return // we reported this
@@ -179,7 +178,6 @@ export default function TextInput({
     // external set isn't a user-undoable edit.
     dispatch({ type: 'selectAll' })
     dispatch({ type: 'insertText', text: value!, isPaste: false })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [isControlled, value])
 
   // Fire onChange when internal state diverges from the last reported

--- a/packages/renderer/src/components/TextInput/TextInput.tsx
+++ b/packages/renderer/src/components/TextInput/TextInput.tsx
@@ -2,6 +2,7 @@ import type React from 'react'
 import {
   type PropsWithChildren,
   useCallback,
+  useContext,
   useEffect,
   useLayoutEffect,
   useMemo,
@@ -18,6 +19,7 @@ import { useDeclaredCursor } from '../../hooks/use-declared-cursor.js'
 import { LayoutEdge } from '../../layout/node.js'
 import type { Color } from '../../styles.js'
 import Box, { type Props as BoxProps } from '../Box.js'
+import FocusContext from '../FocusContext.js'
 import Text from '../Text.js'
 import { cellColumnAt, splitLines } from './caret-math.js'
 import { scrollToKeepCaretVisible, sliceRowByCells } from './scroll-math.js'
@@ -275,11 +277,26 @@ export default function TextInput({
     scrollY,
   ])
 
+  // Subscribe to focus state via FocusContext. The earlier shortcut
+  // `ref.current.focusManager?.activeElement === ref.current` was
+  // always false because `focusManager` lives only on the root node
+  // (per `dom.ts` — "any node can reach it by walking parentNode").
+  // That left `isFocused` permanently false, so the terminal cursor
+  // never declared as active and the user saw no caret. Subscribe via
+  // the manager so we re-render when this element gains/loses focus.
+  const focusCtx = useContext(FocusContext)
+  const [isFocused, setIsFocused] = useState(false)
+  useEffect(() => {
+    const node = ref.current
+    if (!node || !focusCtx) return
+    setIsFocused(focusCtx.manager.activeElement === node)
+    return focusCtx.manager.subscribeToFocus(node, setIsFocused)
+  }, [focusCtx])
+
   // Declare the terminal cursor at the caret, adjusted for scroll
   // offsets so it lands on the visible cell. The hook only renders
   // the cursor when `active` is true — we're active iff this is the
   // focused element.
-  const isFocused = ref.current?.focusManager?.activeElement === ref.current
   const cursorRef = useDeclaredCursor({
     line: caretLineCol.line - scrollY,
     column: caretLineCol.col - scrollX,
@@ -352,6 +369,16 @@ export default function TextInput({
   const handleMouseDown = useCallback(
     (e: MouseDownEvent) => {
       if (disabled) return
+      // Manually focus on press. The default click-to-focus path lives
+      // in `dispatchClick` (hit-test.ts) — but capturing a gesture in
+      // onMouseDown short-circuits the release-side dispatchClick (see
+      // App.handleMouseEvent's release branch: when `activeGesture` is
+      // set it fires onUp and returns early, never calling onClickAt).
+      // Without this manual call, clicking a TextInput would never
+      // focus it, and Tab would be the only way to land in.
+      const node = ref.current
+      if (focusCtx && node) focusCtx.manager.focus(node)
+
       // Click coords are local to the Box (0-indexed from its top-left
       // INCLUDING padding/border). The visible content starts at
       // (scrollX, scrollY) within the buffer, so add the scroll
@@ -382,7 +409,7 @@ export default function TextInput({
         },
       })
     },
-    [disabled, state.value, password, passwordChar, scrollX, scrollY],
+    [disabled, state.value, password, passwordChar, scrollX, scrollY, focusCtx],
   )
 
   // ── Rendering ─────────────────────────────────────────────────────

--- a/packages/renderer/src/components/TextInput/TextInput.tsx
+++ b/packages/renderer/src/components/TextInput/TextInput.tsx
@@ -343,17 +343,25 @@ export default function TextInput({
         return
       }
       // Plain printable keystroke: insert. KeyboardEvent.key is the
-      // literal char for printables; multi-char `key` means a special
-      // key we already handled above. Skip ctrl/meta combos (consumer
-      // may bind them at a higher level).
+      // literal char for printables; multi-character special keys
+      // (e.g. 'left', 'backspace') would have been handled above by
+      // keyToAction. Skip ctrl/meta combos — consumer may bind them
+      // at a higher level.
       if (e.ctrl || e.meta) return
       const ch = e.key
-      if (!ch || ch.length !== 1) return
+      if (!ch) return
+      // Single-grapheme guard. Counted in CODE POINTS, not UTF-16
+      // units, so non-BMP printables (most emoji — '😀'.length is 2
+      // because of the surrogate pair, but [...'😀'].length is 1)
+      // pass through. Multi-grapheme `key` strings (the named special
+      // keys above) are filtered out here.
+      if ([...ch].length !== 1) return
       // Drop non-printable (control) chars silently. Anything < 0x20
-      // except \t we treat as non-text. (Newlines come through as
-      // `key === 'return'` and are handled in keyToAction's submit
-      // branch above.)
-      const code = ch.charCodeAt(0)
+      // except \t we treat as non-text. Surrogate-pair emoji land far
+      // above 0x20 in their full code point, so this gate doesn't
+      // affect them. (Newlines come through as `key === 'return'`
+      // and are handled in keyToAction's submit branch above.)
+      const code = ch.codePointAt(0) ?? 0
       if (code < 0x20 && ch !== '\t') return
       e.preventDefault()
       dispatch({ type: 'insertText', text: ch })

--- a/packages/renderer/src/components/TextInput/TextInput.tsx
+++ b/packages/renderer/src/components/TextInput/TextInput.tsx
@@ -144,28 +144,46 @@ export default function TextInput({
     initialState,
   )
 
-  // Controlled mode: when external `value` differs from internal,
-  // reset state to the new value. Clearing history is intentional —
-  // arbitrary external sets shouldn't be undoable as if they were
-  // user edits. Skip when undefined (uncontrolled).
+  // Controlled-mode loop avoidance: track the last value we reported
+  // (or were initialized with). The two effects below use this single
+  // ref to avoid the classic ping-pong where:
+  //   - user types → state updates → onChange fires
+  //   - parent setState updates the prop
+  //   - sync sees prop !== state, resets state to prop
+  //   - onChange fires again with the reset value
+  //   - parent setState again → infinite loop at 60Hz.
+  //
+  // The ref records "what the parent's value prop should be after
+  // they echo our last report." Sync only fires when the prop differs
+  // from THAT — meaning the parent set value externally, not just
+  // hasn't echoed yet. onChange skips if state matches the ref —
+  // meaning the change came FROM a sync, not a user edit.
+  const lastReportedValue = useRef<string>(
+    isControlled ? value! : (defaultValue ?? ''),
+  )
+
+  // Sync internal state when the parent SETS value to something we
+  // didn't just report. Deps are [value] only — state.value would
+  // re-fire this effect on every keystroke, defeating the loop guard.
+  // The closure-captured state.value is fine for the no-op skip
+  // because if state.value already matches the new prop value, we
+  // don't need to dispatch.
   useEffect(() => {
     if (!isControlled) return
-    if (value === state.value) return
-    dispatch({ type: 'setCaret', charIdx: value!.length, extend: false })
-    // Resetting the buffer requires bypassing the reducer because
-    // the reducer doesn't have a "set value" action (intentionally —
-    // we want all edits to flow through actions). Reset by replacing
-    // through a synthetic insertText action that selects-all-then-
-    // inserts. Simpler: dispatch select-all then insert.
-    // Actually: do this via a one-shot init reset.
+    if (value === lastReportedValue.current) return // we reported this
+    if (value === state.value) return // already in sync somehow
+    lastReportedValue.current = value!
+    // Replace selection-all with insert; clears history because an
+    // external set isn't a user-undoable edit.
     dispatch({ type: 'selectAll' })
     dispatch({ type: 'insertText', text: value!, isPaste: false })
-  }, [isControlled, value, state.value])
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [isControlled, value])
 
-  // Fire onChange when internal value changes from a user action. Skip
-  // when value matches the controlled prop (echo). useRef avoids
-  // re-firing during the controlled-sync above.
-  const lastReportedValue = useRef(state.value)
+  // Fire onChange when internal state diverges from the last reported
+  // value (i.e. user-initiated change). Skip if the change came from
+  // the controlled-sync effect above — that path updates
+  // lastReportedValue first, so this comparison short-circuits.
   useEffect(() => {
     if (state.value === lastReportedValue.current) return
     lastReportedValue.current = state.value

--- a/packages/renderer/src/components/TextInput/TextInput.tsx
+++ b/packages/renderer/src/components/TextInput/TextInput.tsx
@@ -1,15 +1,26 @@
 import type React from 'react'
-import { type PropsWithChildren, useCallback, useEffect, useMemo, useReducer, useRef } from 'react'
+import {
+  type PropsWithChildren,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useReducer,
+  useRef,
+  useState,
+} from 'react'
 import type { Except } from 'type-fest'
 import type { DOMElement } from '../../dom.js'
 import type { KeyboardEvent } from '../../events/keyboard-event.js'
 import type { MouseDownEvent } from '../../events/mouse-event.js'
 import type { PasteEvent } from '../../events/paste-event.js'
 import { useDeclaredCursor } from '../../hooks/use-declared-cursor.js'
+import { LayoutEdge } from '../../layout/node.js'
 import type { Color } from '../../styles.js'
 import Box, { type Props as BoxProps } from '../Box.js'
 import Text from '../Text.js'
 import { cellColumnAt, splitLines } from './caret-math.js'
+import { scrollToKeepCaretVisible, sliceRowByCells } from './scroll-math.js'
 import {
   type Action,
   type ReducerOptions,
@@ -178,17 +189,79 @@ export default function TextInput({
     return { line: lines.length - 1, col: cellColumnAt(lines[lines.length - 1]!, 0) }
   }, [state.value, state.caret])
 
-  // Declare the terminal cursor at the caret. The hook only renders
+  // ── Scroll: keep caret visible inside the visible window ───────────
+  //
+  // Two axes; only one applies per mode. Single-line: horizontal,
+  // measured in cells across the inner content area. Multiline:
+  // vertical, measured in rows across the inner content area.
+  //
+  // Inner content size is read from yoga via measureInnerSize() each
+  // commit. Read in useLayoutEffect so the value is fresh enough to
+  // matter for the next render — yoga's value is one frame stale
+  // (calculateLayout runs after this effect), but for typing the lag
+  // is invisible because each keystroke triggers another render that
+  // catches up.
+  const [inner, setInner] = useState({ width: 0, height: 0 })
+  useLayoutEffect(() => {
+    const node = ref.current
+    if (!node?.yogaNode) return
+    const measured = measureInnerSize(node)
+    if (measured.width !== inner.width || measured.height !== inner.height) {
+      setInner(measured)
+    }
+  })
+
+  const [scrollX, setScrollX] = useState(0)
+  const [scrollY, setScrollY] = useState(0)
+  const allLines = useMemo(() => splitLines(state.value), [state.value])
+  // Total content size. Single-line: cells of the only line.
+  // Multiline: row count.
+  const contentWidth = multiline ? 0 : cellColumnAt(allLines[0]!, allLines[0]!.length)
+  const contentHeight = allLines.length
+
+  // Adjust scroll on every state/size change so the caret stays in
+  // view. useEffect (not useLayoutEffect) so the next paint reflects
+  // both the new caret AND the new scroll in the same render — React
+  // batches the setState here with the original cause.
+  useEffect(() => {
+    if (!multiline && inner.width > 0) {
+      const next = scrollToKeepCaretVisible({
+        scroll: scrollX,
+        caretPos: caretLineCol.col,
+        windowSize: inner.width,
+        contentSize: Math.max(contentWidth, caretLineCol.col + 1),
+      })
+      if (next !== scrollX) setScrollX(next)
+    }
+    if (multiline && inner.height > 0) {
+      const next = scrollToKeepCaretVisible({
+        scroll: scrollY,
+        caretPos: caretLineCol.line,
+        windowSize: inner.height,
+        contentSize: Math.max(contentHeight, caretLineCol.line + 1),
+      })
+      if (next !== scrollY) setScrollY(next)
+    }
+  }, [
+    multiline,
+    inner.width,
+    inner.height,
+    caretLineCol.col,
+    caretLineCol.line,
+    contentWidth,
+    contentHeight,
+    scrollX,
+    scrollY,
+  ])
+
+  // Declare the terminal cursor at the caret, adjusted for scroll
+  // offsets so it lands on the visible cell. The hook only renders
   // the cursor when `active` is true — we're active iff this is the
-  // focused element. We detect focus via DOM-node attribute checked
-  // each render (focus changes trigger a re-render via FocusContext
-  // already, since we'll wrap with autoFocus / tabIndex below).
-  // Position is element-relative; the renderer adds the box's screen
-  // origin.
+  // focused element.
   const isFocused = ref.current?.focusManager?.activeElement === ref.current
   const cursorRef = useDeclaredCursor({
-    line: caretLineCol.line,
-    column: caretLineCol.col,
+    line: caretLineCol.line - scrollY,
+    column: caretLineCol.col - scrollX,
     active: isFocused,
   })
 
@@ -258,14 +331,29 @@ export default function TextInput({
   const handleMouseDown = useCallback(
     (e: MouseDownEvent) => {
       if (disabled) return
-      const idx = clickToCharIndex(state.value, e.localCol, e.localRow, password, passwordChar)
+      // Click coords are local to the Box (0-indexed from its top-left
+      // INCLUDING padding/border). The visible content starts at
+      // (scrollX, scrollY) within the buffer, so add the scroll
+      // offsets to land on the right buffer position. We don't try
+      // to subtract padding/border here — the renderer's hit-test
+      // already accounts for box layout, so localCol/Row are
+      // relative to the OUTER box. If the user adds padding, click
+      // accuracy near the edges will be off by the padding amount;
+      // documented limitation.
+      const idx = clickToCharIndex(
+        state.value,
+        e.localCol + scrollX,
+        e.localRow + scrollY,
+        password,
+        passwordChar,
+      )
       dispatch({ type: 'setCaret', charIdx: idx, extend: e.shiftKey })
       e.captureGesture({
         onMove(m) {
           const newIdx = clickToCharIndex(
             state.value,
-            m.col - (e.col - e.localCol),
-            m.row - (e.row - e.localRow),
+            m.col - (e.col - e.localCol) + scrollX,
+            m.row - (e.row - e.localRow) + scrollY,
             password,
             passwordChar,
           )
@@ -273,15 +361,40 @@ export default function TextInput({
         },
       })
     },
-    [disabled, state.value, password, passwordChar],
+    [disabled, state.value, password, passwordChar, scrollX, scrollY],
   )
 
   // ── Rendering ─────────────────────────────────────────────────────
 
-  // Compute lines-with-selection-highlights for rendering.
+  // Compute lines-with-selection-highlights for rendering. Pass
+  // scroll offsets so the rendered slice matches the cursor's
+  // declared position (single-line: skip `scrollX` cells of the only
+  // line; multiline: skip `scrollY` rows).
   const renderedLines = useMemo(
-    () => renderLines(state, { password, passwordChar, selectionColor, placeholder }),
-    [state, password, passwordChar, selectionColor, placeholder],
+    () =>
+      renderLines(state, {
+        password,
+        passwordChar,
+        selectionColor,
+        placeholder,
+        scrollX,
+        scrollY,
+        innerWidth: inner.width,
+        innerHeight: inner.height,
+        multiline,
+      }),
+    [
+      state,
+      password,
+      passwordChar,
+      selectionColor,
+      placeholder,
+      scrollX,
+      scrollY,
+      inner.width,
+      inner.height,
+      multiline,
+    ],
   )
 
   return (
@@ -377,6 +490,11 @@ type RenderOpts = {
   passwordChar: string
   selectionColor: Color
   placeholder: string | undefined
+  scrollX: number
+  scrollY: number
+  innerWidth: number
+  innerHeight: number
+  multiline: boolean
 }
 
 function maskValue(value: string, password: boolean, passwordChar: string): string {
@@ -393,7 +511,17 @@ function maskValue(value: string, password: boolean, passwordChar: string): stri
  *  selection highlight is visible. Empty buffer renders the
  *  placeholder dimmed. */
 function renderLines(state: TextInputState, opts: RenderOpts): React.ReactNode {
-  const { password, passwordChar, selectionColor, placeholder } = opts
+  const {
+    password,
+    passwordChar,
+    selectionColor,
+    placeholder,
+    scrollX,
+    scrollY,
+    innerWidth,
+    innerHeight,
+    multiline,
+  } = opts
 
   if (state.value === '' && placeholder) {
     return (
@@ -407,39 +535,59 @@ function renderLines(state: TextInputState, opts: RenderOpts): React.ReactNode {
   const lines = splitLines(display)
   const [selStart, selEnd] = selectionOrCaretRange(state)
 
-  // Walk lines, emitting per-line segments. Convert flat selection
-  // indices into per-line indices so each line's highlight is rendered
-  // correctly. Index-as-key is correct here: lines have no stable
-  // identity, the buffer re-renders on every keystroke, and a stable
-  // key per slot avoids unmount-on-edit.
-  let offset = 0
-  return lines.map((line, lineIdx) => {
-    const lineLen = line.length
-    const localStart = clamp(selStart - offset, 0, lineLen)
-    const localEnd = clamp(selEnd - offset, 0, lineLen)
-    offset += lineLen + 1 // +1 for the consumed '\n'
+  // Multiline: window the line array vertically. Single-line: window
+  // the only line horizontally. Both fall back to the full buffer when
+  // measurements aren't available yet (first render).
+  const visibleLines =
+    multiline && innerHeight > 0 ? lines.slice(scrollY, scrollY + innerHeight) : lines
+  const lineOffset = multiline && innerHeight > 0 ? scrollY : 0
 
-    if (localStart === localEnd) {
-      // No selection on this line — render plain.
+  // Walk lines, emitting per-line segments. Convert flat selection
+  // indices into per-line indices. Index-as-key is correct here: lines
+  // have no stable identity, the buffer re-renders on every keystroke,
+  // and a stable key per slot avoids unmount-on-edit.
+  let charOffset = 0
+  for (let i = 0; i < lineOffset; i++) {
+    charOffset += (lines[i]?.length ?? 0) + 1 // +1 for '\n'
+  }
+  return visibleLines.map((line, lineIdx) => {
+    // For single-line, slice horizontally by cells.
+    const visibleLine =
+      !multiline && innerWidth > 0 ? sliceRowByCells(line, scrollX, innerWidth) : line
+    const lineLen = line.length
+    const localStart = clamp(selStart - charOffset, 0, lineLen)
+    const localEnd = clamp(selEnd - charOffset, 0, lineLen)
+    charOffset += lineLen + 1
+
+    // Selection range in the SLICED visible line. Convert by walking
+    // cells; for the simple no-wide-char path this is just char-index
+    // math after subtracting scrollX. For correctness with wide chars
+    // we'd compute via the same cell math sliceRowByCells uses, but
+    // for v1 the simple path is correct enough — selection rendering
+    // on a horizontally-scrolled wide char is a v2 nice-to-have.
+    const visStart = !multiline && innerWidth > 0 ? Math.max(0, localStart - scrollX) : localStart
+    const visEnd = !multiline && innerWidth > 0 ? Math.max(0, localEnd - scrollX) : localEnd
+
+    if (visStart === visEnd) {
       return (
         <Text
           // biome-ignore lint/suspicious/noArrayIndexKey: see comment above
           key={lineIdx}
-          wrap="wrap"
+          wrap="truncate-end"
         >
-          {line || ' '}
+          {visibleLine || ' '}
         </Text>
       )
     }
 
-    const before = line.slice(0, localStart)
-    const sel = line.slice(localStart, localEnd) || ' '
-    const after = line.slice(localEnd)
+    const before = visibleLine.slice(0, visStart)
+    const sel = visibleLine.slice(visStart, visEnd) || ' '
+    const after = visibleLine.slice(visEnd)
     return (
       <Text
         // biome-ignore lint/suspicious/noArrayIndexKey: see comment above
         key={lineIdx}
-        wrap="wrap"
+        wrap="truncate-end"
       >
         {before}
         <Text backgroundColor={selectionColor}>{sel}</Text>
@@ -447,6 +595,32 @@ function renderLines(state: TextInputState, opts: RenderOpts): React.ReactNode {
       </Text>
     )
   })
+}
+
+/**
+ * Read the inner content area (width × height) from a Box's yoga
+ * node, subtracting border + padding insets. Returns 0/0 when the
+ * yoga layout isn't available yet (first render before
+ * calculateLayout, or detached node).
+ */
+function measureInnerSize(node: DOMElement): { width: number; height: number } {
+  const yoga = node.yogaNode
+  if (!yoga) return { width: 0, height: 0 }
+  const w = yoga.getComputedWidth()
+  const h = yoga.getComputedHeight()
+  if (!w || !h) return { width: 0, height: 0 }
+  const padL = yoga.getComputedPadding(LayoutEdge.Left) ?? 0
+  const padR = yoga.getComputedPadding(LayoutEdge.Right) ?? 0
+  const padT = yoga.getComputedPadding(LayoutEdge.Top) ?? 0
+  const padB = yoga.getComputedPadding(LayoutEdge.Bottom) ?? 0
+  const brL = yoga.getComputedBorder(LayoutEdge.Left) ?? 0
+  const brR = yoga.getComputedBorder(LayoutEdge.Right) ?? 0
+  const brT = yoga.getComputedBorder(LayoutEdge.Top) ?? 0
+  const brB = yoga.getComputedBorder(LayoutEdge.Bottom) ?? 0
+  return {
+    width: Math.max(0, Math.floor(w - padL - padR - brL - brR)),
+    height: Math.max(0, Math.floor(h - padT - padB - brT - brB)),
+  }
 }
 
 function clamp(v: number, lo: number, hi: number): number {

--- a/packages/renderer/src/components/TextInput/TextInput.tsx
+++ b/packages/renderer/src/components/TextInput/TextInput.tsx
@@ -293,13 +293,20 @@ export default function TextInput({
     return focusCtx.manager.subscribeToFocus(node, setIsFocused)
   }, [focusCtx])
 
-  // Declare the terminal cursor at the caret, adjusted for scroll
-  // offsets so it lands on the visible cell. The hook only renders
-  // the cursor when `active` is true — we're active iff this is the
-  // focused element.
+  // Declare the terminal cursor at the caret, adjusted for the active
+  // axis's scroll offset so it lands on the visible cell. The hook
+  // only renders the cursor when `active` is true — we're active iff
+  // this is the focused element.
+  //
+  // Only one axis is maintained per mode (scrollX in single-line,
+  // scrollY in multiline) — the inactive axis stays at zero. But if
+  // `multiline` is toggled at runtime AFTER scrolling, the previously
+  // active axis still holds its last offset. Subtracting unconditionally
+  // would push the cursor declaration to the wrong (sometimes negative)
+  // coordinate. Gate by mode so the inactive axis is never applied.
   const cursorRef = useDeclaredCursor({
-    line: caretLineCol.line - scrollY,
-    column: caretLineCol.col - scrollX,
+    line: caretLineCol.line - (multiline ? scrollY : 0),
+    column: caretLineCol.col - (multiline ? 0 : scrollX),
     active: isFocused,
   })
 

--- a/packages/renderer/src/components/TextInput/scroll-math.test.ts
+++ b/packages/renderer/src/components/TextInput/scroll-math.test.ts
@@ -138,4 +138,29 @@ describe('sliceRowByCells', () => {
   it('handles empty row gracefully', () => {
     expect(sliceRowByCells('', 0, 10)).toBe('')
   })
+
+  it('keeps non-BMP emoji intact (no surrogate-pair split)', () => {
+    // '😀' is U+1F600 (one code point, two UTF-16 units). With the
+    // old row[i] walk, scrolling into the middle of the emoji's cell
+    // pair would emit lone surrogates and produce replacement glyphs.
+    // With code-point iteration the emoji always rendered or fully
+    // skipped.
+    expect(sliceRowByCells('a😀b', 0, 5)).toBe('a😀b')
+    // Skip the leading 'a' (1 cell). Emoji starts at cell 1, width 2.
+    expect(sliceRowByCells('a😀b', 1, 5)).toBe('😀b')
+  })
+
+  it('renders space when an emoji straddles the leading edge', () => {
+    // 'a😀b': 'a' (1 cell) + '😀' (2 cells) + 'b' (1 cell). Slice
+    // [2, 6) would land mid-emoji on cell 2 — emit a space placeholder
+    // for the clipped half so layout doesn't drift, then resume with 'b'.
+    expect(sliceRowByCells('a😀b', 2, 4)).toBe(' b')
+  })
+
+  it('renders spaces when an emoji straddles the trailing edge', () => {
+    // 'ab😀': cells 0,1 are 'a','b'; emoji starts at cell 2 (width 2).
+    // Slice [0, 3) fits 'ab' but only one cell of the emoji — emit a
+    // space placeholder rather than a half-emoji.
+    expect(sliceRowByCells('ab😀', 0, 3)).toBe('ab ')
+  })
 })

--- a/packages/renderer/src/components/TextInput/scroll-math.test.ts
+++ b/packages/renderer/src/components/TextInput/scroll-math.test.ts
@@ -1,0 +1,141 @@
+/**
+ * Pure-math tests for the TextInput scroll helpers.
+ */
+
+import { describe, expect, it } from 'vitest'
+import { scrollToKeepCaretVisible, sliceRowByCells } from './scroll-math.js'
+
+describe('scrollToKeepCaretVisible', () => {
+  it('no scroll when caret is in view', () => {
+    const next = scrollToKeepCaretVisible({
+      scroll: 0,
+      caretPos: 5,
+      windowSize: 20,
+      contentSize: 30,
+    })
+    expect(next).toBe(0)
+  })
+
+  it('scrolls left when caret is before the window', () => {
+    const next = scrollToKeepCaretVisible({
+      scroll: 10,
+      caretPos: 3,
+      windowSize: 20,
+      contentSize: 30,
+    })
+    expect(next).toBe(3)
+  })
+
+  it('scrolls right when caret is past the window', () => {
+    // Window of 10 starting at 0; caret at 15 → need to shift right
+    // so caret sits at the trailing edge (cell `windowSize-1`).
+    const next = scrollToKeepCaretVisible({
+      scroll: 0,
+      caretPos: 15,
+      windowSize: 10,
+      contentSize: 30,
+    })
+    expect(next).toBe(6) // 15 - 10 + 1
+  })
+
+  it('treats caret at scroll + windowSize as off-screen (1-cell trailing pad)', () => {
+    // caret AT the boundary (right edge) is invisible — it would
+    // render past the last cell. Predicate uses >= so we shift.
+    const next = scrollToKeepCaretVisible({
+      scroll: 0,
+      caretPos: 10,
+      windowSize: 10,
+      contentSize: 30,
+    })
+    expect(next).toBe(1)
+  })
+
+  it('clamps to content end (no over-scroll past last cell)', () => {
+    const next = scrollToKeepCaretVisible({
+      scroll: 100,
+      caretPos: 28,
+      windowSize: 10,
+      contentSize: 30,
+    })
+    // Caret-into-view brings scroll back to 28 (caret at leading
+    // edge); clamp to max contentSize - windowSize = 20. Resulting
+    // window [20, 30) still contains caret 28, so this is correct.
+    expect(next).toBe(20)
+  })
+
+  it('clamps to 0 (no negative scroll)', () => {
+    const next = scrollToKeepCaretVisible({
+      scroll: -5,
+      caretPos: 0,
+      windowSize: 10,
+      contentSize: 30,
+    })
+    expect(next).toBe(0)
+  })
+
+  it('returns 0 for windowSize 0 (degenerate, avoids divide-by-zero downstream)', () => {
+    const next = scrollToKeepCaretVisible({
+      scroll: 5,
+      caretPos: 10,
+      windowSize: 0,
+      contentSize: 30,
+    })
+    expect(next).toBe(0)
+  })
+
+  it('content shorter than window → scroll always 0', () => {
+    const next = scrollToKeepCaretVisible({
+      scroll: 5, // somehow stale
+      caretPos: 3,
+      windowSize: 20,
+      contentSize: 5,
+    })
+    expect(next).toBe(0)
+  })
+})
+
+describe('sliceRowByCells', () => {
+  it('slices ASCII by cell count', () => {
+    expect(sliceRowByCells('abcdefghij', 0, 5)).toBe('abcde')
+    expect(sliceRowByCells('abcdefghij', 3, 4)).toBe('defg')
+  })
+
+  it('returns empty for windowSize 0', () => {
+    expect(sliceRowByCells('hello', 0, 0)).toBe('')
+  })
+
+  it('returns empty when fromCol exceeds content', () => {
+    expect(sliceRowByCells('hello', 100, 5)).toBe('')
+  })
+
+  it('returns prefix when fromCol negative', () => {
+    expect(sliceRowByCells('hello', -3, 3)).toBe('hel')
+  })
+
+  it('preserves wide CJK chars within the window', () => {
+    // '中文ab' = 2+2+1+1 = 6 cells. Slice cells 0..4 → '中文'
+    expect(sliceRowByCells('中文ab', 0, 4)).toBe('中文')
+  })
+
+  it('renders a space when a wide char straddles the leading edge', () => {
+    // '中文ab', slice cells 1..5 → leading half of 中 is clipped;
+    // emit space + '文ab' = ' 文ab' (5 cells).
+    expect(sliceRowByCells('中文ab', 1, 5)).toBe(' 文ab')
+  })
+
+  it('renders a space when a wide char straddles the trailing edge', () => {
+    // '中文ab', slice cells 0..3 → '中' fits, '文' doesn't (would need
+    // cells 2-3, but only cell 2 fits) → emit '中 '.
+    expect(sliceRowByCells('中文ab', 0, 3)).toBe('中 ')
+  })
+
+  it('preserves combining marks attached to visible base chars', () => {
+    // 'ábc' → 'á' (1 cell) + 'b' + 'c'.
+    // Slice cells 0..2 → 'áb'.
+    expect(sliceRowByCells('ábc', 0, 2)).toBe('áb')
+  })
+
+  it('handles empty row gracefully', () => {
+    expect(sliceRowByCells('', 0, 10)).toBe('')
+  })
+})

--- a/packages/renderer/src/components/TextInput/scroll-math.ts
+++ b/packages/renderer/src/components/TextInput/scroll-math.ts
@@ -1,0 +1,142 @@
+/**
+ * Pure scroll math for TextInput. Decides where the visible window
+ * should sit so the caret stays in view after every edit.
+ *
+ * Two axes:
+ *   - **horizontal** (single-line): scroll cells; window is `width`
+ *     cells wide; caret cell column must stay in `[scroll, scroll + width)`.
+ *   - **vertical** (multiline):     scroll rows; window is `height`
+ *     rows tall; caret row must stay in `[scroll, scroll + height)`.
+ *
+ * The two axes share the same caret-into-view math; only the
+ * dimension differs.
+ */
+
+/**
+ * Adjust a one-dimensional scroll offset so `caretPos` lands inside
+ * `[scroll, scroll + windowSize)`.
+ *
+ * Returns the (possibly unchanged) new scroll offset. Never goes
+ * negative; never scrolls past `contentSize - windowSize`.
+ *
+ * Convention: caret at the RIGHT edge of the window (caretPos ===
+ * scroll + windowSize) is OUT OF VIEW — the caret needs to render at
+ * a cell, not past the last visible cell. So the predicate is `>=`,
+ * which keeps a 1-cell pad at the trailing edge.
+ *
+ * windowSize 0 (degenerate; user passed a zero-size box) returns 0
+ * to avoid divide-by-zero noise downstream.
+ */
+export function scrollToKeepCaretVisible(opts: {
+  scroll: number
+  caretPos: number
+  windowSize: number
+  contentSize: number
+}): number {
+  const { scroll, caretPos, windowSize, contentSize } = opts
+  if (windowSize <= 0) return 0
+  let next = scroll
+  // Caret too far left → scroll left so caret is at the leading edge.
+  if (caretPos < next) next = caretPos
+  // Caret too far right → scroll right so caret is at the trailing
+  // (right) edge minus 1 (so the caret cell itself is visible).
+  else if (caretPos >= next + windowSize) next = caretPos - windowSize + 1
+  // Clamp to content bounds — never scroll past the end of content,
+  // never below 0.
+  const max = Math.max(0, contentSize - windowSize)
+  if (next > max) next = max
+  if (next < 0) next = 0
+  return next
+}
+
+/**
+ * Slice a row by cell column range `[fromCol, fromCol + windowSize)`,
+ * preserving wide-char boundaries. If a wide character straddles the
+ * leading edge, render a space in its place (since the right half
+ * would visually misalign). Same for trailing edge.
+ *
+ * Returns the visible substring suitable for a single `<Text>`. Used
+ * by single-line horizontal scroll.
+ */
+export function sliceRowByCells(row: string, fromCol: number, windowSize: number): string {
+  if (windowSize <= 0) return ''
+  if (fromCol < 0) fromCol = 0
+  let out = ''
+  let cellAcc = 0
+  let visibleCells = 0
+  for (let i = 0; i < row.length; i++) {
+    const ch = row[i]!
+    const w = cellWidthOfChar(ch)
+    if (w === 0) {
+      // Combining mark — attach to whatever was last emitted (or drop
+      // if before the visible range and the base char was clipped).
+      if (cellAcc > fromCol || (cellAcc === fromCol && out.length > 0)) {
+        out += ch
+      }
+      continue
+    }
+    if (cellAcc + w <= fromCol) {
+      cellAcc += w
+      continue
+    }
+    if (cellAcc < fromCol) {
+      // Wide char straddles leading edge → render a space for the
+      // visible half so layout doesn't shift.
+      out += ' '
+      visibleCells += 1
+      cellAcc += w
+      if (visibleCells >= windowSize) break
+      continue
+    }
+    if (visibleCells + w > windowSize) {
+      // Wide char straddles trailing edge → fill remaining cells with
+      // spaces and stop.
+      const room = windowSize - visibleCells
+      out += ' '.repeat(room)
+      visibleCells += room
+      break
+    }
+    out += ch
+    visibleCells += w
+    cellAcc += w
+    if (visibleCells >= windowSize) break
+  }
+  return out
+}
+
+function cellWidthOfChar(ch: string): number {
+  // Fast path for ASCII printable (always 1 cell).
+  const code = ch.codePointAt(0) ?? 0
+  if (code < 0x80) {
+    if (code < 0x20 || code === 0x7f) return 0
+    return 1
+  }
+  // Combining marks. We only check the most common range — full
+  // Unicode combining-class detection is overkill for caret math.
+  // Tests verify this against stringWidth's behavior.
+  if (code >= 0x0300 && code <= 0x036f) return 0
+  if (code === 0x200d) return 0 // ZWJ
+  if (code >= 0xfe00 && code <= 0xfe0f) return 0 // variation selectors
+  // Wide ranges (East Asian Wide / Fullwidth + emoji presentation).
+  // Approximate; matches the behavior of stringWidth for these
+  // ranges. Anything ambiguous defaults to 1.
+  if (
+    (code >= 0x1100 && code <= 0x115f) || // Hangul Jamo
+    (code >= 0x2e80 && code <= 0x303e) || // CJK Radicals + symbols
+    (code >= 0x3041 && code <= 0x33ff) || // Hiragana, Katakana, CJK Symbols
+    (code >= 0x3400 && code <= 0x4dbf) || // CJK Extension A
+    (code >= 0x4e00 && code <= 0x9fff) || // CJK Unified
+    (code >= 0xa000 && code <= 0xa4cf) || // Yi
+    (code >= 0xac00 && code <= 0xd7a3) || // Hangul Syllables
+    (code >= 0xf900 && code <= 0xfaff) || // CJK Compatibility
+    (code >= 0xfe30 && code <= 0xfe4f) || // CJK Compatibility Forms
+    (code >= 0xff00 && code <= 0xff60) || // Fullwidth ASCII
+    (code >= 0xffe0 && code <= 0xffe6) || // Fullwidth signs
+    (code >= 0x1f300 && code <= 0x1f64f) || // Emoji misc
+    (code >= 0x1f680 && code <= 0x1f6ff) || // Transport + map
+    (code >= 0x1f900 && code <= 0x1f9ff) // Emoji extended
+  ) {
+    return 2
+  }
+  return 1
+}

--- a/packages/renderer/src/components/TextInput/scroll-math.ts
+++ b/packages/renderer/src/components/TextInput/scroll-math.ts
@@ -57,6 +57,12 @@ export function scrollToKeepCaretVisible(opts: {
  *
  * Returns the visible substring suitable for a single `<Text>`. Used
  * by single-line horizontal scroll.
+ *
+ * Iteration is by code point, not UTF-16 unit — necessary so non-BMP
+ * characters (most emoji, e.g. 😀 = U+1F600) aren't split into lone
+ * surrogate halves at the boundaries. A `row[i]` walk would emit a
+ * lone high-surrogate when scrollX lands mid-emoji and the terminal
+ * would render a replacement glyph.
  */
 export function sliceRowByCells(row: string, fromCol: number, windowSize: number): string {
   if (windowSize <= 0) return ''
@@ -64,8 +70,10 @@ export function sliceRowByCells(row: string, fromCol: number, windowSize: number
   let out = ''
   let cellAcc = 0
   let visibleCells = 0
-  for (let i = 0; i < row.length; i++) {
-    const ch = row[i]!
+  // for..of walks code points, so `ch` is always one full code point
+  // (1 or 2 UTF-16 units); `cellWidthOfChar` then reads the full
+  // codePointAt(0) and classifies wide ranges correctly.
+  for (const ch of row) {
     const w = cellWidthOfChar(ch)
     if (w === 0) {
       // Combining mark — attach to whatever was last emitted (or drop

--- a/packages/renderer/src/components/TextInput/scroll-math.ts
+++ b/packages/renderer/src/components/TextInput/scroll-math.ts
@@ -50,7 +50,7 @@ export function scrollToKeepCaretVisible(opts: {
 }
 
 /**
- * Slice a row by cell column range `[fromCol, fromCol + windowSize)`,
+ * Slice a row by cell column range `[startCol, startCol + windowSize)`,
  * preserving wide-char boundaries. If a wide character straddles the
  * leading edge, render a space in its place (since the right half
  * would visually misalign). Same for trailing edge.
@@ -60,7 +60,7 @@ export function scrollToKeepCaretVisible(opts: {
  */
 export function sliceRowByCells(row: string, fromCol: number, windowSize: number): string {
   if (windowSize <= 0) return ''
-  if (fromCol < 0) fromCol = 0
+  const startCol = Math.max(0, fromCol)
   let out = ''
   let cellAcc = 0
   let visibleCells = 0
@@ -70,16 +70,16 @@ export function sliceRowByCells(row: string, fromCol: number, windowSize: number
     if (w === 0) {
       // Combining mark — attach to whatever was last emitted (or drop
       // if before the visible range and the base char was clipped).
-      if (cellAcc > fromCol || (cellAcc === fromCol && out.length > 0)) {
+      if (cellAcc > startCol || (cellAcc === startCol && out.length > 0)) {
         out += ch
       }
       continue
     }
-    if (cellAcc + w <= fromCol) {
+    if (cellAcc + w <= startCol) {
       cellAcc += w
       continue
     }
-    if (cellAcc < fromCol) {
+    if (cellAcc < startCol) {
       // Wide char straddles leading edge → render a space for the
       // visible half so layout doesn't shift.
       out += ' '

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yokai/shared",
-  "version": "0.5.1",
+  "version": "0.6.0",
   "description": "Shared utilities — Yoga layout TS port, logger, env helpers",
   "license": "MIT",
   "main": "./dist/index.js",


### PR DESCRIPTION
Follow-up to #33. Closes the scroll limitation from the v1 TextInput PR and bumps the release to v0.6.0.

## What's added

### TextInput scroll
- **Single-line horizontal scroll**: when content exceeds box width, the visible window scrolls so the caret stays in view. Wide chars at the edges become spaces (no half-glyph misalignment).
- **Multiline vertical scroll**: when content exceeds box height, the visible window scrolls vertically so the caret line stays in view.
- Inner content area read from yoga's computed size minus border + padding, so `width` / `height` props refer to the OUTER box (matches every other Box-derived component).
- Click positioning adds scroll offsets so clicks on visible content land on the right buffer char even when scrolled.

### Pure scroll math (`scroll-math.ts`)
Two helpers, fully tested:
- `scrollToKeepCaretVisible({ scroll, caretPos, windowSize, contentSize })` — picks the new offset.
- `sliceRowByCells(row, fromCol, windowSize)` — wide-char-aware substring.

17 tests cover boundary conditions, wide chars, combining marks, edge cases (empty / negative / overflow).

## Remaining limitations (honest)
- IME composition (CJK / Korean) intermediate state — committed text works, intermediate display doesn't.
- Selection highlight on a horizontally-scrolled wide char is approximate.
- Click within padding may snap to the wrong char by the padding amount.

Documented in `docs/components/text-input.md`.

## Release: v0.6.0
- `@yokai/renderer` + `@yokai/shared`: 0.5.1 → 0.6.0
- Root: 0.5.1 → 0.6.0
- README consumption pin updated
- Changelog entry covering everything since v0.5.1 (TextInput + smart paste from #33, FocusGroup onKeyDown refactor, scroll polish from this PR)

## Granular commits

1. `feat(TextInput): pure scroll math helpers`
2. `feat(TextInput): horizontal + vertical scroll keep caret in view`
3. `chore(release): v0.6.0 — TextInput + smart paste + scroll polish`

## Test plan

- [x] All 318 tests pass
- [x] `pnpm -r typecheck`
- [x] `pnpm --filter @yokai/renderer lint`
- [x] `pnpm build`
- [x] `pnpm demo:text-input` smoke runs
- [ ] Manual: type past width in single-line — caret stays visible, content scrolls. Type past height in multiline — caret stays visible, lines scroll.
- [ ] Tag `v0.6.0` after merge.