### PR TITLE
feat(TextInput): selection rendering polish + public API props (Phase D + E, PR 3/4)

### DIFF
--- a/examples/text-input/text-input.tsx
+++ b/examples/text-input/text-input.tsx
@@ -1,12 +1,31 @@
 /**
- * TextInput demo — single-line, multiline, password, controlled.
+ * TextInput demo — soft-wrap edition.
  *
  *   pnpm demo:text-input
  *
- * Four text inputs on screen, each demonstrating a different mode.
- * Tab between them; arrow / Home / End / Ctrl+arrow nav within;
- * Backspace / Delete / Ctrl+W / Ctrl+U / Ctrl+K editing; Ctrl+Z /
- * Ctrl+Shift+Z undo/redo. Selection via Shift+arrows or mouse drag.
+ * Five text inputs covering every prop the soft-wrap work added:
+ *
+ *   - Name      single-line. wrap='none' default (h-scroll past width).
+ *   - Bio       multiline. wrap='soft' default + hanging indent. Type
+ *               past the right edge to watch lines wrap onto
+ *               continuation rows; ↓/↑ walk visual rows including the
+ *               wraps. Indented bullets show the hanging-indent
+ *               decoration aligning continuations under the first
+ *               non-whitespace char.
+ *   - Command   multiline + wordBoundaries='identifier'. Wraps prefer
+ *               break points inside snake_case / kebab-case names AND
+ *               at camelCase transitions. URLs stay atomic.
+ *   - Mentions  multiline + wrapHints. Programmatic atomic spans —
+ *               @toast and chit-abc-123 stay together even when the
+ *               surrounding text would otherwise break inside them.
+ *               Hints are hardcoded against the initial value's char
+ *               positions; a real app would derive them from a parser.
+ *   - Password  single-line, masked. wrap='none' default (h-scroll).
+ *
+ * Tab between fields. Editing: type, Backspace, Delete, Ctrl+W (word
+ * back), Ctrl+U / Ctrl+K (line back / fwd), Ctrl+Z / Ctrl+Shift+Z
+ * (undo/redo). Selection: Shift+arrows or mouse drag — multi-row
+ * selections paint as one continuous stripe.
  *
  * Smart paste: pastes ≤ 32 chars feel like typing (set on the
  * AlternateScreen). Pastes above fire onPaste internally — visible as
@@ -15,9 +34,18 @@
  * Press Ctrl+C to quit.
  */
 
-import { AlternateScreen, Box, Text, TextInput, render, useApp, useInput } from '@yokai/renderer'
+import {
+  AlternateScreen,
+  Box,
+  Text,
+  TextInput,
+  type WrapHint,
+  render,
+  useApp,
+  useInput,
+} from '@yokai/renderer'
 import type React from 'react'
-import { useState } from 'react'
+import { useMemo, useState } from 'react'
 
 function App(): React.ReactNode {
   const { exit } = useApp()
@@ -27,21 +55,42 @@ function App(): React.ReactNode {
 
   const [name, setName] = useState('')
   const [bio, setBio] = useState(
-    'Multiline. Type, paste, undo with Ctrl+Z. Use arrow keys + Home/End.\nLine 2: Ctrl+W deletes a word back; Ctrl+U a line back.',
+    'Multiline soft-wrap. Long lines wrap onto continuation rows; ↓/↑ walk visual rows including wraps.\n  * Hanging indent: continuation rows of an indented line align under the first non-whitespace char.\nShift+arrow extends selection across rows as one continuous stripe.',
+  )
+  const [command, setCommand] = useState(
+    '/sling --target=backend-engineer --chit=chit-abc-123 --link=https://github.com/foo/bar',
+  )
+  const [mentions, setMentions] = useState(
+    '@toast and chit-abc-123 — please review wrap-math',
   )
   const [password, setPassword] = useState('')
   const [submitted, setSubmitted] = useState<string | null>(null)
 
+  // Memoize the wrap-hints array reference. The TextInput's layout
+  // useMemo includes wrapHints as a dep — passing a fresh array every
+  // render forces a layout recompute. Stable ref keeps the layout
+  // cached across re-renders that don't change the buffer.
+  // Indices match the INITIAL value above; if you edit the field,
+  // the hints don't track. A real app would derive hints from a
+  // parser running on state.value.
+  const mentionHints = useMemo<ReadonlyArray<WrapHint>>(
+    () => [
+      { start: 0, end: 6 }, // @toast
+      { start: 11, end: 23 }, // chit-abc-123
+    ],
+    [],
+  )
+
   return (
     <AlternateScreen mouseTracking pasteThreshold={32}>
       <Box flexDirection="column" padding={1} gap={1}>
-        <Text bold>yokai · TextInput demo</Text>
+        <Text bold>yokai · TextInput demo (soft-wrap edition)</Text>
         <Text dim>
           Tab between fields. Type, paste, undo (Ctrl+Z) / redo (Ctrl+Shift+Z). Ctrl+C to quit.
         </Text>
 
         <Box flexDirection="column" gap={1}>
-          <Field label="Name (controlled, single-line)">
+          <Field label="Name (single-line — wrap='none' default; h-scroll past width)">
             <TextInput
               value={name}
               onChange={setName}
@@ -54,7 +103,7 @@ function App(): React.ReactNode {
             />
           </Field>
 
-          <Field label="Bio (uncontrolled, multiline, Ctrl+Enter to submit)">
+          <Field label="Bio (multiline — wrap='soft' default; hanging indent on continuations)">
             <TextInput
               defaultValue={bio}
               onChange={setBio}
@@ -67,7 +116,35 @@ function App(): React.ReactNode {
             />
           </Field>
 
-          <Field label="Password (single-line, masked)">
+          <Field label="Command (multiline + wordBoundaries='identifier' — breaks at -/_/camelCase, URLs atomic)">
+            <TextInput
+              defaultValue={command}
+              onChange={setCommand}
+              multiline
+              wordBoundaries="identifier"
+              onSubmit={(v) => setSubmitted(`command = ${JSON.stringify(v.slice(0, 40))}…`)}
+              borderStyle="round"
+              paddingX={1}
+              width={40}
+              height={4}
+            />
+          </Field>
+
+          <Field label="Mentions (multiline + wrapHints — @toast and chit-abc-123 stay atomic)">
+            <TextInput
+              defaultValue={mentions}
+              onChange={setMentions}
+              multiline
+              wrapHints={mentionHints}
+              onSubmit={(v) => setSubmitted(`mentions = ${JSON.stringify(v.slice(0, 40))}…`)}
+              borderStyle="round"
+              paddingX={1}
+              width={28}
+              height={4}
+            />
+          </Field>
+
+          <Field label="Password (single-line, masked — h-scroll default)">
             <TextInput
               value={password}
               onChange={setPassword}
@@ -87,6 +164,12 @@ function App(): React.ReactNode {
           </Text>
           <Text dim>
             bio length: <Text bold>{bio.length}</Text>
+          </Text>
+          <Text dim>
+            command length: <Text bold>{command.length}</Text>
+          </Text>
+          <Text dim>
+            mentions length: <Text bold>{mentions.length}</Text>
           </Text>
           <Text dim>
             password length: <Text bold>{password.length}</Text>

--- a/packages/renderer/src/components/TextInput/TextInput.tsx
+++ b/packages/renderer/src/components/TextInput/TextInput.tsx
@@ -783,6 +783,32 @@ function renderLines(state: TextInputState, layout: WrapLayout, opts: RenderOpts
   // on every keystroke), and a stable key per slot avoids unmount-on-
   // edit.
   return visibleRows.map((row, rowIdx) => {
+    // Empty visual row (from an empty logical line / consecutive \n).
+    // Renders as a single space — gives the row visual height so the
+    // caret can sit on it, AND fills it with selection bg if a
+    // multi-row selection range passes through this position. Without
+    // the bg, a selection that spans empty lines would appear visually
+    // broken (gaps between the highlighted content rows).
+    //
+    // Touched-by-selection condition for an empty row at position P:
+    // P falls inside the half-open range [selStart, selEnd). The
+    // `selStart < selEnd` guard excludes a degenerate caret-only
+    // "selection" (anchor === focus) from being treated as a stripe.
+    if (row.text === '') {
+      const P = row.startCharIdx
+      const touchesSelection = selStart < selEnd && selStart <= P && P < selEnd
+      return (
+        <Text
+          // biome-ignore lint/suspicious/noArrayIndexKey: see comment above
+          key={rowIdx}
+          wrap="truncate-end"
+          backgroundColor={touchesSelection ? selectionColor : undefined}
+        >
+          {' '}
+        </Text>
+      )
+    }
+
     const maskedText = maskRowText(row.text, password, passwordChar)
     // Hanging-indent decoration: spaces prepended to continuation rows
     // so they visually align under the first non-whitespace char of
@@ -797,17 +823,14 @@ function renderLines(state: TextInputState, layout: WrapLayout, opts: RenderOpts
     const hasInRowSelection = localStart < localEnd
 
     if (!hasInRowSelection) {
-      // No selection on this row — render plain. The `|| ' '` ensures
-      // empty visual rows (zero-cell rows for empty logical lines) get
-      // a single space so the row has height 1; the caret can land on
-      // it. For non-empty content the indent + masked text is used.
+      // No selection on this row — render plain.
       return (
         <Text
           // biome-ignore lint/suspicious/noArrayIndexKey: see comment above
           key={rowIdx}
           wrap="truncate-end"
         >
-          {indent + maskedText || ' '}
+          {indent + maskedText}
         </Text>
       )
     }

--- a/packages/renderer/src/components/TextInput/TextInput.tsx
+++ b/packages/renderer/src/components/TextInput/TextInput.tsx
@@ -963,11 +963,21 @@ function renderLines(state: TextInputState, layout: WrapLayout, opts: RenderOpts
       const localStart = clamp(selStart - row.startCharIdx, 0, row.text.length)
       const localEnd = clamp(selEnd - row.startCharIdx, 0, row.text.length)
       // visStart / visEnd: selection range in the SLICED visible text.
-      // Subtract scrollX (cells) from char-relative localStart/End —
-      // identity for ASCII content; off-by-N for wide chars at the
-      // boundary, same v1 limitation as the old renderer.
-      const visStart = innerWidth > 0 ? Math.max(0, localStart - scrollX) : localStart
-      const visEnd = innerWidth > 0 ? Math.max(0, localEnd - scrollX) : localEnd
+      // Subtract scrollX (cells) from char-relative localStart/End AND
+      // clamp to [0, visibleText.length]. Without the upper clamp, a
+      // selection that's entirely to the right of the horizontal
+      // viewport (selStart and selEnd both past scrollX + innerWidth)
+      // would still pass `visStart !== visEnd` and the renderer would
+      // fall into the selection branch, rendering a phantom
+      // highlighted space (the empty slice + `|| ' '` fallback).
+      // After clamping, off-screen selections collapse to
+      // `visStart === visEnd` and the plain-render branch fires.
+      // Cell math is char-aligned for ASCII content; off-by-N for
+      // wide chars at the boundary, same v1 limitation as the
+      // pre-soft-wrap renderer.
+      const visStart =
+        innerWidth > 0 ? clamp(localStart - scrollX, 0, visibleText.length) : localStart
+      const visEnd = innerWidth > 0 ? clamp(localEnd - scrollX, 0, visibleText.length) : localEnd
 
       if (visStart === visEnd) {
         return (
@@ -981,8 +991,10 @@ function renderLines(state: TextInputState, layout: WrapLayout, opts: RenderOpts
         )
       }
 
+      // Clamping ensures visStart < visEnd here, so the slice is
+      // guaranteed non-empty — no `|| ' '` fallback needed.
       const before = visibleText.slice(0, visStart)
-      const sel = visibleText.slice(visStart, visEnd) || ' '
+      const sel = visibleText.slice(visStart, visEnd)
       const after = visibleText.slice(visEnd)
       return (
         <Text

--- a/packages/renderer/src/components/TextInput/TextInput.tsx
+++ b/packages/renderer/src/components/TextInput/TextInput.tsx
@@ -25,7 +25,7 @@ import Box, { type Props as BoxProps } from '../Box.js'
 import FocusContext from '../FocusContext.js'
 import Text from '../Text.js'
 import { clipboardKeyAction } from './clipboard-action.js'
-import { scrollToKeepCaretVisible } from './scroll-math.js'
+import { scrollToKeepCaretVisible, sliceRowByCells } from './scroll-math.js'
 import {
   type Action,
   type ReducerOptions,
@@ -60,6 +60,26 @@ export type TextInputProps = Except<
   /** Allow newlines in the buffer. Enter inserts a newline; Ctrl+Enter
    *  submits. Default false (single-line). */
   multiline?: boolean
+  /**
+   * Wrap mode.
+   *
+   * - `'soft'` — long lines wrap onto continuation rows. Word boundaries
+   *   used by default; tunable via `wordBoundaries` and `wrapHints`.
+   *   Hanging indent on wraps via `indentedWrap` (default on).
+   * - `'none'` — long lines DON'T wrap. Single-line scrolls horizontally
+   *   to keep the caret visible; multiline truncates each logical line
+   *   at the box's right edge AND scrolls horizontally as the caret
+   *   moves past the visible window.
+   *
+   * Default depends on `multiline`: `'soft'` when multiline (matches
+   * `<textarea>`'s wrap default); `'none'` when single-line (matches
+   * `<input>`, vim's default, every modern editor's "Name field"-style
+   * input). Pass `wrap` explicitly to override either way — for instance
+   * a single-line code-snippet field that should grow vertically can
+   * set `wrap='soft'`, and a multiline address field that should never
+   * wrap can set `wrap='none'`.
+   */
+  wrap?: 'soft' | 'none'
   /** Cap on buffer length in characters. Default unlimited. */
   maxLength?: number
   /** Render placeholder text dimmed when the buffer is empty. */
@@ -161,6 +181,7 @@ export default function TextInput({
   onSubmit,
   onCancel,
   multiline = false,
+  wrap,
   maxLength,
   placeholder,
   password = false,
@@ -176,6 +197,11 @@ export default function TextInput({
   ...boxProps
 }: PropsWithChildren<TextInputProps>): React.ReactNode {
   const isControlled = value !== undefined
+  // Wrap mode default depends on multiline: 'soft' for textarea-style,
+  // 'none' for input-style. Single-line consumers who want vertical
+  // wrap can opt in via wrap='soft'; multiline consumers who want a
+  // single visible logical line per row can opt out via wrap='none'.
+  const effectiveWrap = wrap ?? (multiline ? 'soft' : 'none')
 
   // optsRef MUST be declared before useReducer. On a render that has
   // queued dispatches, useReducer drains them by calling the reducer
@@ -276,22 +302,34 @@ export default function TextInput({
     }
   })
   // Push the latest measured width into optsRef so the next dispatch's
-  // reducer call (visual-row navigation, post-C4) operates on the
-  // current layout. Lags by one frame on the very first render (yoga
-  // hasn't measured yet); the wrap-math primitive treats width=0 as
-  // "no layout, no rows" and visual-row nav falls back gracefully.
-  optsRef.current = { ...optsRef.current, width: inner.width }
+  // reducer call (visual-row navigation, C4) operates on the current
+  // layout. Use the same width regime as the render-side layout above
+  // — MAX_SAFE_INTEGER for wrap='none' (so the reducer's nextVisualRow
+  // sees one row per logical line and Up/Down behave as
+  // logical-line nav, matching what the user sees on screen).
+  optsRef.current = {
+    ...optsRef.current,
+    width: effectiveWrap === 'none' ? Number.MAX_SAFE_INTEGER : inner.width,
+  }
 
   // ── Wrap layout + visual cursor coords ─────────────────────────────
   //
-  // Build the soft-wrap layout from the current buffer and the
-  // measured inner width. The layout decomposes the value into VISUAL
-  // ROWS (one logical line may produce many rows when its cell width
-  // exceeds the budget) and provides bidirectional position maps:
-  // logicalToVisual for placing the cursor; visualToLogical for
-  // mapping clicks back to char indices.
+  // Build the layout from the current buffer + measured inner width.
+  // The layout decomposes the value into VISUAL ROWS (one logical line
+  // may produce many rows when its cell width exceeds the budget) and
+  // provides bidirectional position maps: logicalToVisual for placing
+  // the cursor; visualToLogical for mapping clicks back to char indices.
   //
-  // Width fallback strategy. Two distinct cases produce
+  // Two width regimes:
+  //
+  //   - `wrap === 'none'` — pass MAX_SAFE_INTEGER so no row ever wraps.
+  //     The layout becomes one row per logical line. Caret math still
+  //     works (cell column = sum of cells up to caret); h-scroll
+  //     handles horizontal viewport.
+  //   - `wrap === 'soft'` — pass measured inner.width. Long lines wrap
+  //     onto continuation rows.
+  //
+  // Width fallback strategy (soft-wrap only). Two distinct cases produce
   // `inner.width === 0`, and they need different handling:
   //
   //   1. First render before yoga has measured. No prior valid width —
@@ -314,7 +352,12 @@ export default function TextInput({
   //      doesn't re-render forever.
   const lastValidInnerWidth = useRef(80)
   if (inner.width > 0) lastValidInnerWidth.current = inner.width
-  const layoutWidth = inner.width > 0 ? inner.width : lastValidInnerWidth.current
+  const layoutWidth =
+    effectiveWrap === 'none'
+      ? Number.MAX_SAFE_INTEGER
+      : inner.width > 0
+        ? inner.width
+        : lastValidInnerWidth.current
   const layout = useMemo(
     () => buildWrapLayout(state.value, { width: layoutWidth }),
     [state.value, layoutWidth],
@@ -328,41 +371,31 @@ export default function TextInput({
 
   // ── Scroll: keep caret visible inside the visible window ───────────
   //
-  // scrollY is in VISUAL rows (was logical lines pre-soft-wrap).
-  // scrollX is retained for the future `wrap='none'` opt-in (E1) and
-  // stays at 0 in the soft-wrap default — rows wrap onto next-row
-  // instead of horizontally scrolling within a row. The setter is
-  // prefixed `_` because nothing writes it yet (E1 will rename back).
-  const [scrollX, _setScrollX] = useState(0)
+  // scrollY: visual rows. Always active when innerHeight is bounded.
+  // scrollX: cell columns. Only active when wrap='none' — soft-wrap
+  // doesn't h-scroll because rows wrap onto the next row instead. The
+  // cursor declaration subtracts both unconditionally; in soft-wrap
+  // mode scrollX stays at 0, so the math degenerates to the right
+  // value.
+  const [scrollX, setScrollX] = useState(0)
   const [scrollY, setScrollY] = useState(0)
 
-  // Adjust scrollY on every change that could shift the caret's
-  // visual row out of the visible window. Re-fires on:
-  //
-  //   - inner.height — the box's vertical content area changed (the
-  //     window the caret must fit inside grew or shrank).
-  //   - visual.row — the caret's visual position changed. This is
-  //     transitively driven by state.value (typing / pasting / undo),
-  //     state.caret (any caret-moving action), AND inner.width
-  //     (terminal/container resize → wrap layout rebuild → caret
-  //     visual position recomputes via logicalToVisual). One
-  //     dependency captures all three sources because `visual` is a
-  //     useMemo over (layout, state.caret) and `layout` is a useMemo
-  //     over (state.value, inner.width).
-  //   - layout.rows.length — the total row count changed. Catches the
-  //     edge where width changes but visual.row happens to stay the
-  //     same (e.g. caret on row 0, width grows so content needs
-  //     fewer rows): scrollY needs to clamp to the new max.
-  //   - scrollY — needed for the read-modify-write inside the effect.
+  // Re-scroll on every change that could shift the caret out of the
+  // visible window. See dep notes per-axis below.
   //
   // useEffect (not useLayoutEffect): the next paint reflects both the
   // new caret AND the new scroll in the same render — React batches
-  // the setScrollY here with the original cause.
+  // the setScrollX/Y here with the original cause.
   //
-  // First-frame note: `inner.height === 0` means yoga hasn't measured
-  // yet. Skip the re-scroll for one frame; the next render with a
-  // measured height triggers via the inner.height dep.
+  // First-frame note: `inner.height === 0` / `inner.width === 0` means
+  // yoga hasn't measured yet. Skip for one frame; the next render with
+  // a measured size triggers via the deps.
   useEffect(() => {
+    // Vertical: re-fires on inner.height (box vertical area changed),
+    // visual.row (caret's visual row changed — transitively driven by
+    // state.value / state.caret / inner.width through useMemos),
+    // layout.rows.length (catches the edge where width changes but
+    // visual.row stays the same), and scrollY (read-modify-write).
     if (inner.height > 0) {
       const next = scrollToKeepCaretVisible({
         scroll: scrollY,
@@ -372,7 +405,35 @@ export default function TextInput({
       })
       if (next !== scrollY) setScrollY(next)
     }
-  }, [inner.height, visual.row, layout.rows.length, scrollY])
+    // Horizontal: only when wrap='none'. caretPos = visual.col (in
+    // cells; layout.logicalToVisual returns display cells). contentSize
+    // is the current row's cell width — wrap='none' means one row per
+    // logical line, so this is the caret's logical line's width. Other
+    // logical lines may be longer and clip past the right edge in
+    // multiline mode (single shared scrollX); that's the wrap='none'
+    // multiline UX, matches vim's nowrap behavior.
+    if (effectiveWrap === 'none' && inner.width > 0) {
+      const currentRow = layout.rows[visual.row]
+      const rowWidth = currentRow ? stringWidth(currentRow.text) : 0
+      const next = scrollToKeepCaretVisible({
+        scroll: scrollX,
+        caretPos: visual.col,
+        windowSize: inner.width,
+        contentSize: Math.max(rowWidth, visual.col + 1),
+      })
+      if (next !== scrollX) setScrollX(next)
+    }
+  }, [
+    inner.height,
+    inner.width,
+    visual.row,
+    visual.col,
+    layout.rows,
+    layout.rows.length,
+    scrollX,
+    scrollY,
+    effectiveWrap,
+  ])
 
   // Subscribe to focus state via FocusContext. The earlier shortcut
   // `ref.current.focusManager?.activeElement === ref.current` was
@@ -589,9 +650,11 @@ export default function TextInput({
         passwordChar,
         selectionColor,
         placeholder,
+        scrollX,
         scrollY,
         innerHeight: inner.height,
         innerWidth: inner.width,
+        wrap: effectiveWrap,
       }),
     [
       state,
@@ -600,9 +663,11 @@ export default function TextInput({
       passwordChar,
       selectionColor,
       placeholder,
+      scrollX,
       scrollY,
       inner.height,
       inner.width,
+      effectiveWrap,
     ],
   )
 
@@ -709,15 +774,20 @@ type RenderOpts = {
   passwordChar: string
   selectionColor: Color
   placeholder: string | undefined
+  /** Horizontal scroll offset (cells). Only non-zero when wrap='none'. */
+  scrollX: number
   scrollY: number
   innerHeight: number
   /** Inner content width (cells, net of border + padding). Needed by
-   *  the multi-row selection renderer to compute right-edge slack —
-   *  the gap between the row's content end and the box's right edge —
-   *  which gets filled with selection bg so multi-row selections look
-   *  like one continuous stripe rather than disconnected per-row
-   *  highlights. */
+   *  the multi-row selection renderer (wrap='soft') to compute
+   *  right-edge slack, AND by the per-row cell-slicing path
+   *  (wrap='none') to know how many cells to slice per row. */
   innerWidth: number
+  /** Active wrap mode. `'soft'` uses the wrap layout's visual rows
+   *  with multi-row selection-stripe rendering. `'none'` renders one
+   *  row per logical line and cell-slices each row by `scrollX` for
+   *  horizontal scroll. */
+  wrap: 'soft' | 'none'
 }
 
 /** Mask one row's text with `passwordChar` repeated per code-point.
@@ -759,8 +829,17 @@ function maskRowText(rowText: string, password: boolean, passwordChar: string): 
  *  buffer) the slice may overshoot, so it's clamped to maskedText
  *  length defensively. */
 function renderLines(state: TextInputState, layout: WrapLayout, opts: RenderOpts): React.ReactNode {
-  const { password, passwordChar, selectionColor, placeholder, scrollY, innerHeight, innerWidth } =
-    opts
+  const {
+    password,
+    passwordChar,
+    selectionColor,
+    placeholder,
+    scrollX,
+    scrollY,
+    innerHeight,
+    innerWidth,
+    wrap,
+  } = opts
 
   if (state.value === '' && placeholder) {
     return (
@@ -777,6 +856,57 @@ function renderLines(state: TextInputState, layout: WrapLayout, opts: RenderOpts
   // size to content; subsequent renders apply the slice.
   const visibleRows =
     innerHeight > 0 ? layout.rows.slice(scrollY, scrollY + innerHeight) : layout.rows
+
+  // wrap='none' branch: one row per logical line, cell-sliced by
+  // scrollX for horizontal scroll. Selection is rendered in-row only —
+  // multi-row selection stripe (right-edge / indent fill) doesn't
+  // apply because hanging-indent doesn't apply, and the row's right
+  // edge is past the visible window when content overflows. Same
+  // approximation the pre-soft-wrap renderer used for selection across
+  // a horizontally-scrolled wide char (selection cell math treats
+  // scroll offset as char-aligned).
+  if (wrap === 'none') {
+    return visibleRows.map((row, rowIdx) => {
+      const maskedText = maskRowText(row.text, password, passwordChar)
+      const visibleText =
+        innerWidth > 0 ? sliceRowByCells(maskedText, scrollX, innerWidth) : maskedText
+      const localStart = clamp(selStart - row.startCharIdx, 0, row.text.length)
+      const localEnd = clamp(selEnd - row.startCharIdx, 0, row.text.length)
+      // visStart / visEnd: selection range in the SLICED visible text.
+      // Subtract scrollX (cells) from char-relative localStart/End —
+      // identity for ASCII content; off-by-N for wide chars at the
+      // boundary, same v1 limitation as the old renderer.
+      const visStart = innerWidth > 0 ? Math.max(0, localStart - scrollX) : localStart
+      const visEnd = innerWidth > 0 ? Math.max(0, localEnd - scrollX) : localEnd
+
+      if (visStart === visEnd) {
+        return (
+          <Text
+            // biome-ignore lint/suspicious/noArrayIndexKey: see comment below
+            key={rowIdx}
+            wrap="truncate-end"
+          >
+            {visibleText || ' '}
+          </Text>
+        )
+      }
+
+      const before = visibleText.slice(0, visStart)
+      const sel = visibleText.slice(visStart, visEnd) || ' '
+      const after = visibleText.slice(visEnd)
+      return (
+        <Text
+          // biome-ignore lint/suspicious/noArrayIndexKey: see comment below
+          key={rowIdx}
+          wrap="truncate-end"
+        >
+          {before}
+          <Text backgroundColor={selectionColor}>{sel}</Text>
+          {after}
+        </Text>
+      )
+    })
+  }
 
   // Walk visible rows, emitting per-row segments. Index-as-key is
   // correct here: rows have no stable identity (the buffer re-renders

--- a/packages/renderer/src/components/TextInput/TextInput.tsx
+++ b/packages/renderer/src/components/TextInput/TextInput.tsx
@@ -18,6 +18,7 @@ import type { PasteEvent } from '../../events/paste-event.js'
 import { useClipboard } from '../../hooks/use-clipboard.js'
 import { useDeclaredCursor } from '../../hooks/use-declared-cursor.js'
 import { LayoutEdge } from '../../layout/node.js'
+import { stringWidth } from '../../stringWidth.js'
 import type { Color } from '../../styles.js'
 import type { CursorStyle } from '../../termio/dec.js'
 import Box, { type Props as BoxProps } from '../Box.js'
@@ -590,8 +591,19 @@ export default function TextInput({
         placeholder,
         scrollY,
         innerHeight: inner.height,
+        innerWidth: inner.width,
       }),
-    [state, layout, password, passwordChar, selectionColor, placeholder, scrollY, inner.height],
+    [
+      state,
+      layout,
+      password,
+      passwordChar,
+      selectionColor,
+      placeholder,
+      scrollY,
+      inner.height,
+      inner.width,
+    ],
   )
 
   // Focus-aware border color. Extract idle borderColor from boxProps so
@@ -699,6 +711,13 @@ type RenderOpts = {
   placeholder: string | undefined
   scrollY: number
   innerHeight: number
+  /** Inner content width (cells, net of border + padding). Needed by
+   *  the multi-row selection renderer to compute right-edge slack —
+   *  the gap between the row's content end and the box's right edge —
+   *  which gets filled with selection bg so multi-row selections look
+   *  like one continuous stripe rather than disconnected per-row
+   *  highlights. */
+  innerWidth: number
 }
 
 /** Mask one row's text with `passwordChar` repeated per code-point.
@@ -711,8 +730,27 @@ function maskRowText(rowText: string, password: boolean, passwordChar: string): 
 
 /** Render visual rows from the wrap layout, slicing each row's
  *  selection range and applying password masking + indent decoration.
+ *
+ *  Multi-row selection rendering: a selection that spans more than one
+ *  visual row paints as a CONTINUOUS STRIPE — partial-row segments at
+ *  the start/end fill the row's right-edge slack with selection bg,
+ *  and continuation rows get the same bg over their hanging-indent
+ *  decoration. Eye sees one highlighted region instead of a series of
+ *  disconnected per-row segments.
+ *
+ *  Two row-edge booleans drive the decoration:
+ *
+ *    - `indentBg`: selection started BEFORE this row's first char →
+ *      indent decoration cells get bg. Means the row is mid- or
+ *      end-of a multi-row selection (selection coming in from above).
+ *    - `rightSlackBg`: selection extends PAST this row's last char →
+ *      slack from row content's right edge to box's right edge gets
+ *      bg. Means selection continues onto the next row.
+ *
  *  Empty buffer renders the placeholder dimmed (single-row,
- *  truncate-end so a long placeholder doesn't itself wrap).
+ *  truncate-end so a long placeholder doesn't itself wrap). Empty
+ *  visual rows in a multi-row selection are NOT yet bg-decorated;
+ *  D3 adds that.
  *
  *  Per-row selection slicing uses UNMASKED row.text indices because
  *  row.startCharIdx / state.caret / state.selection are all buffer-
@@ -721,7 +759,8 @@ function maskRowText(rowText: string, password: boolean, passwordChar: string): 
  *  buffer) the slice may overshoot, so it's clamped to maskedText
  *  length defensively. */
 function renderLines(state: TextInputState, layout: WrapLayout, opts: RenderOpts): React.ReactNode {
-  const { password, passwordChar, selectionColor, placeholder, scrollY, innerHeight } = opts
+  const { password, passwordChar, selectionColor, placeholder, scrollY, innerHeight, innerWidth } =
+    opts
 
   if (state.value === '' && placeholder) {
     return (
@@ -755,8 +794,9 @@ function renderLines(state: TextInputState, layout: WrapLayout, opts: RenderOpts
     // Selection slice in unmasked-row-text indices.
     const localStart = clamp(selStart - row.startCharIdx, 0, row.text.length)
     const localEnd = clamp(selEnd - row.startCharIdx, 0, row.text.length)
+    const hasInRowSelection = localStart < localEnd
 
-    if (localStart === localEnd) {
+    if (!hasInRowSelection) {
       // No selection on this row — render plain. The `|| ' '` ensures
       // empty visual rows (zero-cell rows for empty logical lines) get
       // a single space so the row has height 1; the caret can land on
@@ -772,6 +812,22 @@ function renderLines(state: TextInputState, layout: WrapLayout, opts: RenderOpts
       )
     }
 
+    // Multi-row selection decoration. Each row in a stripe-spanning
+    // selection paints as: [indent (maybe bg)][before][sel + slack
+    // (bg)][after]. The indent gets bg only when selection extended
+    // from the row above (selStart strictly less than this row's
+    // start); the right-slack gets bg only when selection continues
+    // to the row below (selEnd strictly greater than this row's end).
+    const indentBg = selStart < row.startCharIdx
+    const rightSlackBg = selEnd > row.endCharIdx
+    // Right-slack cell count: how many cells between this row's content
+    // end and the box's right edge. Only filled (with bg) when slack
+    // exists AND selection continues past row's end. innerWidth === 0
+    // (first render) gives slack=0 — no fill, defer until measured.
+    const usedCells = row.indentCells + stringWidth(maskedText)
+    const rightSlack = rightSlackBg ? Math.max(0, innerWidth - usedCells) : 0
+    const slackChars = rightSlack > 0 ? ' '.repeat(rightSlack) : ''
+
     // Defensive clamp for the password+non-ASCII edge: mask length can
     // be < row.text length when the buffer has multi-UTF-16-unit graphemes.
     const sliceStart = Math.min(localStart, maskedText.length)
@@ -785,9 +841,12 @@ function renderLines(state: TextInputState, layout: WrapLayout, opts: RenderOpts
         key={rowIdx}
         wrap="truncate-end"
       >
-        {indent}
+        {indentBg ? <Text backgroundColor={selectionColor}>{indent}</Text> : indent}
         {before}
-        <Text backgroundColor={selectionColor}>{sel}</Text>
+        <Text backgroundColor={selectionColor}>
+          {sel}
+          {slackChars}
+        </Text>
         {after}
       </Text>
     )

--- a/packages/renderer/src/components/TextInput/TextInput.tsx
+++ b/packages/renderer/src/components/TextInput/TextInput.tsx
@@ -34,7 +34,12 @@ import {
   reduce,
   selectionOrCaretRange,
 } from './state.js'
-import { type WordBoundaryMode, type WrapLayout, buildWrapLayout } from './wrap-math.js'
+import {
+  type WordBoundaryMode,
+  type WrapHint,
+  type WrapLayout,
+  buildWrapLayout,
+} from './wrap-math.js'
 
 export type TextInputProps = Except<
   BoxProps,
@@ -111,6 +116,26 @@ export type TextInputProps = Except<
    *   with flags, file paths, identifiers).
    */
   wordBoundaries?: WordBoundaryMode
+  /**
+   * Programmatic wrap hints — buffer-relative atomic spans that the
+   * wrap algorithm must NOT break inside. Useful for keeping
+   * semantically-atomic content together: mention chips (`@toast`),
+   * chit-id refs (`chit-abc-123`), inline code spans, etc.
+   *
+   * Hints intersect each logical line's range automatically (the
+   * wrap-math primitive clips to per-line ranges). Empty / inverted
+   * ranges (`end <= start`) are silently ignored.
+   *
+   * **Memoize the array reference.** This prop is in the layout
+   * useMemo's dep array — passing a fresh array every render forces
+   * a layout recompute on every render (O(N) over the buffer).
+   * `useMemo([dependencies])` it consumer-side, or hoist a stable
+   * reference, OR accept the recompute if the buffer is small.
+   *
+   * No-op when `wrap='none'` (no wrap, no break-points, no hints
+   * to honor).
+   */
+  wrapHints?: ReadonlyArray<WrapHint>
   /** Cap on buffer length in characters. Default unlimited. */
   maxLength?: number
   /** Render placeholder text dimmed when the buffer is empty. */
@@ -215,6 +240,7 @@ export default function TextInput({
   wrap,
   indentedWrap = true,
   wordBoundaries = 'whitespace',
+  wrapHints,
   maxLength,
   placeholder,
   password = false,
@@ -257,6 +283,7 @@ export default function TextInput({
     width: optsRef.current.width,
     indentedWrap,
     wordBoundaries,
+    hints: wrapHints,
   }
 
   // Reducer bridge — the React-shape (state, action) => state, closing
@@ -397,8 +424,14 @@ export default function TextInput({
         ? inner.width
         : lastValidInnerWidth.current
   const layout = useMemo(
-    () => buildWrapLayout(state.value, { width: layoutWidth, indentedWrap, wordBoundaries }),
-    [state.value, layoutWidth, indentedWrap, wordBoundaries],
+    () =>
+      buildWrapLayout(state.value, {
+        width: layoutWidth,
+        indentedWrap,
+        wordBoundaries,
+        hints: wrapHints,
+      }),
+    [state.value, layoutWidth, indentedWrap, wordBoundaries, wrapHints],
   )
   // Caret in visual cell coords. `col` already includes any indent
   // decoration on continuation rows (display-col convention from

--- a/packages/renderer/src/components/TextInput/TextInput.tsx
+++ b/packages/renderer/src/components/TextInput/TextInput.tsx
@@ -493,6 +493,14 @@ export default function TextInput({
         contentSize: Math.max(rowWidth, visual.col + 1),
       })
       if (next !== scrollX) setScrollX(next)
+    } else if (scrollX !== 0) {
+      // wrap mode left 'none' (toggled at runtime, OR width=0 first
+      // render). Soft-wrap doesn't h-scroll, but the cursor declaration
+      // and click handler still subtract / add scrollX unconditionally
+      // (degenerate to no-op when 0). A stale non-zero scrollX from the
+      // previous wrap='none' epoch would shift cursor and click target
+      // off the rendered text. Reset to keep them aligned.
+      setScrollX(0)
     }
   }, [
     inner.height,

--- a/packages/renderer/src/components/TextInput/TextInput.tsx
+++ b/packages/renderer/src/components/TextInput/TextInput.tsx
@@ -34,7 +34,7 @@ import {
   reduce,
   selectionOrCaretRange,
 } from './state.js'
-import { type WrapLayout, buildWrapLayout } from './wrap-math.js'
+import { type WordBoundaryMode, type WrapLayout, buildWrapLayout } from './wrap-math.js'
 
 export type TextInputProps = Except<
   BoxProps,
@@ -96,6 +96,21 @@ export type TextInputProps = Except<
    * abandoned automatically. No-op when `wrap='none'`.
    */
   indentedWrap?: boolean
+  /**
+   * Word-boundary detection mode for wrap break-points (only applies
+   * when `wrap='soft'`).
+   *
+   * - `'whitespace'` (default): wrap breaks only at standard
+   *   whitespace (space, tab). The simplest, fastest mode — fits
+   *   most prose / chat / form-field content.
+   * - `'identifier'`: also breaks at `_` / `-` boundaries
+   *   (snake_case, kebab-case) and at lowercase→uppercase
+   *   transitions (camelCase, PascalCase). Treats URLs
+   *   (`http(s)://...`) as atomic — never breaks inside them.
+   *   Tuned for code-like + CLI command content (slash commands
+   *   with flags, file paths, identifiers).
+   */
+  wordBoundaries?: WordBoundaryMode
   /** Cap on buffer length in characters. Default unlimited. */
   maxLength?: number
   /** Render placeholder text dimmed when the buffer is empty. */
@@ -199,6 +214,7 @@ export default function TextInput({
   multiline = false,
   wrap,
   indentedWrap = true,
+  wordBoundaries = 'whitespace',
   maxLength,
   placeholder,
   password = false,
@@ -240,6 +256,7 @@ export default function TextInput({
     historyCap,
     width: optsRef.current.width,
     indentedWrap,
+    wordBoundaries,
   }
 
   // Reducer bridge — the React-shape (state, action) => state, closing
@@ -380,8 +397,8 @@ export default function TextInput({
         ? inner.width
         : lastValidInnerWidth.current
   const layout = useMemo(
-    () => buildWrapLayout(state.value, { width: layoutWidth, indentedWrap }),
-    [state.value, layoutWidth, indentedWrap],
+    () => buildWrapLayout(state.value, { width: layoutWidth, indentedWrap, wordBoundaries }),
+    [state.value, layoutWidth, indentedWrap, wordBoundaries],
   )
   // Caret in visual cell coords. `col` already includes any indent
   // decoration on continuation rows (display-col convention from

--- a/packages/renderer/src/components/TextInput/TextInput.tsx
+++ b/packages/renderer/src/components/TextInput/TextInput.tsx
@@ -556,9 +556,20 @@ export default function TextInput({
   // cursor at the box's outer top-left corner instead of at the
   // caret's actual cell. Visible immediately as a cursor "above" or
   // "to the left of" the text.
+  // Clamp visual.col to the rightmost in-box cell when the buffer
+  // position is past the rendered content (e.g. trailing whitespace
+  // beyond the row's nominal width). Trailing whitespace is invisible
+  // and clipped by the renderer; the cursor would otherwise land past
+  // the box's right border. Logical position stays in state.caret;
+  // this only affects visual placement. Wrap='none' uses scrollX to
+  // keep the caret in view, so the clamp only fires for soft-wrap.
+  const clampedVisualCol =
+    effectiveWrap === 'soft' && inner.width > 0 && visual.col >= inner.width
+      ? Math.max(0, inner.width - 1)
+      : visual.col
   const cursorRef = useDeclaredCursor({
     line: inner.offsetY + visual.row - scrollY,
-    column: inner.offsetX + visual.col - scrollX,
+    column: inner.offsetX + clampedVisualCol - scrollX,
     active: isFocused,
     style: cursorStyle,
     blink: cursorBlink,
@@ -1006,6 +1017,12 @@ function renderLines(state: TextInputState, layout: WrapLayout, opts: RenderOpts
     if (row.text === '') {
       const P = row.startCharIdx
       const touchesSelection = selStart < selEnd && selStart <= P && P < selEnd
+      // Pad empty rows to the full inner width so every cell inside
+      // the box is explicitly written. Otherwise cells past the single
+      // placeholder space stay at terminal background, which can look
+      // visually inconsistent inside the box. Falls back to a single
+      // space when innerWidth isn't measured yet (first render).
+      const fillCells = innerWidth > 0 ? Math.max(1, innerWidth) : 1
       return (
         <Text
           // biome-ignore lint/suspicious/noArrayIndexKey: see comment above
@@ -1013,7 +1030,7 @@ function renderLines(state: TextInputState, layout: WrapLayout, opts: RenderOpts
           wrap="truncate-end"
           backgroundColor={touchesSelection ? selectionColor : undefined}
         >
-          {' '}
+          {' '.repeat(fillCells)}
         </Text>
       )
     }
@@ -1026,47 +1043,78 @@ function renderLines(state: TextInputState, layout: WrapLayout, opts: RenderOpts
     // row.text already.
     const indent = row.indentCells > 0 ? ' '.repeat(row.indentCells) : ''
 
+    // Clip the masked text to fit available content cells (innerWidth
+    // minus indent decoration). Wrap-math allows trailing whitespace
+    // to overflow the row's nominal width (HTML/CSS pre-wrap convention
+    // — spaces are visual nothing and shouldn't reflow surrounding
+    // content as the user types more chars). Clipping here prevents
+    // the rendering Text's truncate-end from triggering on what's
+    // actually invisible whitespace; without it, every row that ends
+    // with a trailing space at the wrap boundary shows an ellipsis on
+    // an otherwise clean wrap.
+    const maxContentCells =
+      innerWidth > 0 ? Math.max(0, innerWidth - row.indentCells) : Number.MAX_SAFE_INTEGER
+    const visibleMaskedText =
+      innerWidth > 0 && stringWidth(maskedText) > maxContentCells
+        ? sliceRowByCells(maskedText, 0, maxContentCells)
+        : maskedText
+    // Trailing pad: always render full-width rows so every cell inside
+    // the box is explicitly written (as a space char). Without this,
+    // cells past row content stay at terminal background — visually
+    // can look like inconsistent "random spaces" against the box's
+    // interior, especially when the box is much wider than the row's
+    // content. Padding makes the rendered area visually uniform.
+    const trailingPad =
+      innerWidth > 0 ? Math.max(0, maxContentCells - stringWidth(visibleMaskedText)) : 0
+    const trailingPadStr = trailingPad > 0 ? ' '.repeat(trailingPad) : ''
+
     // Selection slice in unmasked-row-text indices.
     const localStart = clamp(selStart - row.startCharIdx, 0, row.text.length)
     const localEnd = clamp(selEnd - row.startCharIdx, 0, row.text.length)
     const hasInRowSelection = localStart < localEnd
 
     if (!hasInRowSelection) {
-      // No selection on this row — render plain.
+      // No selection on this row — render plain. Padded to full width.
       return (
         <Text
           // biome-ignore lint/suspicious/noArrayIndexKey: see comment above
           key={rowIdx}
           wrap="truncate-end"
         >
-          {indent + maskedText}
+          {indent + visibleMaskedText + trailingPadStr}
         </Text>
       )
     }
 
-    // Multi-row selection decoration. Each row in a stripe-spanning
-    // selection paints as: [indent (maybe bg)][before][sel + slack
-    // (bg)][after]. The indent gets bg only when selection extended
-    // from the row above (selStart strictly less than this row's
-    // start); the right-slack gets bg only when selection continues
-    // to the row below (selEnd strictly greater than this row's end).
+    // Selection decoration. Each row paints as: [indent (maybe bg)]
+    // [before][sel + slack (bg)][after][pad]. The indent gets bg only
+    // when selection extended from the row above (selStart strictly
+    // less than this row's start); the right-slack gets bg when
+    // selection reaches OR extends past this row's end position. The
+    // `>=` (vs `>`) handles the case where the user dragged through
+    // empty cells past content end — selection clamps to
+    // row.endCharIdx (per layout.visualToLogical), but visually the
+    // highlight should still fill the slack so it's clear what the
+    // user dragged over. Matches VS Code / Sublime behavior.
+    //
+    // The trailing pad goes EITHER inside the bg slack (when selection
+    // extends to row end → trailingPadStr fills with bg as part of
+    // slack) OR after the after segment (when selection is contained
+    // within content → trailingPadStr fills with no bg as final pad).
+    // Either way the rendered row is full-width.
     const indentBg = selStart < row.startCharIdx
-    const rightSlackBg = selEnd > row.endCharIdx
-    // Right-slack cell count: how many cells between this row's content
-    // end and the box's right edge. Only filled (with bg) when slack
-    // exists AND selection continues past row's end. innerWidth === 0
-    // (first render) gives slack=0 — no fill, defer until measured.
-    const usedCells = row.indentCells + stringWidth(maskedText)
-    const rightSlack = rightSlackBg ? Math.max(0, innerWidth - usedCells) : 0
-    const slackChars = rightSlack > 0 ? ' '.repeat(rightSlack) : ''
+    const rightSlackBg = selEnd >= row.endCharIdx
+    const slackChars = rightSlackBg ? trailingPadStr : ''
+    const trailingNoBg = rightSlackBg ? '' : trailingPadStr
 
-    // Defensive clamp for the password+non-ASCII edge: mask length can
-    // be < row.text length when the buffer has multi-UTF-16-unit graphemes.
-    const sliceStart = Math.min(localStart, maskedText.length)
-    const sliceEnd = Math.min(localEnd, maskedText.length)
-    const before = maskedText.slice(0, sliceStart)
-    const sel = maskedText.slice(sliceStart, sliceEnd) || ' '
-    const after = maskedText.slice(sliceEnd)
+    // Defensive clamp for the password+non-ASCII edge AND for the
+    // trailing-whitespace clip above: visibleMaskedText length can be
+    // < unmasked-row length, so localStart/localEnd may overshoot.
+    const sliceStart = Math.min(localStart, visibleMaskedText.length)
+    const sliceEnd = Math.min(localEnd, visibleMaskedText.length)
+    const before = visibleMaskedText.slice(0, sliceStart)
+    const sel = visibleMaskedText.slice(sliceStart, sliceEnd) || ' '
+    const after = visibleMaskedText.slice(sliceEnd)
     return (
       <Text
         // biome-ignore lint/suspicious/noArrayIndexKey: see comment above
@@ -1080,6 +1128,7 @@ function renderLines(state: TextInputState, layout: WrapLayout, opts: RenderOpts
           {slackChars}
         </Text>
         {after}
+        {trailingNoBg}
       </Text>
     )
   })

--- a/packages/renderer/src/components/TextInput/TextInput.tsx
+++ b/packages/renderer/src/components/TextInput/TextInput.tsx
@@ -80,6 +80,22 @@ export type TextInputProps = Except<
    * wrap can set `wrap='none'`.
    */
   wrap?: 'soft' | 'none'
+  /**
+   * When `wrap='soft'`, continuation rows of a wrapped logical line
+   * visually align under the first non-whitespace character of the
+   * original line — vim's `breakindent`, VS Code's "wrap with
+   * indent." Default `true` (enabled), matching what every modern
+   * editor does for prose / list / quote / indented-code content.
+   *
+   * Set `false` for the unindented behavior (continuation rows start
+   * at column 0). Useful when the consumer wants raw column-0 wrap
+   * for terminal-style content like log lines.
+   *
+   * Threshold: indent only applies when the indent leaves at least
+   * width / 2 cells of content room — beyond that the indent gets
+   * abandoned automatically. No-op when `wrap='none'`.
+   */
+  indentedWrap?: boolean
   /** Cap on buffer length in characters. Default unlimited. */
   maxLength?: number
   /** Render placeholder text dimmed when the buffer is empty. */
@@ -182,6 +198,7 @@ export default function TextInput({
   onCancel,
   multiline = false,
   wrap,
+  indentedWrap = true,
   maxLength,
   placeholder,
   password = false,
@@ -214,11 +231,15 @@ export default function TextInput({
   // re-renders-update-state-before-effects round trip. Width is updated
   // separately AFTER `inner` is declared (see the matching mutation in
   // the Scroll section) — `inner.width` isn't in scope yet here.
+  // Wrap-related options (indentedWrap, wordBoundaries, hints) MUST
+  // mirror the renderer's so visual-row Up/Down nav lands where the
+  // user sees the row break.
   optsRef.current = {
     multiline,
     maxLength,
     historyCap,
     width: optsRef.current.width,
+    indentedWrap,
   }
 
   // Reducer bridge — the React-shape (state, action) => state, closing
@@ -359,8 +380,8 @@ export default function TextInput({
         ? inner.width
         : lastValidInnerWidth.current
   const layout = useMemo(
-    () => buildWrapLayout(state.value, { width: layoutWidth }),
-    [state.value, layoutWidth],
+    () => buildWrapLayout(state.value, { width: layoutWidth, indentedWrap }),
+    [state.value, layoutWidth, indentedWrap],
   )
   // Caret in visual cell coords. `col` already includes any indent
   // decoration on continuation rows (display-col convention from

--- a/packages/renderer/src/components/TextInput/state.ts
+++ b/packages/renderer/src/components/TextInput/state.ts
@@ -14,7 +14,12 @@ import {
   wordBoundaryAfter,
   wordBoundaryBefore,
 } from './caret-math.js'
-import { buildWrapLayout, nextVisualRow } from './wrap-math.js'
+import {
+  type WordBoundaryMode,
+  type WrapHint,
+  buildWrapLayout,
+  nextVisualRow,
+} from './wrap-math.js'
 
 /** Selection is anchor (where the user pressed) and focus (where they
  *  moved to). Either order — the helpers normalise via min/max. */
@@ -76,6 +81,17 @@ export type ReducerOptions = {
    *  gracefully — the wrap-math primitive already does so by
    *  returning an empty layout. */
   width: number
+  /** Hanging-indent mode for visual-row nav. Mirrors the renderer's
+   *  `indentedWrap` prop so Up/Down nav rows align with the on-screen
+   *  layout. Default `true` (enabled). */
+  indentedWrap?: boolean
+  /** Word-boundary mode for visual-row nav. Mirrors the renderer's
+   *  `wordBoundaries` prop. Default `'whitespace'`. */
+  wordBoundaries?: WordBoundaryMode
+  /** Programmatic wrap hints for visual-row nav. Mirrors the
+   *  renderer's `wrapHints` prop. Optional — undefined means no
+   *  hints. */
+  hints?: ReadonlyArray<WrapHint>
   /** Maximum entries to keep in history. Older entries drop from
    *  the front. Default 100. */
   historyCap?: number
@@ -367,7 +383,12 @@ function reduceCore(state: TextInputState, action: Action, opts: ReducerOptions)
           nextCaret = moveCaretIndex(state.value, state.caret, action.direction)
           nextPreferredCol = null
         } else {
-          const layout = buildWrapLayout(state.value, { width: opts.width })
+          const layout = buildWrapLayout(state.value, {
+            width: opts.width,
+            indentedWrap: opts.indentedWrap,
+            wordBoundaries: opts.wordBoundaries,
+            hints: opts.hints,
+          })
           // First vertical step in a chain: capture the current display
           // col as the "preferred" column. Subsequent steps reuse the
           // same value so the caret survives passing through rows that

--- a/packages/renderer/src/components/TextInput/wrap-math.test.ts
+++ b/packages/renderer/src/components/TextInput/wrap-math.test.ts
@@ -150,14 +150,18 @@ describe('wrapByWords', () => {
     })
 
     it('handles three-word wrapping at exact boundaries', () => {
-      // "the quick fox" = 13. Width 5: "the " (4) fits, "q" pushes
-      // to 5, fits, "u" → 6, no whitespace break in row → wait no.
-      // Walk: t(1) h(2) e(3) " "(4) lastBreak=4. q(5) fits. u(6)
-      // > 5, break at lastBreak=4. Push "the ", row="quick"...
-      //   q(1) u(2) i(3) c(4) k(5). Then " "(6) fits as ws past
-      //   width but lastBreak=6. f(7) > 5, break at 6. Push
-      //   "quick ", row="fox".
-      expect(wrapByWords('the quick fox', 5)).toEqual(['the ', 'quick ', 'fox'])
+      // "the quick fox" = 13. Width 5. Trace:
+      //   t(1) h(2) e(3) " "(4) lastBreak=4 — "the " fits.
+      //   q(5) — fits exactly. u(6 > 5) — break at lastBreak=4.
+      //     Push "the ", row="qu".
+      //   i(3) c(4) k(5) — row="quick" (5).
+      //   " "(would be 6 > 5 AND row.length>0) — whitespace overflow
+      //     break. Push "quick", row=" ", hasContent=false.
+      //   f(2) o(3) x(4) — row=" fox" (4). End. Push " fox".
+      // Each row ≤ 5; trailing whitespace wraps to next row instead
+      // of overflowing the row width (which would produce ellipsis
+      // on the rendering Text).
+      expect(wrapByWords('the quick fox', 5)).toEqual(['the ', 'quick', ' fox'])
     })
 
     it('one-word input fits when shorter than width', () => {

--- a/packages/renderer/src/components/TextInput/wrap-math.test.ts
+++ b/packages/renderer/src/components/TextInput/wrap-math.test.ts
@@ -150,18 +150,14 @@ describe('wrapByWords', () => {
     })
 
     it('handles three-word wrapping at exact boundaries', () => {
-      // "the quick fox" = 13. Width 5. Trace:
-      //   t(1) h(2) e(3) " "(4) lastBreak=4 — "the " fits.
-      //   q(5) — fits exactly. u(6 > 5) — break at lastBreak=4.
-      //     Push "the ", row="qu".
-      //   i(3) c(4) k(5) — row="quick" (5).
-      //   " "(would be 6 > 5 AND row.length>0) — whitespace overflow
-      //     break. Push "quick", row=" ", hasContent=false.
-      //   f(2) o(3) x(4) — row=" fox" (4). End. Push " fox".
-      // Each row ≤ 5; trailing whitespace wraps to next row instead
-      // of overflowing the row width (which would produce ellipsis
-      // on the rendering Text).
-      expect(wrapByWords('the quick fox', 5)).toEqual(['the ', 'quick', ' fox'])
+      // "the quick fox" = 13. Width 5: "the " (4) fits, "q" pushes
+      // to 5, fits, "u" → 6, break at lastBreak=4. Push "the ", row.
+      // Walk: t(1) h(2) e(3) " "(4) lastBreak=4. q(5) fits. u(6)
+      // > 5, break at lastBreak=4. Push "the ", row="quick"...
+      //   q(1) u(2) i(3) c(4) k(5). Then " "(6) fits as ws past
+      //   width but lastBreak=6. f(7) > 5, break at 6. Push
+      //   "quick ", row="fox".
+      expect(wrapByWords('the quick fox', 5)).toEqual(['the ', 'quick ', 'fox'])
     })
 
     it('one-word input fits when shorter than width', () => {
@@ -212,57 +208,33 @@ describe('wrapByWords', () => {
       expect(result[0]).toBe('hello ')
     })
 
-    it('preserves leading whitespace as part of the first word (no break before content)', () => {
-      // "  hello" width 4 — leading whitespace must NOT be a break
-      // candidate. The whole "  hello" stays atomic until something
-      // forces a break.
-      // Walk: " "(1, no lastBreak — hasContent=false). " "(2, no
-      // lastBreak). h(3). e(4). l(5)>4, no lastBreak → char-wrap
-      // fallback: push "  he", row="l" w=1. l(2). o(3). End: push
-      // "llo". → ["  he", "llo"]
+    it('breaks at leading whitespace when overflow forces it (preserves word integrity)', () => {
+      // "  hello" width 4. Leading whitespace IS a break candidate —
+      // when "hello" overflows the row, wrap breaks at the last
+      // leading whitespace position instead of mid-word.
+      // Walk: " "(1, brk=1). " "(2, brk=2). h(3). e(4). l(5)>4, break
+      // at brk=2. Push "  ". row=overhang+"l" = "hel"+"l" = "hell" (4).
+      // o(5)>4. brk=-1 (reset by break). char-wrap. Push "hell".
+      // row="o". End. Push "o". → ["  ", "hell", "o"]
+      // Word integrity preferred over compact rows: "hello" stays
+      // intact across rows when possible. Earlier versions char-wrapped
+      // "hello" to "  he"/"llo" which looked broken.
       const result = wrapByWords('  hello', 4)
       expect(result.join('')).toBe('  hello')
-      // The first row should NOT be just whitespace — that'd mean we
-      // used leading ws as a break point.
-      expect(result[0]).not.toBe('  ')
+      expect(result[0]).toBe('  ')
     })
 
-    it('wraps when consecutive whitespace would push past width', () => {
-      // "hello   world" width 6: the "trailing whitespace fits past
-      // width" rule applies for ONE trailing whitespace at a word
-      // boundary, not arbitrary multi-space runs. Trace:
-      // hello(5), " "(6) — fits exactly, lastChar='o' not ws.
-      // " "(would be 7 > 6 AND lastChar=' ' AND row.length=6>0) → break.
-      //   Push "hello ". New row=" ". hasContent=false.
-      // " "(2). lastChar=' ' but rowWidth(2) ≤ 6, no break. Append.
-      //   row="  ". hasContent still false (no break candidate set).
-      // w(3), o(4), r(5), l(6), d(7>6) — char-wrap fallback because
-      //   no break candidate (the leading whitespace didn't qualify).
-      //   Push "  worl". New row="d". End: push "d".
-      // Matches CSS pre-wrap behavior — multi-space runs wrap at the
-      // first overflow rather than letting the row grow indefinitely.
-      // The previous "let trailing ws overflow forever" rule caused
-      // a real cursor-out-of-box bug when users held the spacebar.
-      expect(wrapByWords('hello   world', 6)).toEqual(['hello ', '  worl', 'd'])
-    })
-
-    it('repeated whitespace wraps onto new rows (cursor stays in box)', () => {
-      // Regression: holding the spacebar in a multiline input used to
-      // grow the row indefinitely. Cursor's logical column tracked the
-      // buffer end → terminal rendered cursor outside the input box.
-      // Fix: whitespace-overflow break on consecutive whitespace.
-      // "con " + 100 spaces, width 66:
-      //   row 1: "con " (4) + 62 spaces = 66 cells. (62nd space appends
-      //          at rowWidth=66; 63rd would push to 67 → break.)
-      //   row 2: 1 + 37 more = 38 spaces. 38 ≤ 66, fits.
-      const text = `con ${' '.repeat(100)}`
-      const rows = wrapByWords(text, 66)
-      expect(rows).toHaveLength(2)
-      expect(rows[0]).toBe(`con ${' '.repeat(62)}`)
-      expect(rows[0]?.length).toBe(66)
-      expect(rows[1]).toBe(' '.repeat(38))
-      // Rejoin invariant.
-      expect(rows.join('')).toBe(text)
+    it('handles multiple consecutive spaces preserved at break point', () => {
+      // "hello   world" width 6 → "hello   " (8 cells but ws counts
+      // as 1 each in stringWidth, lastBreak resets each time).
+      // Walk: hello(5), " "(6, lastBreak=6), " "(7, lastBreak=7),
+      // " "(8, lastBreak=8), w(9)>6, break at lastBreak=8 → push
+      // "hello   ", row="world".
+      // Trailing whitespace stays on the row it terminates per HTML/CSS
+      // pre-wrap convention. The renderer's responsibility is to clip
+      // visible cells past width (no ellipsis) — overflow rows are
+      // cosmetic, not data corruption.
+      expect(wrapByWords('hello   world', 6)).toEqual(['hello   ', 'world'])
     })
 
     it('does NOT break at non-breaking space (U+00A0)', () => {

--- a/packages/renderer/src/components/TextInput/wrap-math.test.ts
+++ b/packages/renderer/src/components/TextInput/wrap-math.test.ts
@@ -223,13 +223,42 @@ describe('wrapByWords', () => {
       expect(result[0]).not.toBe('  ')
     })
 
-    it('handles multiple consecutive spaces preserved at break point', () => {
-      // "hello   world" width 6 → "hello   " (8 cells but ws counts
-      // as 1 each in stringWidth, lastBreak resets each time).
-      // Walk: hello(5), " "(6, lastBreak=6), " "(7, lastBreak=7),
-      // " "(8, lastBreak=8), w(9)>6, break at lastBreak=8 → push
-      // "hello   ", row="world".
-      expect(wrapByWords('hello   world', 6)).toEqual(['hello   ', 'world'])
+    it('wraps when consecutive whitespace would push past width', () => {
+      // "hello   world" width 6: the "trailing whitespace fits past
+      // width" rule applies for ONE trailing whitespace at a word
+      // boundary, not arbitrary multi-space runs. Trace:
+      // hello(5), " "(6) — fits exactly, lastChar='o' not ws.
+      // " "(would be 7 > 6 AND lastChar=' ' AND row.length=6>0) → break.
+      //   Push "hello ". New row=" ". hasContent=false.
+      // " "(2). lastChar=' ' but rowWidth(2) ≤ 6, no break. Append.
+      //   row="  ". hasContent still false (no break candidate set).
+      // w(3), o(4), r(5), l(6), d(7>6) — char-wrap fallback because
+      //   no break candidate (the leading whitespace didn't qualify).
+      //   Push "  worl". New row="d". End: push "d".
+      // Matches CSS pre-wrap behavior — multi-space runs wrap at the
+      // first overflow rather than letting the row grow indefinitely.
+      // The previous "let trailing ws overflow forever" rule caused
+      // a real cursor-out-of-box bug when users held the spacebar.
+      expect(wrapByWords('hello   world', 6)).toEqual(['hello ', '  worl', 'd'])
+    })
+
+    it('repeated whitespace wraps onto new rows (cursor stays in box)', () => {
+      // Regression: holding the spacebar in a multiline input used to
+      // grow the row indefinitely. Cursor's logical column tracked the
+      // buffer end → terminal rendered cursor outside the input box.
+      // Fix: whitespace-overflow break on consecutive whitespace.
+      // "con " + 100 spaces, width 66:
+      //   row 1: "con " (4) + 62 spaces = 66 cells. (62nd space appends
+      //          at rowWidth=66; 63rd would push to 67 → break.)
+      //   row 2: 1 + 37 more = 38 spaces. 38 ≤ 66, fits.
+      const text = `con ${' '.repeat(100)}`
+      const rows = wrapByWords(text, 66)
+      expect(rows).toHaveLength(2)
+      expect(rows[0]).toBe(`con ${' '.repeat(62)}`)
+      expect(rows[0]?.length).toBe(66)
+      expect(rows[1]).toBe(' '.repeat(38))
+      // Rejoin invariant.
+      expect(rows.join('')).toBe(text)
     })
 
     it('does NOT break at non-breaking space (U+00A0)', () => {

--- a/packages/renderer/src/components/TextInput/wrap-math.ts
+++ b/packages/renderer/src/components/TextInput/wrap-math.ts
@@ -399,24 +399,30 @@ export function wrapByWords(
     const absPosBefore = rowAbsStart + row.length
 
     if (breakable) {
-      // Overflow break for repeated whitespace: if the row already
-      // ends in whitespace AND adding this whitespace would push past
-      // width, wrap here. Without this, holding the spacebar (or any
-      // whitespace-only repeating input) grows the current row
-      // indefinitely; the cursor's logical column tracks the buffer's
-      // end and ends up declared past the box's right edge, which the
-      // terminal renders as a cursor floating outside the input.
+      // Whitespace overflow break: if adding this whitespace would
+      // push the row past width AND the row already has at least one
+      // grapheme, wrap here instead of letting the row exceed width.
+      // The trailing whitespace becomes the start of the next row.
       //
-      // The "trailing whitespace stays on the row" rule still applies
-      // for a SINGLE trailing whitespace at a word boundary — that
-      // single space fits past width on the terminating row, then the
-      // next non-whitespace word triggers a normal break. The
-      // `lastChar is whitespace` guard preserves that behavior:
-      // 'hello ' at width 6 stays one row (lastChar is 'o' when the
-      // space arrives, no overflow break); 'hello  ' at width 6 wraps
-      // (lastChar is ' ' when the second space arrives + overflow).
-      const lastChar = row.length > 0 ? row[row.length - 1] : ''
-      if (rowWidth + w > width && row.length > 0 && (lastChar === ' ' || lastChar === '\t')) {
+      // Without this, two pathologies appeared:
+      //   1. Holding the spacebar grew the current row indefinitely;
+      //      the cursor's logical column tracked the buffer's end and
+      //      got declared past the box's right edge.
+      //   2. Even a SINGLE trailing whitespace at end of row produced
+      //      a row `width + 1` cells wide. The rendering Text
+      //      (`wrap='truncate-end'`) showed an ellipsis on what should
+      //      have been a clean wrap. With soft-wrap there should NEVER
+      //      be an ellipsis — every char fits on a row by construction.
+      //
+      // Earlier versions gated this break on "row already ends in
+      // whitespace" to preserve the HTML/CSS "trailing whitespace fits
+      // past width" convention. yokai's renderer doesn't follow that
+      // convention (Text truncates excess content with an ellipsis),
+      // so the gate produced visible ugliness. Always-break is more
+      // consistent: multi-row selection stripes line up cleanly,
+      // cursor placement never exceeds the visible box, and consumers
+      // never see `…` on prose content.
+      if (rowWidth + w > width && row.length > 0) {
         rows.push(row)
         rowAbsStart += row.length
         row = segment
@@ -427,8 +433,7 @@ export function wrapByWords(
         prevChar = segment[0]
         continue
       }
-      // Whitespace fits past width on the terminating row (the
-      // single-trailing-whitespace case above). Append.
+      // Whitespace fits within remaining row budget. Append.
       row += segment
       rowWidth += w
       // Record whitespace as a HARD break candidate UNLESS it's

--- a/packages/renderer/src/components/TextInput/wrap-math.ts
+++ b/packages/renderer/src/components/TextInput/wrap-math.ts
@@ -399,7 +399,36 @@ export function wrapByWords(
     const absPosBefore = rowAbsStart + row.length
 
     if (breakable) {
-      // Whitespace always fits past width (invisible at boundary).
+      // Overflow break for repeated whitespace: if the row already
+      // ends in whitespace AND adding this whitespace would push past
+      // width, wrap here. Without this, holding the spacebar (or any
+      // whitespace-only repeating input) grows the current row
+      // indefinitely; the cursor's logical column tracks the buffer's
+      // end and ends up declared past the box's right edge, which the
+      // terminal renders as a cursor floating outside the input.
+      //
+      // The "trailing whitespace stays on the row" rule still applies
+      // for a SINGLE trailing whitespace at a word boundary — that
+      // single space fits past width on the terminating row, then the
+      // next non-whitespace word triggers a normal break. The
+      // `lastChar is whitespace` guard preserves that behavior:
+      // 'hello ' at width 6 stays one row (lastChar is 'o' when the
+      // space arrives, no overflow break); 'hello  ' at width 6 wraps
+      // (lastChar is ' ' when the second space arrives + overflow).
+      const lastChar = row.length > 0 ? row[row.length - 1] : ''
+      if (rowWidth + w > width && row.length > 0 && (lastChar === ' ' || lastChar === '\t')) {
+        rows.push(row)
+        rowAbsStart += row.length
+        row = segment
+        rowWidth = w
+        lastBreakIdx = -1
+        lastBreakIsHard = false
+        hasContent = false
+        prevChar = segment[0]
+        continue
+      }
+      // Whitespace fits past width on the terminating row (the
+      // single-trailing-whitespace case above). Append.
       row += segment
       rowWidth += w
       // Record whitespace as a HARD break candidate UNLESS it's

--- a/packages/renderer/src/components/TextInput/wrap-math.ts
+++ b/packages/renderer/src/components/TextInput/wrap-math.ts
@@ -399,49 +399,36 @@ export function wrapByWords(
     const absPosBefore = rowAbsStart + row.length
 
     if (breakable) {
-      // Whitespace overflow break: if adding this whitespace would
-      // push the row past width AND the row already has at least one
-      // grapheme, wrap here instead of letting the row exceed width.
-      // The trailing whitespace becomes the start of the next row.
+      // Whitespace always fits past width — trailing whitespace stays
+      // on the row it terminates rather than wrapping onto a new row.
+      // Matches HTML/CSS pre-wrap convention. The renderer side clips
+      // the visible cells to box width so trailing whitespace past
+      // width is invisible rather than triggering an ellipsis.
       //
-      // Without this, two pathologies appeared:
-      //   1. Holding the spacebar grew the current row indefinitely;
-      //      the cursor's logical column tracked the buffer's end and
-      //      got declared past the box's right edge.
-      //   2. Even a SINGLE trailing whitespace at end of row produced
-      //      a row `width + 1` cells wide. The rendering Text
-      //      (`wrap='truncate-end'`) showed an ellipsis on what should
-      //      have been a clean wrap. With soft-wrap there should NEVER
-      //      be an ellipsis — every char fits on a row by construction.
+      // Why this matters for UX: when the user types text in a field
+      // and content wraps, the trailing space between the last word
+      // and the wrapped word stays on the previous row rather than
+      // jumping to the start of the new row as more characters are
+      // added. Spaces are visual nothing — they shouldn't reflow
+      // surrounding content.
       //
-      // Earlier versions gated this break on "row already ends in
-      // whitespace" to preserve the HTML/CSS "trailing whitespace fits
-      // past width" convention. yokai's renderer doesn't follow that
-      // convention (Text truncates excess content with an ellipsis),
-      // so the gate produced visible ugliness. Always-break is more
-      // consistent: multi-row selection stripes line up cleanly,
-      // cursor placement never exceeds the visible box, and consumers
-      // never see `…` on prose content.
-      if (rowWidth + w > width && row.length > 0) {
-        rows.push(row)
-        rowAbsStart += row.length
-        row = segment
-        rowWidth = w
-        lastBreakIdx = -1
-        lastBreakIsHard = false
-        hasContent = false
-        prevChar = segment[0]
-        continue
-      }
-      // Whitespace fits within remaining row budget. Append.
+      // Whitespace is recorded as a HARD break candidate regardless of
+      // hasContent. Earlier versions guarded with `hasContent` to keep
+      // leading-whitespace-+-first-word atomic (so '  hello' stays as
+      // one row even when it'd overflow), but that produced ugly mid-
+      // word char-wrap when the row really did overflow ('      app
+      // ban' at width 6 broke 'app' into 'a'+'p'+'p' instead of
+      // wrapping after the leading spaces). Without the guard, leading
+      // whitespace becomes a break point ONLY when overflow forces it
+      // — fitting rows still keep leading whitespace + first word
+      // together (no overflow → brk never used).
+      //
+      // Atomic-span exception: still skip recording when inside a
+      // wrap hint range — consumers explicitly bound those positions
+      // together.
       row += segment
       rowWidth += w
-      // Record whitespace as a HARD break candidate UNLESS it's
-      // inside a caller-supplied atomic span. Inside-an-atomic-span
-      // means the consumer explicitly bound this range together
-      // (e.g. "Mr. Smith" via wrap hint); the space between Mr. and
-      // Smith mustn't be used as a break point.
-      if (hasContent && !isInsideRange(allAtomicSpans, absPosBefore)) {
+      if (!isInsideRange(allAtomicSpans, absPosBefore)) {
         lastBreakIdx = row.length
         lastBreakIsHard = true
       }

--- a/packages/renderer/src/index.ts
+++ b/packages/renderer/src/index.ts
@@ -28,6 +28,7 @@ export type {
 } from './components/Resizable'
 export { default as TextInput } from './components/TextInput/TextInput'
 export type { TextInputProps } from './components/TextInput/TextInput'
+export type { WordBoundaryMode, WrapHint } from './components/TextInput/wrap-math'
 export { PasteEvent } from './events/paste-event'
 export { default as FocusGroup } from './components/FocusGroup'
 export type { FocusGroupProps, FocusGroupDirection } from './components/FocusGroup'


### PR DESCRIPTION
Phases D + E of the soft-wrap multiline TextInput work. Multi-row selections now paint as one continuous stripe instead of disconnected per-row segments, and consumers get four new props to tune wrap behavior.

This is **PR 3 of 4** in the soft-wrap series. PR #38 shipped the wrap-math primitive (Phases A+B). PR #39 wired it into the production render path (Phase C). PR #4 wraps up with cross-cutting tests, demos exercising the new API, and docs.

## Phase D — Selection rendering polish (2 commits)

- `d06aa8f` **D2: continuous selection stripe across visual rows** — A selection that spans more than one visual row paints as ONE continuous highlighted region. Two row-edge booleans drive the decoration: `indentBg` (selection started before this row's first char → indent decoration cells get bg) and `rightSlackBg` (selection extends past this row's last char → slack between content end and box's right edge gets bg). Both computed from existing buffer-relative selection range + row metadata; no new state.
- `fc322b4` **D3: empty-row selection fill** — A multi-row selection that spans empty logical lines (consecutive `\n`) now visibly highlights the empty row with a single bg-colored space, instead of leaving a gap between content rows.

D1 (per-visual-row selection slicing) was absorbed into PR #39's C2+C3 work — slicing was already there from the moment the renderer started consuming the layout.

## Phase E — Consumer-facing props (4 commits)

- `f39ebf8` **E1: `wrap='soft' | 'none'`** with multiline-aware default. Default per-mode: `'soft'` when `multiline` (matches `<textarea>`), `'none'` otherwise (matches `<input>`). PR #2 made soft-wrap uniformly default; this fixes the surprising single-line-wraps-vertically behavior. The Password field in the demo now horizontally scrolls instead of growing vertically. Re-introduces the `scrollX` machinery for `wrap='none'`. Two render paths in `renderLines` — the multi-row stripe (D2/D3) for `wrap='soft'`, the legacy per-row cell-slicing for `wrap='none'`.
- `27843ea` **E2: `indentedWrap?: boolean`** — pass-through. Default `true`. No-op when `wrap='none'`.
- `895ba50` **E3: `wordBoundaries?: 'whitespace' | 'identifier'`** — pass-through. Default `'whitespace'`. Identifier mode breaks at `_`/`-` and camelCase boundaries, keeps URLs atomic.
- `84846e5` **E4: `wrapHints?: ReadonlyArray<WrapHint>`** — pass-through with a critical memoization note in the docstring (passing a fresh array every render forces re-wrap). `WrapHint` and `WordBoundaryMode` types re-exported from package root for consumer convenience.

## Cross-cutting: ReducerOptions plumbing

The reducer's visual-row Up/Down nav rebuilds its own layout (per the C4 design — pure reducer, no shared state with render). For the nav to land on the same rows the user sees, the reducer's WrapOptions must mirror the renderer's. `ReducerOptions` extended with `indentedWrap`, `wordBoundaries`, `hints` fields; `optsRef.current` updated to push those alongside `width`. The moveCaret 'up'/'down' branch's `buildWrapLayout` call now consumes them.

Existing 608 tests untouched — all options are optional with backward-compatible defaults.

## Verification

- Typecheck, lint, build all clean
- 608 tests still passing
- Bundle size: 433KB → 441KB

**Interactive smoke-test required** — selection rendering and wrap-mode behavior need eyes. Try:

- Shift-arrow across a wrapped logical line in Bio → continuous stripe, not segments
- Shift-select across an empty line in a multiline input → empty line highlighted
- Default Password field (single-line, no `wrap` prop) → horizontal scroll past width 50
- Pass `wrap='soft'` to Name field → grows vertically when content exceeds width
- Pass `wordBoundaries='identifier'` to a multiline with snake_case content → breaks at `_`

## Decisions worth eyes on

1. **Multi-row stripe NOT enabled in `wrap='none'`** — The `right-slack-fill` semantics don't quite map when the row's right edge is past the visible window (h-scroll active). For wrap='none' multiline, multi-row selection still works (per-row in-row segments) but doesn't get the continuous-stripe polish. Same v1 limitation as the pre-soft-wrap renderer.
2. **`wrapHints` array memoization** — documented in the prop's docstring, NOT enforced by internal shallow-compare. Decision: trust consumers to memoize. Internal shallow-compare adds API surface (compare semantics differ from === across versions) and benefits only consumers who forgot to memoize. Worth revisiting if a real consumer reports the gotcha.
3. **`WrapHint.joinWith`** — type field still reserved (NOT implemented). Unchanged from PR #38; renderer-side glyph injection at forced break points is a soft-wrap follow-up.

## Known limitations carried forward

- Selection rendering on a horizontally-scrolled wide character (wrap='none' + emoji/CJK at scroll boundary) — same v1 limitation the pre-soft-wrap renderer documented; selection cell math treats scroll offset as char-aligned.
- Layout rebuild in the reducer per Up/Down dispatch is O(N) on the buffer. Acceptable for typical inputs; future shared-with-render layout cache (via ref + dispatch) is a perf optimization tracked for later.

🤖 Generated with [Claude Code](https://claude.com/claude-code)