### PR TITLE
chore(release): bump to 0.7.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "yokai",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "private": true,
   "description": "React terminal renderer — pure TypeScript Yoga layout, diff-based rendering, ScrollBox",
   "license": "MIT",

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yokai/renderer",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "React terminal renderer — reconciler + Yoga layout + TTY output",
   "license": "MIT",
   "main": "./dist/index.js",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@yokai/shared",
-  "version": "0.6.0",
+  "version": "0.7.0",
   "description": "Shared utilities — Yoga layout TS port, logger, env helpers",
   "license": "MIT",
   "main": "./dist/index.js",


### PR DESCRIPTION
## Summary

Bump `@yokai/renderer`, `@yokai/shared`, and root to **0.7.0**. The soft-wrap release.

## What's new since 0.5.1

- **Soft-wrap multiline TextInput** — `wrap`, `indentedWrap`, `wordBoundaries`, `wrapHints` props. Visual-row up/down nav with preferred-column tracking. Continuous selection stripe across visual rows. Empty-row selection fill.
- **Wrap-math primitives** — cell-aware char fallback, word-aware whitespace breaks, identifier-aware word boundaries (snake_case / camelCase / URLs), programmatic wrap hints (atomic spans), hanging-indent ("breakindent"), logical↔visual position maps.
- **Checkbox / Radio** — focusable primitives, no-click-focus default, `claimFocusOnClick` opt-in.
- **Demos** — `pnpm demo:scratchpad` (draggable multiline editor in a window), `pnpm demo:drag` (glacier-cyan rectangles + drop zone with shrink-and-lock).

## Test plan

- [ ] CI green (typecheck / lint / build / test)
- [ ] `pnpm build` clean
- [ ] After merge: tag `v0.7.0` on the merge commit and cut a GitHub release