### PR TITLE
chore: align all descriptions to the public tagline

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # yokai
 
-React terminal renderer. Pure-TypeScript Yoga flexbox, diff-based screen output, ScrollBox with viewport culling and hardware scroll hints.
+Serious React TUI renderer for serious CLI apps. Pure TypeScript Yoga layout, diff-based rendering, ScrollBox, alt buffer, mouse events, draggable and resizable components.
 
 ![drag and drop in the terminal](./docs/drag.gif)
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "yokai",
   "version": "0.7.0",
   "private": true,
-  "description": "React terminal renderer — pure TypeScript Yoga layout, diff-based rendering, ScrollBox",
+  "description": "Serious React TUI renderer for serious CLI apps. Pure TypeScript Yoga layout, diff-based rendering, ScrollBox, alt buffer, mouse events, draggable and resizable components.",
   "license": "MIT",
   "author": "Mark <psyhik17@gmail.com>",
   "repository": {

--- a/packages/renderer/package.json
+++ b/packages/renderer/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yokai/renderer",
   "version": "0.7.0",
-  "description": "React terminal renderer — reconciler + Yoga layout + TTY output",
+  "description": "Serious React TUI renderer for serious CLI apps. Pure TypeScript Yoga layout, diff-based rendering, ScrollBox, alt buffer, mouse events, draggable and resizable components.",
   "license": "MIT",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@yokai/shared",
   "version": "0.7.0",
-  "description": "Shared utilities — Yoga layout TS port, logger, env helpers",
+  "description": "Serious React TUI renderer for serious CLI apps. Pure TypeScript Yoga layout, diff-based rendering, ScrollBox, alt buffer, mouse events, draggable and resizable components.",
   "license": "MIT",
   "main": "./dist/index.js",
   "module": "./dist/index.mjs",


### PR DESCRIPTION
Match GitHub repo description across root + both publishable packages + README first line, so npm, GitHub, and the README all say the same thing.