### PR TITLE
feat: cursor visibility fix + style/blink/color knobs

### DIFF
--- a/docs/components/text-input.md
+++ b/docs/components/text-input.md
@@ -26,6 +26,9 @@ Component-specific props. All `<Box>` props are accepted EXCEPT `onKeyDown`, `on
 | `disabled` | `boolean` | `false` | Ignore keystrokes. The input still claims focus. |
 | `selectionColor` | `Color` | `'cyan'` | Background of the selection highlight. |
 | `borderColorFocus` | `Color` | `'cyan'` | Border color while focused. Swaps `borderColor` on focus, reverts on blur. No-op when no `borderStyle` is set. To opt out, pass the same value as `borderColor`. |
+| `cursorStyle` | `'block' \| 'underline' \| 'bar'` | terminal default | Cursor shape while focused. DECSCUSR; restored to terminal default on blur. |
+| `cursorBlink` | `boolean` | terminal default | Cursor blink while focused. Pairs with `cursorStyle`. |
+| `cursorColor` | `Color` | terminal default | Cursor color while focused. OSC 12; supported by xterm/iTerm2/kitty/alacritty/Windows Terminal/VS Code. `ansi256(N)` not supported. |
 | `autoFocus` | `boolean` | `false` | Focus on mount. |
 | `historyCap` | `number` | `100` | Max undo entries. Older entries drop. |
 

--- a/examples/cursor-styles/cursor-styles.tsx
+++ b/examples/cursor-styles/cursor-styles.tsx
@@ -1,0 +1,252 @@
+/**
+ * Cursor styles demo — every (style × blink × color) combination
+ * driven by real focusable checkboxes.
+ *
+ *   pnpm demo:cursor-styles
+ *
+ * Tab between sections. Arrows within a section. Enter / Space toggles
+ * the focused checkbox. Mouse click toggles too. Type into the
+ * TextInput at the bottom to watch the cursor morph live as you flip
+ * the boxes.
+ *
+ * Press Ctrl+C to quit.
+ */
+
+import {
+  AlternateScreen,
+  Box,
+  type Color,
+  type CursorStyle,
+  FocusGroup,
+  type KeyboardEvent,
+  Text,
+  TextInput,
+  render,
+  useApp,
+  useFocus,
+  useInput,
+} from '@yokai/renderer'
+import type React from 'react'
+import { useState } from 'react'
+
+type ColorChoice = 'default' | 'red' | 'green' | 'blue' | 'yellow' | 'magenta' | 'cyan' | '#ff8800'
+
+const STYLES: ReadonlyArray<CursorStyle> = ['block', 'underline', 'bar']
+const COLORS: ReadonlyArray<ColorChoice> = [
+  'default',
+  'red',
+  'green',
+  'blue',
+  'yellow',
+  'magenta',
+  'cyan',
+  '#ff8800',
+]
+
+function App(): React.ReactNode {
+  const { exit } = useApp()
+  useInput((input, key) => {
+    if (key.ctrl && input === 'c') exit()
+  })
+
+  const [style, setStyle] = useState<CursorStyle>('block')
+  const [blink, setBlink] = useState(true)
+  const [color, setColor] = useState<ColorChoice>('default')
+  const [text, setText] = useState('Type here to see the cursor')
+
+  // Convert ColorChoice → the actual prop value (undefined = terminal default).
+  const cursorColor: Color | undefined = color === 'default' ? undefined : color
+
+  return (
+    <AlternateScreen mouseTracking>
+      <Box flexDirection="column" padding={1} gap={1}>
+        <Text bold>yokai · Cursor styles demo</Text>
+        <Text dim>
+          Tab between sections · Arrows within a section · Enter/Space toggles · Mouse click also
+          toggles · Ctrl+C to quit
+        </Text>
+
+        <Group label="Style (DECSCUSR shape)">
+          <FocusGroup direction="row">
+            {STYLES.map((s) => (
+              <Radio
+                key={s}
+                current={style}
+                value={s}
+                onChange={setStyle}
+                label={s}
+                swatch={swatchFor(s)}
+              />
+            ))}
+          </FocusGroup>
+        </Group>
+
+        <Group label="Blink (DECSCUSR pair)">
+          <FocusGroup direction="row">
+            <Radio current={blink} value={true} onChange={setBlink} label="blinking" />
+            <Radio current={blink} value={false} onChange={setBlink} label="steady" />
+          </FocusGroup>
+        </Group>
+
+        <Group label="Color (OSC 12)">
+          <FocusGroup direction="row">
+            {COLORS.map((c) => (
+              <Radio
+                key={c}
+                current={color}
+                value={c}
+                onChange={setColor}
+                label={c}
+                swatch={c === 'default' ? '·' : '█'}
+                swatchColor={c === 'default' ? undefined : c}
+              />
+            ))}
+          </FocusGroup>
+        </Group>
+
+        <Box flexDirection="column" gap={1} marginTop={1}>
+          <Text dim>Live preview — type to watch the cursor</Text>
+          <TextInput
+            value={text}
+            onChange={setText}
+            borderStyle="round"
+            paddingX={1}
+            width={60}
+            cursorStyle={style}
+            cursorBlink={blink}
+            cursorColor={cursorColor}
+          />
+        </Box>
+
+        <Box flexDirection="column">
+          <Text dim>Equivalent props:</Text>
+          <Text>
+            {`<TextInput cursorStyle="${style}" cursorBlink={${blink}} cursorColor=${
+              cursorColor === undefined ? '{undefined}' : `"${cursorColor}"`
+            } />`}
+          </Text>
+        </Box>
+      </Box>
+    </AlternateScreen>
+  )
+}
+
+// ── Primitives ────────────────────────────────────────────────────────
+
+/**
+ * Mutually-exclusive checkbox — picks one value from a set, like an
+ * HTML radio. `current === value` means "this one is selected." On
+ * toggle, the only behavior is "set the parent to my value" (no
+ * uncheck — the parent always has SOME value).
+ */
+// Generic-without-constraint: with `T extends string | boolean`,
+// TypeScript widens T to the constraint bound when inferring from
+// the props, which then fails to accept `Dispatch<SetStateAction<X>>`
+// at the call site. Unconstrained T is fine here — callers always
+// pass matching `current` / `value` / `onChange` triples and TS
+// happily infers each one.
+function Radio<T>({
+  current,
+  value,
+  onChange,
+  label,
+  swatch,
+  swatchColor,
+}: {
+  current: T
+  value: T
+  onChange: (v: T) => void
+  label: string
+  swatch?: string
+  swatchColor?: string
+}): React.ReactNode {
+  const checked = current === value
+  return (
+    <Toggle
+      checked={checked}
+      onChange={(c) => {
+        // Radio semantics: clicking an already-checked option is a
+        // no-op (you can't uncheck without selecting another).
+        if (c) onChange(value)
+      }}
+      label={label}
+      swatch={swatch}
+      swatchColor={swatchColor}
+    />
+  )
+}
+
+/**
+ * Single boolean checkbox. The whole row is the focusable element so
+ * a click anywhere on `[ ] label` toggles, not just on the bracket
+ * glyph. Shows focus chrome via a left-margin caret indicator.
+ */
+function Toggle({
+  checked,
+  onChange,
+  label,
+  swatch,
+  swatchColor,
+}: {
+  checked: boolean
+  onChange: (v: boolean) => void
+  label: string
+  swatch?: string
+  swatchColor?: string
+}): React.ReactNode {
+  const { ref, isFocused } = useFocus()
+  const onKeyDown = (e: KeyboardEvent): void => {
+    // 'return' = Enter, ' ' = Space. Both are the conventional toggle
+    // keys on a checkbox. preventDefault so FocusGroup's arrow nav
+    // doesn't see us steal focus on Enter (it doesn't anyway, but
+    // belt-and-suspenders).
+    if (e.key === 'return' || e.key === ' ') {
+      e.preventDefault()
+      onChange(!checked)
+    }
+  }
+  return (
+    <Box
+      ref={ref}
+      tabIndex={0}
+      onClick={() => onChange(!checked)}
+      onKeyDown={onKeyDown}
+      paddingX={1}
+    >
+      <Text color={isFocused ? 'cyan' : undefined} bold={isFocused}>
+        {`${isFocused ? '▸ ' : '  '}[${checked ? 'x' : ' '}] `}
+      </Text>
+      {swatch !== undefined && (
+        <Text color={swatchColor as Color | undefined}>{`${swatch} `}</Text>
+      )}
+      <Text color={isFocused ? 'cyan' : undefined} bold={isFocused}>
+        {label}
+      </Text>
+    </Box>
+  )
+}
+
+function Group({
+  label,
+  children,
+}: {
+  label: string
+  children: React.ReactNode
+}): React.ReactNode {
+  return (
+    <Box flexDirection="column">
+      <Text dim>{label}</Text>
+      {children}
+    </Box>
+  )
+}
+
+// Visual swatch glyphs for cursor styles — tiny ASCII analogs of
+// what each shape looks like on the terminal.
+function swatchFor(style: CursorStyle): string {
+  if (style === 'block') return '█'
+  if (style === 'underline') return '_'
+  return '|' // bar
+}
+
+render(<App />)

--- a/examples/cursor-styles/package.json
+++ b/examples/cursor-styles/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@yokai-example/cursor-styles",
+  "version": "0.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "start": "tsx cursor-styles.tsx"
+  },
+  "dependencies": {
+    "@yokai/renderer": "workspace:*",
+    "react": "^19.2.5"
+  },
+  "devDependencies": {
+    "tsx": "^4.21.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "demo:drag-and-drop": "pnpm --filter @yokai-example/drag-and-drop start",
     "demo:resizable": "pnpm --filter @yokai-example/resizable start",
     "demo:focus-nav": "pnpm --filter @yokai-example/focus-nav start",
-    "demo:text-input": "pnpm --filter @yokai-example/text-input start"
+    "demo:text-input": "pnpm --filter @yokai-example/text-input start",
+    "demo:cursor-styles": "pnpm --filter @yokai-example/cursor-styles start"
   },
   "engines": {
     "node": ">=22.0.0"

--- a/packages/renderer/src/components/App.tsx
+++ b/packages/renderer/src/components/App.tsx
@@ -1,4 +1,4 @@
-import { isEnvTruthy, logError, logForDebugging } from '@yokai/shared'
+import { logError, logForDebugging } from '@yokai/shared'
 import { PureComponent, type ReactNode } from 'react'
 import type { DOMElement } from '../dom'
 import { EventEmitter } from '../events/emitter'
@@ -27,7 +27,7 @@ import {
   FOCUS_IN,
   FOCUS_OUT,
 } from '../termio/csi'
-import { DBP, DFE, DISABLE_MOUSE_TRACKING, EBP, EFE, HIDE_CURSOR, SHOW_CURSOR } from '../termio/dec'
+import { DBP, DFE, DISABLE_MOUSE_TRACKING, EBP, EFE, SHOW_CURSOR } from '../termio/dec'
 import AppContext from './AppContext'
 import ClipboardContext from './ClipboardContext'
 import { ClockProvider } from './ClockContext'
@@ -119,6 +119,13 @@ type Props = {
   // helper (native utility, tmux load-buffer, OSC 52). Fire-and-forget;
   // exposed to React land via ClipboardContext + useClipboard().
   readonly copyToClipboard: (text: string) => void
+  // Hide the physical terminal cursor and update ink's visibility
+  // tracking. Goes through this method (not a direct stdout write of
+  // HIDE_CURSOR) so ink's `cursorVisible` state stays consistent —
+  // the diff renderer's SHOW_CURSOR / HIDE_CURSOR transitions read
+  // that field to avoid spam writes, and an out-of-band hide would
+  // make it lie. Honors `CLAUDE_CODE_ACCESSIBILITY` internally.
+  readonly hideCursor: () => void
   // Focus subsystem references — exposed to React land via FocusContext
   // so useFocus / useFocusManager / FocusGroup can subscribe / dispatch
   // without walking the DOM each call.
@@ -278,10 +285,12 @@ export default class App extends PureComponent<Props, State> {
     )
   }
   override componentDidMount() {
-    // In accessibility mode, keep the native cursor visible for screen magnifiers and other tools
-    if (this.props.stdout.isTTY && !isEnvTruthy(process.env.CLAUDE_CODE_ACCESSIBILITY)) {
-      this.props.stdout.write(HIDE_CURSOR)
-    }
+    // Hide the cursor by default — diff renders happen between frames
+    // and a visible cursor flickers across the screen during paint. The
+    // render-path SHOW_CURSOR re-enables it at the declared position
+    // when a focusable consumer (TextInput etc.) takes the cursor.
+    // hideCursor honors CLAUDE_CODE_ACCESSIBILITY internally.
+    this.props.hideCursor()
   }
   override componentWillUnmount() {
     if (this.props.stdout.isTTY) {
@@ -528,12 +537,10 @@ export default class App extends PureComponent<Props, State> {
         }
       }
 
-      // Hide cursor (unless in accessibility mode) and re-enable focus reporting after resuming
+      // Hide cursor (via ink so visibility tracking stays consistent)
+      // and re-enable focus reporting after resuming.
+      this.props.hideCursor()
       if (this.props.stdout.isTTY) {
-        if (!isEnvTruthy(process.env.CLAUDE_CODE_ACCESSIBILITY)) {
-          this.props.stdout.write(HIDE_CURSOR)
-        }
-        // Re-enable focus reporting to restore terminal state
         this.props.stdout.write(EFE)
       }
 

--- a/packages/renderer/src/components/App.tsx
+++ b/packages/renderer/src/components/App.tsx
@@ -126,6 +126,10 @@ type Props = {
   // that field to avoid spam writes, and an out-of-band hide would
   // make it lie. Honors `CLAUDE_CODE_ACCESSIBILITY` internally.
   readonly hideCursor: () => void
+  // Flush any active DECSCUSR / OSC 12 cursor overrides back to
+  // terminal defaults. Called by App on suspend so the user's shell
+  // prompt doesn't inherit an in-app cursor style.
+  readonly restoreCursorDefaults: () => void
   // Focus subsystem references — exposed to React land via FocusContext
   // so useFocus / useFocusManager / FocusGroup can subscribe / dispatch
   // without walking the DOM each call.
@@ -515,6 +519,14 @@ export default class App extends PureComponent<Props, State> {
     while (this.rawModeEnabledCount > 0) {
       this.handleSetRawMode(false)
     }
+
+    // Restore cursor shape + color to terminal defaults before
+    // showing the cursor — without this, the shell prompt inherits
+    // any DECSCUSR / OSC 12 we applied while a TextInput was focused.
+    // No-op if no overrides were applied. Goes through ink so the
+    // tracking fields clear; on resume, the next render re-applies
+    // the override if the declaration is still active.
+    this.props.restoreCursorDefaults()
 
     // Show cursor, disable focus reporting, and disable mouse tracking
     // before suspending. DISABLE_MOUSE_TRACKING is a no-op if tracking

--- a/packages/renderer/src/components/CursorDeclarationContext.ts
+++ b/packages/renderer/src/components/CursorDeclarationContext.ts
@@ -1,5 +1,6 @@
 import { createContext } from 'react'
 import type { DOMElement } from '../dom'
+import type { Color } from '../styles'
 import type { CursorStyle } from '../termio/dec'
 
 export type CursorDeclaration = {
@@ -26,6 +27,22 @@ export type CursorDeclaration = {
    * `blink ?? true`) — DECSCUSR can't set just one half.
    */
   readonly blink?: boolean
+  /**
+   * Optional cursor color override. When set, ink emits OSC 12 at
+   * the same point in the render path as DECSCUSR. When undefined,
+   * the terminal's configured color wins. When a declaration that
+   * had a color is replaced by one without (or cleared), ink emits
+   * OSC 112 to reset.
+   *
+   * Support varies by terminal — xterm, iTerm2, kitty, alacritty,
+   * Windows Terminal, VS Code all honor it. Older terminals ignore
+   * the sequence (no harm done).
+   *
+   * `ansi256(N)` colors aren't supported by OSC 12 syntax — they
+   * pass through and the terminal will likely ignore them. Use
+   * `'#rrggbb'`, `'rgb(r,g,b)'`, or named colors.
+   */
+  readonly color?: Color
 }
 
 /**

--- a/packages/renderer/src/components/CursorDeclarationContext.ts
+++ b/packages/renderer/src/components/CursorDeclarationContext.ts
@@ -1,5 +1,6 @@
 import { createContext } from 'react'
 import type { DOMElement } from '../dom'
+import type { CursorStyle } from '../termio/dec'
 
 export type CursorDeclaration = {
   /** Display column (terminal cell width) within the declared node */
@@ -8,6 +9,23 @@ export type CursorDeclaration = {
   readonly relativeY: number
   /** The ink-box DOMElement whose yoga layout provides the absolute origin */
   readonly node: DOMElement
+  /**
+   * Optional cursor shape. When set, ink emits DECSCUSR alongside the
+   * position write to override the terminal's configured shape. When
+   * undefined, the terminal's configured shape wins (no DECSCUSR
+   * write). When the declaration goes back to undefined-style after
+   * having had one, ink emits `CSI 0 SP q` to restore the default —
+   * so consumers don't poison the user's shell with their last
+   * cursor config.
+   */
+  readonly style?: CursorStyle
+  /**
+   * Optional blink override. Pairs with `style` in the DECSCUSR
+   * sequence (style + blink combine into one of 6 codes). Setting
+   * either alone defaults the other (`style ?? 'block'`,
+   * `blink ?? true`) — DECSCUSR can't set just one half.
+   */
+  readonly blink?: boolean
 }
 
 /**

--- a/packages/renderer/src/components/TextInput/TextInput.tsx
+++ b/packages/renderer/src/components/TextInput/TextInput.tsx
@@ -19,6 +19,7 @@ import { useClipboard } from '../../hooks/use-clipboard.js'
 import { useDeclaredCursor } from '../../hooks/use-declared-cursor.js'
 import { LayoutEdge } from '../../layout/node.js'
 import type { Color } from '../../styles.js'
+import type { CursorStyle } from '../../termio/dec.js'
 import Box, { type Props as BoxProps } from '../Box.js'
 import FocusContext from '../FocusContext.js'
 import Text from '../Text.js'
@@ -88,6 +89,38 @@ export type TextInputProps = Except<
    * keeps the border static across focus transitions.
    */
   borderColorFocus?: Color
+  /**
+   * Terminal cursor shape while this input is focused. Default
+   * undefined — the user's terminal-configured cursor wins.
+   *
+   * 'block' is the classic full-cell rectangle, 'underline' is the
+   * vt220 underscore, 'bar' is the modern editor caret. Emitted via
+   * DECSCUSR (`CSI Ps SP q`); ink restores the terminal default
+   * automatically when the input blurs / unmounts so the user's
+   * shell isn't left with our shape.
+   */
+  cursorStyle?: CursorStyle
+  /**
+   * Whether the cursor blinks while this input is focused. Default
+   * undefined — the user's terminal-configured blink wins.
+   *
+   * Pairs with `cursorStyle` in the DECSCUSR sequence — DECSCUSR
+   * can't set just one half. Setting `cursorBlink` alone defaults
+   * `cursorStyle` to `'block'`; setting `cursorStyle` alone defaults
+   * `cursorBlink` to `true`.
+   */
+  cursorBlink?: boolean
+  /**
+   * Cursor color while this input is focused. Default undefined —
+   * the user's terminal-configured cursor color wins. Emitted via
+   * OSC 12; ink restores the default automatically on blur / unmount.
+   *
+   * Most modern terminals (xterm, iTerm2, kitty, alacritty, Windows
+   * Terminal, VS Code) honor it. `ansi256(N)` colors aren't supported
+   * by the OSC 12 syntax — use hex (`'#00ff00'`), `rgb(...)`, or
+   * named colors.
+   */
+  cursorColor?: Color
   /** Auto-focus on mount. */
   autoFocus?: boolean
   /** Maximum history entries kept for undo/redo. Default 100. */
@@ -134,6 +167,9 @@ export default function TextInput({
   disabled = false,
   selectionColor = 'cyan',
   borderColorFocus = 'cyan',
+  cursorStyle,
+  cursorBlink,
+  cursorColor,
   autoFocus = false,
   historyCap,
   ...boxProps
@@ -329,6 +365,9 @@ export default function TextInput({
     line: caretLineCol.line - (multiline ? scrollY : 0),
     column: caretLineCol.col - (multiline ? 0 : scrollX),
     active: isFocused,
+    style: cursorStyle,
+    blink: cursorBlink,
+    color: cursorColor,
   })
 
   // Merge cursorRef into our element ref. The hook's ref is for the

--- a/packages/renderer/src/components/TextInput/TextInput.tsx
+++ b/packages/renderer/src/components/TextInput/TextInput.tsx
@@ -276,12 +276,17 @@ export default function TextInput({
   // (calculateLayout runs after this effect), but for typing the lag
   // is invisible because each keystroke triggers another render that
   // catches up.
-  const [inner, setInner] = useState({ width: 0, height: 0 })
+  const [inner, setInner] = useState({ width: 0, height: 0, offsetX: 0, offsetY: 0 })
   useLayoutEffect(() => {
     const node = ref.current
     if (!node?.yogaNode) return
     const measured = measureInnerSize(node)
-    if (measured.width !== inner.width || measured.height !== inner.height) {
+    if (
+      measured.width !== inner.width ||
+      measured.height !== inner.height ||
+      measured.offsetX !== inner.offsetX ||
+      measured.offsetY !== inner.offsetY
+    ) {
       setInner(measured)
     }
   })
@@ -361,9 +366,16 @@ export default function TextInput({
   // active axis still holds its last offset. Subtracting unconditionally
   // would push the cursor declaration to the wrong (sometimes negative)
   // coordinate. Gate by mode so the inactive axis is never applied.
+  // Cursor declaration coords are interpreted relative to the OUTER
+  // box rect (per useDeclaredCursor's contract), but the rendered
+  // text starts at (offsetX, offsetY) inside that — past the border
+  // and padding. Without the offset, a TextInput with `borderStyle`
+  // or `paddingX/Y` lands the visible cursor at the box's outer
+  // top-left corner instead of at the caret's actual cell. Visible
+  // immediately as a cursor "above" or "to the left of" the text.
   const cursorRef = useDeclaredCursor({
-    line: caretLineCol.line - (multiline ? scrollY : 0),
-    column: caretLineCol.col - (multiline ? 0 : scrollX),
+    line: inner.offsetY + caretLineCol.line - (multiline ? scrollY : 0),
+    column: inner.offsetX + caretLineCol.col - (multiline ? 0 : scrollX),
     active: isFocused,
     style: cursorStyle,
     blink: cursorBlink,
@@ -771,12 +783,23 @@ function renderLines(state: TextInputState, opts: RenderOpts): React.ReactNode {
  * yoga layout isn't available yet (first render before
  * calculateLayout, or detached node).
  */
-function measureInnerSize(node: DOMElement): { width: number; height: number } {
+function measureInnerSize(node: DOMElement): {
+  width: number
+  height: number
+  /** Cell columns from outer-box left edge to where content starts
+   *  (border + padding). Used to align the cursor declaration with
+   *  the rendered text — without this offset, the declared cursor
+   *  lands at the box's outer top-left corner rather than at the
+   *  caret's actual cell. */
+  offsetX: number
+  /** Cell rows from outer-box top edge to where content starts. */
+  offsetY: number
+} {
   const yoga = node.yogaNode
-  if (!yoga) return { width: 0, height: 0 }
+  if (!yoga) return { width: 0, height: 0, offsetX: 0, offsetY: 0 }
   const w = yoga.getComputedWidth()
   const h = yoga.getComputedHeight()
-  if (!w || !h) return { width: 0, height: 0 }
+  if (!w || !h) return { width: 0, height: 0, offsetX: 0, offsetY: 0 }
   const padL = yoga.getComputedPadding(LayoutEdge.Left) ?? 0
   const padR = yoga.getComputedPadding(LayoutEdge.Right) ?? 0
   const padT = yoga.getComputedPadding(LayoutEdge.Top) ?? 0
@@ -788,6 +811,8 @@ function measureInnerSize(node: DOMElement): { width: number; height: number } {
   return {
     width: Math.max(0, Math.floor(w - padL - padR - brL - brR)),
     height: Math.max(0, Math.floor(h - padT - padB - brT - brB)),
+    offsetX: Math.floor(brL + padL),
+    offsetY: Math.floor(brT + padT),
   }
 }
 

--- a/packages/renderer/src/hooks/use-declared-cursor.ts
+++ b/packages/renderer/src/hooks/use-declared-cursor.ts
@@ -1,9 +1,48 @@
 import { useCallback, useContext, useLayoutEffect, useRef } from 'react'
 import CursorDeclarationContext from '../components/CursorDeclarationContext'
 import type { DOMElement } from '../dom'
+import type { Color } from '../styles'
+import type { CursorStyle } from '../termio/dec'
+
+export type UseDeclaredCursorOptions = {
+  /** Line number within the declared node (cell row, 0-indexed). */
+  readonly line: number
+  /** Display column within the declared node (cell col, 0-indexed). */
+  readonly column: number
+  /**
+   * When true, set the declared position so the terminal cursor parks
+   * at (line, column) of the attached node. When false, clear the
+   * declaration (conditionally — see implementation note about sibling
+   * handoff and memoized siblings).
+   */
+  readonly active: boolean
+  /**
+   * Optional cursor shape override (DECSCUSR). When set, ink emits
+   * `CSI Ps SP q` alongside the position write. When undefined, the
+   * terminal's configured shape wins. Restored to terminal default
+   * automatically when the declaration clears.
+   */
+  readonly style?: CursorStyle
+  /**
+   * Optional blink override. Pairs with `style` in the DECSCUSR
+   * sequence — DECSCUSR can't set just one half, so leaving either
+   * unset defaults that half (`style ?? 'block'`, `blink ?? true`).
+   */
+  readonly blink?: boolean
+  /**
+   * Optional cursor color override (OSC 12). Support varies by
+   * terminal — xterm, iTerm2, kitty, alacritty, Windows Terminal, VS
+   * Code all honor it; older terminals ignore the sequence (no harm
+   * done). `ansi256(N)` colors aren't supported by OSC 12 syntax.
+   * Restored to terminal default automatically when the declaration
+   * clears.
+   */
+  readonly color?: Color
+}
 
 /**
- * Declares where the terminal cursor should be parked after each frame.
+ * Declares where the terminal cursor should be parked after each frame,
+ * plus optional shape / blink / color overrides.
  *
  * Terminal emulators render IME preedit text at the physical cursor
  * position, and screen readers / screen magnifiers track the native
@@ -21,16 +60,26 @@ import type { DOMElement } from '../dom'
  * (no one-keystroke lag). Test env uses onImmediateRender (synchronous,
  * no microtask), so tests compensate by calling ink.onRender()
  * explicitly after render.
+ *
+ * @example
+ *   const cursorRef = useDeclaredCursor({
+ *     line: caret.line,
+ *     column: caret.col,
+ *     active: isFocused,
+ *     style: 'bar',
+ *     blink: false,
+ *     color: '#00ff00',
+ *   })
+ *   return <Box ref={cursorRef}>...</Box>
  */
 export function useDeclaredCursor({
   line,
   column,
   active,
-}: {
-  line: number
-  column: number
-  active: boolean
-}): (element: DOMElement | null) => void {
+  style,
+  blink,
+  color,
+}: UseDeclaredCursorOptions): (element: DOMElement | null) => void {
   const setCursorDeclaration = useContext(CursorDeclarationContext)
   const nodeRef = useRef<DOMElement | null>(null)
 
@@ -50,11 +99,20 @@ export function useDeclaredCursor({
   //      check it would clobber.
   // No dep array: must re-declare every commit so the active instance
   // re-claims the declaration after another instance's unmount-cleanup or
-  // sibling handoff nulls it.
+  // sibling handoff nulls it. style/blink/color are forwarded as-is —
+  // ink dedupes via its own `cursorStyleApplied`/`cursorColorApplied`
+  // tracking, so this hook doesn't need to memoize the declaration.
   useLayoutEffect(() => {
     const node = nodeRef.current
     if (active && node) {
-      setCursorDeclaration({ relativeX: column, relativeY: line, node })
+      setCursorDeclaration({
+        relativeX: column,
+        relativeY: line,
+        node,
+        style,
+        blink,
+        color,
+      })
     } else {
       setCursorDeclaration(null, node)
     }

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -64,6 +64,8 @@ export { useTerminalTitle } from './hooks/use-terminal-title'
 export { useTabStatus } from './hooks/use-tab-status'
 export type { TabStatusKind } from './hooks/use-tab-status'
 export { useDeclaredCursor } from './hooks/use-declared-cursor'
+export type { UseDeclaredCursorOptions } from './hooks/use-declared-cursor'
+export type { CursorStyle } from './termio/dec'
 export { useSearchHighlight } from './hooks/use-search-highlight'
 export { useSelection, useHasSelection } from './hooks/use-selection'
 

--- a/packages/renderer/src/ink.tsx
+++ b/packages/renderer/src/ink.tsx
@@ -1,6 +1,6 @@
 import { closeSync, constants as fsConstants, openSync, readSync, writeSync } from 'node:fs'
 import { format } from 'node:util'
-import { logForDebugging } from '@yokai/shared'
+import { isEnvTruthy, logForDebugging } from '@yokai/shared'
 import { logError } from '@yokai/shared'
 import { getYogaCounters } from '@yokai/shared/yoga-layout'
 import autoBind from 'auto-bind'
@@ -94,6 +94,7 @@ import {
   ENABLE_MOUSE_TRACKING,
   ENTER_ALT_SCREEN,
   EXIT_ALT_SCREEN,
+  HIDE_CURSOR,
   SHOW_CURSOR,
 } from './termio/dec'
 import {
@@ -235,6 +236,14 @@ export default class Ink {
   // screen readers / screen magnifiers track it — so parking at the text
   // input's caret makes CJK input appear inline and lets a11y tools follow.
   private cursorDeclaration: CursorDeclaration | null = null
+  // Whether the physical terminal cursor is currently visible. App.componentDidMount
+  // hides it on mount (HIDE_CURSOR) so the diff-renderer doesn't show flicker
+  // between frames; useDeclaredCursor consumers (TextInput's caret) rely on
+  // it being shown again at their declared position. Track current visibility
+  // so we only emit SHOW_CURSOR / HIDE_CURSOR on transitions, never per-frame
+  // — repeated emits add bytes but no visual change, and on slow terminals
+  // can cause real cursor flicker.
+  private cursorVisible = false
   // Main-screen: physical cursor position after the declared-cursor move,
   // tracked separately from frame.cursor (which must stay at content-bottom
   // for log-update's relative-move invariants). Alt-screen doesn't need
@@ -868,15 +877,32 @@ export default class Ink {
             })
           }
         }
+        // Show the cursor at the declared position. Position write goes
+        // first so the cursor moves invisibly to the right cell, THEN
+        // appears — avoids a one-frame flash at the previous position.
+        // Only on transition; per-frame SHOW_CURSOR adds bytes for no
+        // visual change AND can cause real flicker on slow terminals.
+        if (!this.cursorVisible) {
+          optimized.push({ type: 'stdout', content: SHOW_CURSOR })
+          this.cursorVisible = true
+        }
         this.displayCursor = target
       } else {
-        // Declaration cleared (input blur, unmount). Restore physical cursor
-        // to frame.cursor before forgetting the park position — otherwise
-        // displayCursor=null lies about where the cursor is, and the NEXT
-        // frame's preamble (or log-update's relative moves) computes from a
-        // wrong spot. The preamble above handles hasDiff; this handles
-        // !hasDiff (e.g. accessibility mode where blur doesn't change
-        // renderedValue since invert is identity).
+        // Declaration cleared (input blur, unmount). Hide the cursor
+        // FIRST so the subsequent restore-move doesn't flash a visible
+        // cursor across the screen. App.componentDidMount established
+        // hidden-by-default; we're returning the visibility state to
+        // its baseline.
+        if (this.cursorVisible) {
+          optimized.push({ type: 'stdout', content: HIDE_CURSOR })
+          this.cursorVisible = false
+        }
+        // Restore physical cursor to frame.cursor before forgetting the
+        // park position — otherwise displayCursor=null lies about where
+        // the cursor is, and the NEXT frame's preamble (or log-update's
+        // relative moves) computes from a wrong spot. The preamble above
+        // handles hasDiff; this handles !hasDiff (e.g. accessibility mode
+        // where blur doesn't change renderedValue since invert is identity).
         if (parked !== null && !this.altScreenActive && !hasDiff) {
           const rdx = frame.cursor.x - parked.x
           const rdy = frame.cursor.y - parked.y
@@ -1509,6 +1535,28 @@ export default class Ink {
     })
   }
   /**
+   * Hide the physical terminal cursor and update internal visibility
+   * tracking. App calls this on mount + on resume-from-suspend so the
+   * diff renderer doesn't show cursor flicker between frames; the
+   * render-path SHOW_CURSOR write later in the same tick re-enables
+   * the cursor at the declared position when a TextInput is focused.
+   *
+   * Goes through this method (rather than App writing HIDE_CURSOR
+   * directly) so `cursorVisible` state stays consistent — without it,
+   * a TextInput-focused → suspend → resume sequence leaves the
+   * terminal cursor hidden but ink thinks it's visible, so subsequent
+   * renders never re-emit SHOW.
+   *
+   * Honors `CLAUDE_CODE_ACCESSIBILITY` — in accessibility mode the
+   * native cursor stays visible for screen magnifiers and other tools.
+   */
+  hideCursor(): void {
+    if (!this.options.stdout.isTTY) return
+    if (isEnvTruthy(process.env.CLAUDE_CODE_ACCESSIBILITY)) return
+    this.options.stdout.write(HIDE_CURSOR)
+    this.cursorVisible = false
+  }
+  /**
    * Look up the URL at (col, row) in the current front frame. Checks for
    * an OSC 8 hyperlink first, then falls back to scanning the row for a
    * plain-text URL (mouse tracking intercepts the terminal's native
@@ -1704,6 +1752,7 @@ export default class Ink {
         dispatchKeyboardEvent={this.dispatchKeyboardEvent}
         dispatchPasteEvent={this.dispatchPasteEvent}
         copyToClipboard={this.copyToClipboard}
+        hideCursor={this.hideCursor}
         focusManager={this.focusManager}
         rootNode={this.rootNode}
       >

--- a/packages/renderer/src/ink.tsx
+++ b/packages/renderer/src/ink.tsx
@@ -95,7 +95,10 @@ import {
   ENTER_ALT_SCREEN,
   EXIT_ALT_SCREEN,
   HIDE_CURSOR,
+  RESET_CURSOR_STYLE,
   SHOW_CURSOR,
+  decscusr,
+  decscusrCode,
 } from './termio/dec'
 import {
   CLEAR_ITERM2_PROGRESS,
@@ -244,6 +247,13 @@ export default class Ink {
   // — repeated emits add bytes but no visual change, and on slow terminals
   // can cause real cursor flicker.
   private cursorVisible = false
+  // Last DECSCUSR code we wrote (1-6 per cursor style + blink combo).
+  // null = no override applied (terminal default in effect). Tracked so
+  // we only emit DECSCUSR on transition AND so we know to emit
+  // RESET_CURSOR_STYLE when a declaration with a style is replaced by
+  // one without — without the reset, an input that sets `style: 'bar'`
+  // and then unmounts leaves the user's shell prompt as a bar cursor.
+  private cursorStyleApplied: number | null = null
   // Main-screen: physical cursor position after the declared-cursor move,
   // tracked separately from frame.cursor (which must stay at content-bottom
   // for log-update's relative-move invariants). Alt-screen doesn't need
@@ -828,11 +838,28 @@ export default class Ink {
         : null
     const parked = this.displayCursor
 
+    // DECSCUSR style + blink override. `desiredStyleCode` is null when
+    // the declaration doesn't request any override (no DECSCUSR write
+    // needed) OR when there's no declaration at all. When non-null
+    // it's the 1-6 code for the configured style+blink pair.
+    //
+    // The transition cases:
+    //   null → code   : write DECSCUSR(code)              (apply override)
+    //   code → other  : write DECSCUSR(other)             (change style)
+    //   code → null   : write RESET_CURSOR_STYLE          (restore default)
+    //   same → same   : skip                              (no-op fast path)
+    const desiredStyleCode =
+      decl !== null && (decl.style !== undefined || decl.blink !== undefined)
+        ? decscusrCode(decl.style ?? 'block', decl.blink ?? true)
+        : null
+    const styleChanged = desiredStyleCode !== this.cursorStyleApplied
+
     // Preserve the empty-diff zero-write fast path: skip all cursor writes
-    // when nothing rendered AND the park target is unchanged.
+    // when nothing rendered AND the park target is unchanged AND no
+    // style override transition is pending.
     const targetMoved =
       target !== null && (parked === null || parked.x !== target.x || parked.y !== target.y)
-    if (hasDiff || targetMoved || (target === null && parked !== null)) {
+    if (hasDiff || targetMoved || styleChanged || (target === null && parked !== null)) {
       // Main-screen preamble: log-update's relative moves assume the
       // physical cursor is at prevFrame.cursor. If last frame parked it
       // elsewhere, move back before the diff runs. Alt-screen's CSI H
@@ -914,6 +941,20 @@ export default class Ink {
           }
         }
         this.displayCursor = null
+      }
+
+      // DECSCUSR style/blink override — fires after position + visibility
+      // so the cursor is at its final cell when the shape change applies.
+      // Cleared declarations (desiredStyleCode === null) emit
+      // RESET_CURSOR_STYLE so the user's terminal config wins again
+      // post-input — the difference between "yokai is a good citizen"
+      // and "yokai poisons your shell with a bar cursor."
+      if (styleChanged) {
+        optimized.push({
+          type: 'stdout',
+          content: desiredStyleCode !== null ? decscusr(desiredStyleCode) : RESET_CURSOR_STYLE,
+        })
+        this.cursorStyleApplied = desiredStyleCode
       }
     }
     const tWrite = performance.now()

--- a/packages/renderer/src/ink.tsx
+++ b/packages/renderer/src/ink.tsx
@@ -1628,6 +1628,27 @@ export default class Ink {
     this.cursorVisible = false
   }
   /**
+   * Restore the terminal's configured cursor shape + color, flushing
+   * any active DECSCUSR / OSC 12 overrides. Called by App when
+   * suspending (so the user's shell prompt isn't left with a
+   * yokai-styled cursor) and by the unmount path.
+   *
+   * Updates the tracking fields to null so the next render after a
+   * resume re-applies the override if a declaration with style/color
+   * is still active. Idempotent — no writes if nothing was applied.
+   */
+  restoreCursorDefaults(): void {
+    if (!this.options.stdout.isTTY) return
+    if (this.cursorStyleApplied !== null) {
+      this.options.stdout.write(RESET_CURSOR_STYLE)
+      this.cursorStyleApplied = null
+    }
+    if (this.cursorColorApplied !== null) {
+      this.options.stdout.write(RESET_CURSOR_COLOR)
+      this.cursorColorApplied = null
+    }
+  }
+  /**
    * Look up the URL at (col, row) in the current front frame. Checks for
    * an OSC 8 hyperlink first, then falls back to scanning the row for a
    * plain-text URL (mouse tracking intercepts the terminal's native
@@ -1824,6 +1845,7 @@ export default class Ink {
         dispatchPasteEvent={this.dispatchPasteEvent}
         copyToClipboard={this.copyToClipboard}
         hideCursor={this.hideCursor}
+        restoreCursorDefaults={this.restoreCursorDefaults}
         focusManager={this.focusManager}
         rootNode={this.rootNode}
       >
@@ -1883,6 +1905,18 @@ export default class Ink {
       writeSync(1, DFE)
       // Disable bracketed paste mode
       writeSync(1, DBP)
+      // Restore cursor shape + color to terminal defaults BEFORE the
+      // SHOW_CURSOR below — otherwise an input that styled itself as a
+      // green bar cursor leaves the user's shell with that config
+      // forever. Idempotent: a no-op when we never set them.
+      if (this.cursorStyleApplied !== null) {
+        writeSync(1, RESET_CURSOR_STYLE)
+        this.cursorStyleApplied = null
+      }
+      if (this.cursorColorApplied !== null) {
+        writeSync(1, RESET_CURSOR_COLOR)
+        this.cursorColorApplied = null
+      }
       // Show cursor
       writeSync(1, SHOW_CURSOR)
       // Clear iTerm2 progress bar

--- a/packages/renderer/src/ink.tsx
+++ b/packages/renderer/src/ink.tsx
@@ -103,7 +103,9 @@ import {
 import {
   CLEAR_ITERM2_PROGRESS,
   CLEAR_TAB_STATUS,
+  RESET_CURSOR_COLOR,
   setClipboard,
+  setCursorColor,
   supportsTabStatus,
   wrapForMultiplexer,
 } from './termio/osc'
@@ -254,6 +256,14 @@ export default class Ink {
   // one without — without the reset, an input that sets `style: 'bar'`
   // and then unmounts leaves the user's shell prompt as a bar cursor.
   private cursorStyleApplied: number | null = null
+  // Last cursor color we wrote (raw user-provided string — we track
+  // the input rather than the formatted OSC 12 payload so equality
+  // checks don't false-positive on equivalent inputs that format
+  // differently). null = no override (terminal default in effect).
+  // Same restoration semantics as cursorStyleApplied — when cleared,
+  // we emit RESET_CURSOR_COLOR (OSC 112) so the shell prompt isn't
+  // left magenta after our input unmounts.
+  private cursorColorApplied: string | null = null
   // Main-screen: physical cursor position after the declared-cursor move,
   // tracked separately from frame.cursor (which must stay at content-bottom
   // for log-update's relative-move invariants). Alt-screen doesn't need
@@ -843,23 +853,31 @@ export default class Ink {
     // needed) OR when there's no declaration at all. When non-null
     // it's the 1-6 code for the configured style+blink pair.
     //
-    // The transition cases:
-    //   null → code   : write DECSCUSR(code)              (apply override)
-    //   code → other  : write DECSCUSR(other)             (change style)
-    //   code → null   : write RESET_CURSOR_STYLE          (restore default)
-    //   same → same   : skip                              (no-op fast path)
+    // The transition cases (apply identically to color below):
+    //   null → value : write apply sequence              (override on)
+    //   value → other: write apply sequence              (override change)
+    //   value → null : write reset sequence              (restore default)
+    //   same → same  : skip                              (fast path)
     const desiredStyleCode =
       decl !== null && (decl.style !== undefined || decl.blink !== undefined)
         ? decscusrCode(decl.style ?? 'block', decl.blink ?? true)
         : null
     const styleChanged = desiredStyleCode !== this.cursorStyleApplied
+    const desiredColor = decl?.color !== undefined ? String(decl.color) : null
+    const colorChanged = desiredColor !== this.cursorColorApplied
 
     // Preserve the empty-diff zero-write fast path: skip all cursor writes
     // when nothing rendered AND the park target is unchanged AND no
-    // style override transition is pending.
+    // style/color override transition is pending.
     const targetMoved =
       target !== null && (parked === null || parked.x !== target.x || parked.y !== target.y)
-    if (hasDiff || targetMoved || styleChanged || (target === null && parked !== null)) {
+    if (
+      hasDiff ||
+      targetMoved ||
+      styleChanged ||
+      colorChanged ||
+      (target === null && parked !== null)
+    ) {
       // Main-screen preamble: log-update's relative moves assume the
       // physical cursor is at prevFrame.cursor. If last frame parked it
       // elsewhere, move back before the diff runs. Alt-screen's CSI H
@@ -955,6 +973,18 @@ export default class Ink {
           content: desiredStyleCode !== null ? decscusr(desiredStyleCode) : RESET_CURSOR_STYLE,
         })
         this.cursorStyleApplied = desiredStyleCode
+      }
+
+      // OSC 12 cursor color override — same transition semantics as
+      // style. Terminals that don't support it ignore the sequence
+      // (no harm). RESET_CURSOR_COLOR (OSC 112) restores the user's
+      // configured color when our override clears.
+      if (colorChanged) {
+        optimized.push({
+          type: 'stdout',
+          content: desiredColor !== null ? setCursorColor(desiredColor) : RESET_CURSOR_COLOR,
+        })
+        this.cursorColorApplied = desiredColor
       }
     }
     const tWrite = performance.now()

--- a/packages/renderer/src/termio/dec.test.ts
+++ b/packages/renderer/src/termio/dec.test.ts
@@ -1,0 +1,65 @@
+/**
+ * Tests for DEC private mode helpers, specifically the DECSCUSR
+ * (cursor style + blink) machinery introduced for the cursor-styling
+ * PR. The 1-6 code matrix is enumerated explicitly so a regression
+ * where someone swaps two codes shows up immediately rather than
+ * "the cursor looks slightly different now."
+ */
+
+import { describe, expect, it } from 'vitest'
+import { type CursorStyle, RESET_CURSOR_STYLE, decscusr, decscusrCode } from './dec.js'
+
+const ESC = '\x1b'
+
+describe('decscusrCode', () => {
+  // Full matrix as a table of [style, blink, expected code]. Lifted
+  // from the DECSCUSR spec — 1-6 are the visible cursor configurations
+  // a terminal can be in. 0 (default) is reset, tested separately via
+  // RESET_CURSOR_STYLE below.
+  const matrix: ReadonlyArray<[CursorStyle, boolean, number]> = [
+    ['block', true, 1], //  blinking block
+    ['block', false, 2], //  steady block
+    ['underline', true, 3], //  blinking underline
+    ['underline', false, 4], //  steady underline
+    ['bar', true, 5], //  blinking bar
+    ['bar', false, 6], //  steady bar
+  ]
+
+  for (const [style, blink, expected] of matrix) {
+    it(`(${style}, blink=${blink}) → ${expected}`, () => {
+      expect(decscusrCode(style, blink)).toBe(expected)
+    })
+  }
+})
+
+describe('decscusr', () => {
+  it('emits CSI Ps SP q with literal space before q', () => {
+    // The space matters — `CSI 5 q` is a totally different sequence
+    // (DECSED selective erase). DECSCUSR is `CSI Ps SP q`.
+    expect(decscusr(1)).toBe(`${ESC}[1 q`)
+    expect(decscusr(6)).toBe(`${ESC}[6 q`)
+  })
+
+  it('accepts 0 (reset to terminal default)', () => {
+    expect(decscusr(0)).toBe(`${ESC}[0 q`)
+  })
+
+  it('handles multi-digit codes (defensive — DECSCUSR codes are 0-6)', () => {
+    // Future DECSCUSR codes may exist (some terminals extend); the
+    // helper shouldn't break.
+    expect(decscusr(10)).toBe(`${ESC}[10 q`)
+  })
+})
+
+describe('RESET_CURSOR_STYLE', () => {
+  it('is `CSI 0 SP q`', () => {
+    // Hardcoded for clarity — the constant is what most callers use,
+    // bypassing decscusr(). A regression here breaks every cleanup
+    // path that restores the terminal default cursor.
+    expect(RESET_CURSOR_STYLE).toBe(`${ESC}[0 q`)
+  })
+
+  it('matches decscusr(0)', () => {
+    expect(RESET_CURSOR_STYLE).toBe(decscusr(0))
+  })
+})

--- a/packages/renderer/src/termio/dec.ts
+++ b/packages/renderer/src/termio/dec.ts
@@ -58,3 +58,41 @@ export const DISABLE_MOUSE_TRACKING =
   decreset(DEC.MOUSE_ANY) +
   decreset(DEC.MOUSE_BUTTON) +
   decreset(DEC.MOUSE_NORMAL)
+
+/**
+ * Cursor shape.
+ *
+ * - `'block'`     — full-cell rectangle; DEC's default cursor
+ * - `'underline'` — single-row line at the cell's bottom (vt220 underscore cursor)
+ * - `'bar'`       — single-column line at the cell's left edge (modern editor caret)
+ *
+ * Combined with `blink` and emitted via DECSCUSR (`CSI Ps SP q`).
+ */
+export type CursorStyle = 'block' | 'underline' | 'bar'
+
+// DECSCUSR code matrix: rows = style, cols = [steady, blinking].
+// 0 is reserved for "reset to terminal default" (RESET_CURSOR_STYLE).
+const CURSOR_STYLE_CODES: Record<CursorStyle, readonly [number, number]> = {
+  block: [2, 1],
+  underline: [4, 3],
+  bar: [6, 5],
+}
+
+/** DECSCUSR code (1-6) for a given (style, blink) pair. */
+export function decscusrCode(style: CursorStyle, blink: boolean): number {
+  const [steady, blinking] = CURSOR_STYLE_CODES[style]
+  return blink ? blinking : steady
+}
+
+/**
+ * DECSCUSR sequence: `CSI Ps SP q` (literal space before `q`). Most
+ * modern terminals (xterm, iTerm2, kitty, Windows Terminal, alacritty,
+ * VS Code) honor codes 0-6. Others ignore the sequence — safe to emit
+ * unconditionally.
+ */
+export function decscusr(code: number): string {
+  return csi(`${code} q`)
+}
+
+/** `CSI 0 SP q` — restore terminal-configured cursor shape + blink. */
+export const RESET_CURSOR_STYLE = decscusr(0)

--- a/packages/renderer/src/termio/osc.test.ts
+++ b/packages/renderer/src/termio/osc.test.ts
@@ -25,7 +25,13 @@ vi.mock('@yokai/shared', async () => {
   }
 })
 
-import { _resetLinuxCopyCache, setClipboard } from './osc.js'
+import {
+  RESET_CURSOR_COLOR,
+  _resetLinuxCopyCache,
+  formatCursorColor,
+  setClipboard,
+  setCursorColor,
+} from './osc.js'
 
 const ESC = '\x1b'
 const BEL = '\x07'
@@ -194,5 +200,62 @@ describe('setClipboard', () => {
         )
       })
     })
+  })
+})
+
+describe('formatCursorColor', () => {
+  it('passes hex colors through unchanged', () => {
+    expect(formatCursorColor('#00ff00')).toBe('#00ff00')
+    expect(formatCursorColor('#abc123')).toBe('#abc123')
+  })
+
+  it('converts rgb(...) to #rrggbb', () => {
+    expect(formatCursorColor('rgb(0,255,0)')).toBe('#00ff00')
+    expect(formatCursorColor('rgb(255, 128, 64)')).toBe('#ff8040')
+  })
+
+  it('clamps rgb components to a byte (defensive — should never be > 255)', () => {
+    // & 0xff truncates rather than throws; verifies the formatter
+    // doesn't silently emit malformed hex if someone passes 300.
+    expect(formatCursorColor('rgb(300,0,0)')).toBe('#2c0000') // 300 & 0xff = 44 = 0x2c
+  })
+
+  it('strips the ansi: prefix from yokai-style named colors', () => {
+    expect(formatCursorColor('ansi:cyan')).toBe('cyan')
+    expect(formatCursorColor('ansi:redBright')).toBe('redBright')
+  })
+
+  it('passes named colors / theme keys / arbitrary strings through', () => {
+    // The terminal interprets these (or doesn't); not our problem.
+    expect(formatCursorColor('red')).toBe('red')
+    expect(formatCursorColor('dodgerblue')).toBe('dodgerblue')
+    expect(formatCursorColor('some-theme-key')).toBe('some-theme-key')
+  })
+
+  it('passes ansi256 through (documented unsupported by OSC 12)', () => {
+    // Terminals will probably ignore — there's no OSC 12 ansi256
+    // syntax. Documented behavior; tested so a future "convert to RGB"
+    // change is intentional, not accidental.
+    expect(formatCursorColor('ansi256(15)')).toBe('ansi256(15)')
+  })
+})
+
+describe('setCursorColor', () => {
+  it('wraps the formatted color in OSC 12', () => {
+    expect(setCursorColor('#00ff00')).toBe(`${ESC}]12;#00ff00${BEL}`)
+  })
+
+  it('formats rgb(...) before wrapping', () => {
+    expect(setCursorColor('rgb(255,0,128)')).toBe(`${ESC}]12;#ff0080${BEL}`)
+  })
+
+  it('strips ansi: prefix before wrapping', () => {
+    expect(setCursorColor('ansi:magenta')).toBe(`${ESC}]12;magenta${BEL}`)
+  })
+})
+
+describe('RESET_CURSOR_COLOR', () => {
+  it('is the OSC 112 sequence with no payload', () => {
+    expect(RESET_CURSOR_COLOR).toBe(`${ESC}]112${BEL}`)
   })
 })

--- a/packages/renderer/src/termio/osc.ts
+++ b/packages/renderer/src/termio/osc.ts
@@ -239,6 +239,55 @@ export const OSC = {
 } as const
 
 /**
+ * Translate a yokai `Color`-shaped string into an OSC 12-compatible
+ * value. xterm and friends accept:
+ *
+ *   - `#rrggbb` hex
+ *   - `rgb:rrrr/gggg/bbbb` 16-bit-component xterm syntax
+ *   - X11 / CSS named colors (`red`, `cyan`, `dodgerblue`, …)
+ *
+ * Conversions:
+ *   - `'#rrggbb'`            → as-is
+ *   - `'rgb(r,g,b)'`         → `'#rrggbb'` (8-bit per channel)
+ *   - `'ansi:cyan'`          → `'cyan'`   (drop the yokai prefix)
+ *   - `'ansi256(N)'`         → as-is (terminals will likely ignore;
+ *                               OSC 12 has no ansi256 syntax —
+ *                               documented as unsupported)
+ *   - anything else (named color, theme key, raw string) → as-is
+ *
+ * Pure helper, no I/O.
+ */
+export function formatCursorColor(color: string): string {
+  const rgbMatch = /^rgb\((\d+),\s*(\d+),\s*(\d+)\)$/.exec(color)
+  if (rgbMatch) {
+    const r = Number.parseInt(rgbMatch[1]!, 10) & 0xff
+    const g = Number.parseInt(rgbMatch[2]!, 10) & 0xff
+    const b = Number.parseInt(rgbMatch[3]!, 10) & 0xff
+    return `#${r.toString(16).padStart(2, '0')}${g.toString(16).padStart(2, '0')}${b.toString(16).padStart(2, '0')}`
+  }
+  if (color.startsWith('ansi:')) return color.slice(5)
+  return color
+}
+
+/**
+ * Build the OSC 12 sequence that sets the terminal cursor color.
+ * Terminator follows the osc() helper convention (ST for kitty, BEL
+ * everywhere else). Returns the full sequence ready to write to
+ * stdout.
+ */
+export function setCursorColor(color: string): string {
+  return osc(OSC.SET_CURSOR_COLOR, formatCursorColor(color))
+}
+
+/**
+ * OSC 112 — reset the cursor color to the terminal's configured value.
+ * No payload. Used by ink when a declaration with a `color` is
+ * replaced by one without (or cleared) so the user's shell prompt
+ * doesn't keep our color override after the input unmounts.
+ */
+export const RESET_CURSOR_COLOR = osc(OSC.RESET_CURSOR_COLOR)
+
+/**
  * Parse an OSC sequence into an action
  *
  * @param content - The sequence content (without ESC ] and terminator)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -28,6 +28,19 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
 
+  examples/cursor-styles:
+    dependencies:
+      '@yokai/renderer':
+        specifier: workspace:*
+        version: link:../../packages/renderer
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+    devDependencies:
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+
   examples/drag:
     dependencies:
       '@yokai/renderer':


### PR DESCRIPTION
## Summary

Fixes the visibility bug Mark hit (cursor was positioned correctly via useDeclaredCursor but stayed invisible because App globally hid it on mount and the render path never re-showed it). Plus adds the three terminal-controllable cursor knobs to round out a "the input feels real" cursor primitive.

## What you can do now

```tsx
<TextInput
  cursorStyle="bar"        // 'block' | 'underline' | 'bar'
  cursorBlink={false}
  cursorColor="#00ff00"    // hex / rgb(...) / 'ansi:cyan' / X11 names
/>
```

Default = undefined for all three → terminal-configured cursor wins. Restored to terminal defaults automatically on blur / unmount / suspend so a yokai-styled cursor doesn't poison the user's shell prompt.

The hook layer (`useDeclaredCursor`) is now public, so any custom focusable widget can theme its cursor with the same plumbing — not just TextInput.

## Commits (7, granular, each self-contained)

1. `fix(ink): show cursor when an active declaration exists` — the visibility bug. App.componentDidMount hides globally; render path now emits SHOW_CURSOR on transition into "active declaration." Added `Ink.hideCursor()` so App's two existing direct-write hide sites (mount, post-suspend) coordinate with the visibility tracking.
2. `feat(ink): emit DECSCUSR style + blink alongside cursor position` — `CSI Ps SP q`, 1-6 code matrix, `cursorStyleApplied` tracking, RESET_CURSOR_STYLE on transition out.
3. `feat(ink): emit OSC 12 cursor color alongside cursor position` — `ESC ]12;<color>BEL`, formatCursorColor() handles RGB/hex/named/ansi:prefix conversions, RESET_CURSOR_COLOR (OSC 112) on transition out.
4. `feat(use-declared-cursor): style + blink + color props` — hook surface. `UseDeclaredCursorOptions` + `CursorStyle` exported publicly.
5. `feat(TextInput): cursorStyle + cursorBlink + cursorColor props` — the consumer-facing prop layer; pure forwarding to the hook.
6. `feat(ink): restore cursor defaults on unmount + suspend` — the "good citizen" cleanup. New `Ink.restoreCursorDefaults()` for App's suspend; unmount path writes resets directly. Both idempotent.
7. `test(termio): cursor sequence shapes + DECSCUSR matrix` — pure-helper coverage. 11 tests in dec.test.ts, 11 new tests appended to osc.test.ts. Full DECSCUSR (style × blink) matrix enumerated as a table.

## What's deliberately NOT here

- **Custom synthetic cursor animations / smoothing** — covered by the roadmap Phase 5 "skip outright" reasoning. We use the real terminal cursor for IME composition + screen reader / magnifier tracking; replacing with a synthetic glyph regresses both. The aesthetic upside isn't worth the functional regression for a production renderer.

## Test plan

- [ ] `pnpm demo:text-input` — focused TextInput now shows a visible cursor
- [ ] Click between Name / Bio / Password fields — cursor moves with focus, becomes invisible when nothing is focused
- [ ] Type, then exit (Ctrl+C from non-focused state) — shell prompt's cursor matches the user's shell config (bar / block / whatever), not whatever the last TextInput was
- [ ] On Unix: Ctrl+Z to suspend, then `fg` to resume — shell prompt cursor restored on suspend, in-app cursor restored on resume
- [ ] Pass `cursorStyle="bar" cursorBlink={false} cursorColor="#00ff00"` to a TextInput — cursor renders as steady green bar while focused, terminal default on blur

## Numbers

367 tests pass (was 346 + 11 dec.test + 10 osc.test additions = 367). typecheck + lint + build all green. `dist/` rebuilt before push so demo loads the changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)