### PR TITLE
docs(readme): add demo gif

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 React terminal renderer. Pure-TypeScript Yoga flexbox, diff-based screen output, ScrollBox with viewport culling and hardware scroll hints.
 
+![drag and drop in the terminal](./docs/drag.gif)
+
 Used by [claude-corp](https://github.com/re-marked/claude-corp). Forked from [claude-code-kit](https://github.com/minnzen/claude-code-kit), itself a fork of [Ink](https://github.com/vadimdemedes/ink).
 
 ## Packages


### PR DESCRIPTION
Drops a 43 MB drag-and-drop screencap (`docs/drag.gif`) into the README, right under the tagline. Visitors landing on the repo from the HN post see the moving image first instead of a text wall.