### PR TITLE
Phase F: cross-cutting tests + word-mode atomic-span overflow fix

### DIFF
--- a/packages/renderer/src/components/TextInput/TextInput.wrap.test.ts
+++ b/packages/renderer/src/components/TextInput/TextInput.wrap.test.ts
@@ -1,0 +1,429 @@
+/**
+ * TextInput integration tests — state + wrap-math composed.
+ *
+ * The pure layers each have exhaustive unit suites:
+ *   - state.test.ts    — reducer mechanics (no wrap-math knowledge)
+ *   - wrap-math.test.ts — pure wrap helpers (no state machine)
+ *
+ * This file pins the BEHAVIORAL contract that emerges when they're
+ * composed via ReducerOptions: typing past a wrap boundary, deleting
+ * a char that uncrosses one, hint-marked spans surviving edits,
+ * indented-wrap caret nav, the wrap-mode prop matrix flowing through
+ * cleanly. Anything that requires BOTH layers to work in concert
+ * lives here.
+ *
+ * Scope contract — what belongs here vs the other two test files:
+ *   - state.test.ts:  drive `reduce`, assert state. Width irrelevant
+ *                     except for wide enough to not affect nav.
+ *   - wrap-math.test.ts: pure-helper invariants. No reducer, no state.
+ *   - this file:      reducer + wrap-math composed. Drive `reduce`
+ *                     with a width that DOES wrap, then assert that
+ *                     the resulting state + a fresh layout (computed
+ *                     the same way the renderer does) tell a coherent
+ *                     story.
+ *
+ * Why not render React: the codebase pattern is "shallow constructibility
+ * tests + state-machine + pure-helper", not virtual-terminal pixel
+ * assertions. The integration boundary that matters is reducer ↔
+ * wrap-math; the React shell is a thin dispatch layer over both.
+ * Component-level visual verification stays in the demo
+ * (`pnpm demo:text-input`).
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  type Action,
+  type ReducerOptions,
+  initialState,
+  reduce,
+  selectedText,
+  selectionOrCaretRange,
+} from './state.js'
+import { type WrapHint, buildWrapLayout } from './wrap-math.js'
+
+// Realistic options — a multiline TextInput at a narrow width that
+// will reliably wrap typical buffers used in these tests.
+const W10: ReducerOptions = { multiline: true, maxLength: undefined, width: 10 }
+const W12: ReducerOptions = { multiline: true, maxLength: undefined, width: 12 }
+const W20: ReducerOptions = { multiline: true, maxLength: undefined, width: 20 }
+
+function build(value: string, ...actions: Action[]) {
+  let s = initialState(value)
+  for (const a of actions) s = reduce(s, a, W10)
+  return s
+}
+
+/** Re-derive the layout the renderer would build for the current
+ *  state under a given options. Mirrors the `useMemo` in TextInput.tsx
+ *  so the integration assertions exercise the same composition. */
+function layoutOf(value: string, opts: ReducerOptions) {
+  return buildWrapLayout(value, {
+    width: opts.width,
+    indentedWrap: opts.indentedWrap,
+    wordBoundaries: opts.wordBoundaries,
+    hints: opts.hints,
+  })
+}
+
+// ── Editing across wrap boundaries ───────────────────────────────────
+
+describe('TextInput integration: editing across wrap boundaries', () => {
+  it('typing past the wrap boundary creates a new visual row, caret follows', () => {
+    // Empty buffer at width 10. Type 12 a's. The buffer wraps to two
+    // visual rows (10 + 2). Caret ends on the continuation row.
+    let s = initialState('')
+    s = reduce(s, { type: 'insertText', text: 'a'.repeat(12) }, W10)
+    expect(s.value).toBe('a'.repeat(12))
+    expect(s.caret).toBe(12)
+
+    const layout = layoutOf(s.value, W10)
+    expect(layout.rows.length).toBe(2)
+    const visCaret = layout.logicalToVisual(s.caret)
+    expect(visCaret.row).toBe(1)
+    expect(visCaret.col).toBe(2)
+  })
+
+  it('backspace that crosses BACK over the wrap boundary collapses the layout to one row', () => {
+    // Start with 11 chars (wraps to 2 rows: 10 + 1). Backspace twice
+    // → 9 chars → fits in 1 row. Caret on row 0 at col 9.
+    let s = build('a'.repeat(11))
+    s = reduce(s, { type: 'moveCaret', direction: 'docEnd', extend: false }, W10)
+    s = reduce(s, { type: 'deleteBackward' }, W10)
+    s = reduce(s, { type: 'deleteBackward' }, W10)
+    expect(s.value).toBe('a'.repeat(9))
+
+    const layout = layoutOf(s.value, W10)
+    expect(layout.rows.length).toBe(1)
+    expect(layout.logicalToVisual(s.caret)).toEqual({ row: 0, col: 9 })
+  })
+
+  it('delete forward at end of a visual row joins the buffer; layout reflows', () => {
+    // 'aaaaa bbbbb ccccc' (17 chars, 3 words). Width 12 wraps to two
+    // rows: 'aaaaa bbbbb ' / 'ccccc'. Place caret at idx 11 (the
+    // space before 'ccccc'). Forward-delete the space — the buffer
+    // becomes 'aaaaa bbbbbccccc' (16 chars), still wraps to 2 rows
+    // but at a different boundary because 'bbbbbccccc' is a single
+    // long token now.
+    let s = initialState('aaaaa bbbbb ccccc')
+    s = reduce(s, { type: 'setCaret', charIdx: 11, extend: false }, W12)
+    s = reduce(s, { type: 'deleteForward' }, W12)
+    expect(s.value).toBe('aaaaa bbbbbccccc')
+    expect(s.caret).toBe(11)
+
+    const layout = layoutOf(s.value, W12)
+    expect(layout.rows.length).toBeGreaterThan(1)
+    // The 11-char token 'bbbbbccccc' is now atomic from word-wrap's
+    // perspective — but it's longer than width 12 minus 'aaaaa '
+    // (6 chars, 6 cells)? No: 'aaaaa bbbbbccccc' fits as
+    // 'aaaaa ' (6) on row 0 if 'bbbbbccccc' (11) won't fit alongside
+    // … 6 + 11 = 17 > 12, so word-wrap pushes 'bbbbbccccc' to row 1.
+    // Then 'bbbbbccccc' is 11 cells, fits in row 1. Verify exactly.
+    expect(layout.rows[0]?.text).toBe('aaaaa ')
+    expect(layout.rows[1]?.text).toBe('bbbbbccccc')
+  })
+
+  it('insertText that replaces a multi-row selection: buffer and caret are coherent', () => {
+    // 'aaaaaaaaaa bbbbbbbbbb' (21 chars). Width 10 wraps to:
+    //   row 0: 'aaaaaaaaaa' (chars 0-10)
+    //   row 1: ' '          (char 10-11) — trailing whitespace stays past width
+    //   row 2: 'bbbbbbbbbb' (chars 11-21)
+    // Select [5, 16] — middle of row 0 to middle of row 2 — and replace
+    // with 'X'. Buffer becomes 'aaaaaXbbbbb' (11 chars), wraps to 2
+    // rows. Caret ends at idx 6 (start + len of 'X').
+    let s = initialState('aaaaaaaaaa bbbbbbbbbb')
+    s = reduce(s, { type: 'setCaret', charIdx: 5, extend: false }, W10)
+    s = reduce(s, { type: 'setCaret', charIdx: 16, extend: true }, W10)
+    s = reduce(s, { type: 'insertText', text: 'X' }, W10)
+    expect(s.value).toBe('aaaaaXbbbbb')
+    expect(s.caret).toBe(6)
+    expect(s.selection).toBeNull()
+
+    const layout = layoutOf(s.value, W10)
+    expect(layout.rows.length).toBe(2)
+    expect(layout.logicalToVisual(s.caret)).toEqual({ row: 0, col: 6 })
+  })
+})
+
+// ── Selection across wrap ────────────────────────────────────────────
+
+describe('TextInput integration: selection across wrap', () => {
+  it('selectionOrCaretRange returns logical range that spans multiple visual rows', () => {
+    // 22 a's at width 10 → 3 rows (10 + 10 + 2). Select [3, 18] — anchor
+    // on row 0 col 3, focus on row 1 col 8.
+    let s = initialState('a'.repeat(22))
+    s = reduce(s, { type: 'setCaret', charIdx: 3, extend: false }, W10)
+    s = reduce(s, { type: 'setCaret', charIdx: 18, extend: true }, W10)
+
+    const [start, end] = selectionOrCaretRange(s)
+    expect(start).toBe(3)
+    expect(end).toBe(18)
+
+    const layout = layoutOf(s.value, W10)
+    expect(layout.logicalToVisual(start).row).toBe(0)
+    expect(layout.logicalToVisual(end).row).toBe(1)
+    // selectedText is just the slice — wrap-agnostic by construction.
+    expect(selectedText(s)).toBe('a'.repeat(15))
+  })
+
+  it('selectAll spans every visual row of a wrapped buffer', () => {
+    let s = initialState('a'.repeat(25))
+    s = reduce(s, { type: 'selectAll' }, W10)
+    expect(s.selection).toEqual({ anchor: 0, focus: 25 })
+
+    const layout = layoutOf(s.value, W10)
+    expect(layout.rows.length).toBe(3)
+    // Selection covers from row 0 col 0 to last-row last-col, inclusive
+    // of every visual row in between.
+    const [, end] = selectionOrCaretRange(s)
+    expect(layout.logicalToVisual(end).row).toBe(layout.rows.length - 1)
+  })
+})
+
+// ── Wrap mode plumbing ───────────────────────────────────────────────
+
+describe('TextInput integration: wrap-mode props flow through ReducerOptions', () => {
+  it('wordBoundaries=identifier — snake_case stays whole when only the suffix would overflow', () => {
+    // 'do_something_long' (17 chars) at width 12 with identifier mode.
+    // Identifier mode prefers breaking AFTER underscore. Layout should
+    // break at the _ boundary, not mid-letter.
+    const value = 'do_something_long'
+    const opts: ReducerOptions = { ...W12, wordBoundaries: 'identifier' }
+    const layout = layoutOf(value, opts)
+    // Whitespace mode would char-wrap (no whitespace anywhere); identifier
+    // mode finds the underscore. Verify rows split at underscore boundaries.
+    expect(layout.rows.length).toBeGreaterThan(1)
+    for (const row of layout.rows) {
+      // No row should END mid-token (i.e., not at an _ boundary or
+      // buffer end). Last row is exempt.
+      if (row !== layout.rows[layout.rows.length - 1]) {
+        const endsAtUnderscore = value[row.endCharIdx - 1] === '_'
+        expect(endsAtUnderscore).toBe(true)
+      }
+    }
+  })
+
+  it('wrapHints — buffer-relative hint protects an atomic span across the layout', () => {
+    // 'see chit-abc-123 done' (21 chars). Without a hint, identifier
+    // mode would happily break at hyphens inside chit-abc-123.
+    // A hint covering [4, 16] forbids breaks inside that range,
+    // forcing the wrap to land elsewhere.
+    const value = 'see chit-abc-123 done'
+    const hints: WrapHint[] = [{ start: 4, end: 16 }]
+    const opts: ReducerOptions = { ...W12, wordBoundaries: 'identifier', hints }
+    const layout = layoutOf(value, opts)
+
+    // No row should split inside the hinted range.
+    for (const row of layout.rows) {
+      const splitsHint = row.endCharIdx > 4 && row.endCharIdx < 16
+      expect(splitsHint).toBe(false)
+    }
+  })
+
+  it('indentedWrap — caret nav from row 0 down to a continuation row clamps preferredCol to display col', () => {
+    // '    apple banana' (16 chars, 4 leading spaces). Width 12 +
+    // indentedWrap=true → row 0 'apple ' decoration omitted (it's a
+    // first row), row 1 has 4 indent cells of decoration before
+    // 'banana'. Place caret on row 0 at display col 8 (idx 8 = 'e' in
+    // 'apple'). Press Down. The caret should land in the continuation
+    // row — but at display col 8, which is INSIDE the indent
+    // decoration. visualToLogical clicks-inside-indent snap to row
+    // content start, so caret lands at the start of 'banana' (idx 10).
+    const value = '    apple banana'
+    const opts: ReducerOptions = { ...W12, indentedWrap: true }
+    let s = initialState(value)
+    s = reduce(s, { type: 'setCaret', charIdx: 8, extend: false }, opts)
+    expect(s.preferredCol).toBeNull()
+    s = reduce(s, { type: 'moveCaret', direction: 'down', extend: false }, opts)
+
+    // preferredCol captured from row 0 display col 8.
+    expect(s.preferredCol).toBe(8)
+    // Caret on continuation row. The exact char idx depends on
+    // visualToLogical's indent-clamp rule: display col 8, indent is
+    // 4, so text-internal col is 4. Continuation row text is
+    // 'banana' starting at idx 10. col 4 within 'banana' = idx 14.
+    const layout = layoutOf(s.value, opts)
+    const visCaret = layout.logicalToVisual(s.caret)
+    expect(visCaret.row).toBe(1)
+    expect(s.caret).toBe(14)
+  })
+})
+
+// ── Soft-wrap edge cases ─────────────────────────────────────────────
+
+describe('TextInput integration: soft-wrap edge cases', () => {
+  it('CJK at row boundary — packs by cells, never splits a 2-cell grapheme', () => {
+    // '中文测试日本' = 6 chars × 2 cells = 12 cells. Width 8 = 4 chars per
+    // row. Two rows of 4 chars each, no straddling.
+    const value = '中文测试日本'
+    let s = initialState(value)
+    s = reduce(s, { type: 'setCaret', charIdx: 4, extend: false }, { ...W10, width: 8 })
+    expect(s.caret).toBe(4)
+
+    const layout = buildWrapLayout(value, { width: 8 })
+    expect(layout.rows.length).toBe(2)
+    expect(layout.rows[0]?.text).toBe('中文测试')
+    expect(layout.rows[1]?.text).toBe('日本')
+    // Caret at idx 4 is exactly at the row boundary. Per the wrap
+    // convention, position-at-wrap-boundary prefers START of next row.
+    expect(layout.logicalToVisual(s.caret)).toEqual({ row: 1, col: 0 })
+  })
+
+  it('emoji + ASCII mix — surrogate pairs stay together at wrap boundaries', () => {
+    // 'a😀b😀c' — 'a' (1 cell), '😀' (2 cells, 2 UTF-16 units),
+    // 'b' (1), '😀' (2), 'c' (1). 7 cells total. Width 3 forces the
+    // tightest packing where the emoji fills row capacity:
+    //   row 0: 'a😀' (3 cells, 3 chars: a + surrogate pair)
+    //   row 1: 'b😀' (3 cells, 3 chars)
+    //   row 2: 'c'   (1 cell)
+    // The grapheme segmenter ensures each emoji lands intact on
+    // exactly one row — no row text contains a lone surrogate.
+    const value = 'a😀b😀c'
+    const layout = buildWrapLayout(value, { width: 3 })
+    expect(layout.rows.length).toBe(3)
+    expect(layout.rows[0]?.text).toBe('a😀')
+    expect(layout.rows[1]?.text).toBe('b😀')
+    expect(layout.rows[2]?.text).toBe('c')
+    // Rejoin: rows concat = original buffer (no chars lost or
+    // duplicated, surrogate pairs intact).
+    expect(layout.rows.map((r) => r.text).join('')).toBe(value)
+  })
+
+  it('very long single token char-wraps when no whitespace break is available', () => {
+    // 'supercalifragilisticexpialidocious' = 34 chars, no whitespace.
+    // Width 10 falls back to char-wrap: 4 rows of 10 + 4.
+    const value = 'supercalifragilisticexpialidocious'
+    const layout = buildWrapLayout(value, { width: 10 })
+    expect(layout.rows.length).toBe(4)
+    expect(layout.rows[0]?.text.length).toBe(10)
+    expect(layout.rows[1]?.text.length).toBe(10)
+    expect(layout.rows[2]?.text.length).toBe(10)
+    expect(layout.rows[3]?.text.length).toBe(4)
+  })
+
+  it('consecutive newlines produce empty visual rows the caret can sit on', () => {
+    // '\n\n\n' is 3 newlines → 4 logical lines (all empty) → 4 visual
+    // rows of zero cells. Caret can land on each.
+    const value = '\n\n\n'
+    const s = initialState(value) // caret at end = 3
+    expect(s.caret).toBe(3)
+
+    const layout = buildWrapLayout(value, { width: 20 })
+    expect(layout.rows.length).toBe(4)
+    for (const row of layout.rows) expect(row.text).toBe('')
+
+    // Each char idx maps to a distinct row (caret placement on each
+    // empty line works).
+    expect(layout.logicalToVisual(0)).toEqual({ row: 0, col: 0 })
+    expect(layout.logicalToVisual(1)).toEqual({ row: 1, col: 0 })
+    expect(layout.logicalToVisual(2)).toEqual({ row: 2, col: 0 })
+    expect(layout.logicalToVisual(3)).toEqual({ row: 3, col: 0 })
+  })
+
+  it('width=0 — first-frame fallback: edits still apply, layout returns no rows', () => {
+    // Yoga hasn't measured yet. Reducer accepts edits; caret nav
+    // falls back to logical-line walk; layout is empty but doesn't
+    // crash.
+    const ZERO: ReducerOptions = { multiline: true, maxLength: undefined, width: 0 }
+    let s = initialState('hello\nworld')
+    s = reduce(s, { type: 'insertText', text: 'X' }, ZERO)
+    expect(s.value).toBe('hello\nworldX')
+
+    const layout = buildWrapLayout(s.value, { width: 0 })
+    expect(layout.rows.length).toBe(0)
+    // Safe-fallback maps return {0,0} / 0 — no crash.
+    expect(layout.logicalToVisual(s.caret)).toEqual({ row: 0, col: 0 })
+    expect(layout.visualToLogical(0, 0)).toBe(0)
+  })
+
+  it('hint span wider than width — no break inside, rejoin holds, terminates', () => {
+    // A hinted span longer than `width` cannot be broken AT ALL —
+    // wrap math must accept the overflow rather than dropping content
+    // or looping. Verify (a) no row breaks INSIDE the hint range,
+    // (b) the rejoin invariant survives, (c) the layout terminates.
+    const value = 'pre veryLongAtomicWord post'
+    // 'veryLongAtomicWord' = chars 4-22 (18 chars). Hint covers the
+    // full word.
+    const hints: WrapHint[] = [{ start: 4, end: 22 }]
+    const layout = buildWrapLayout(value, { width: 10, hints })
+
+    // No row may end strictly inside the hint range — that would be
+    // a break inside the atomic span.
+    for (const row of layout.rows) {
+      const splitsHint = row.endCharIdx > 4 && row.endCharIdx < 22
+      expect(splitsHint).toBe(false)
+    }
+    // Rejoin: rows concat = original buffer.
+    expect(layout.rows.map((r) => r.text).join('')).toBe(value)
+  })
+})
+
+// ── Realistic editing flow ───────────────────────────────────────────
+
+describe('TextInput integration: realistic editing scenario', () => {
+  it('compose: type long content, navigate up across visual rows, edit mid-row, navigate down', () => {
+    // Empty buffer at width 12. Type two long words — verify wrap.
+    // Navigate up — verify caret lands on a continuation row at the
+    // preferred col. Insert a char — verify wrap reflows. Navigate
+    // down — verify caret lands at preferredCol (clamped to row).
+    let s = initialState('')
+    s = reduce(s, { type: 'insertText', text: 'aaaaaaaaaaaaa bbbbbbbbbbbbb' }, W12)
+    expect(s.value).toBe('aaaaaaaaaaaaa bbbbbbbbbbbbb')
+    expect(s.caret).toBe(27)
+
+    // 'aaaaaaaaaaaaa bbbbbbbbbbbbb' is 27 chars at width 12.
+    // wrapByWords: try to fit 12 cells in row 0. First word is 13
+    // chars (longer than width) — char-wrap fallback for it. So row
+    // 0 = 'aaaaaaaaaaaa' (12), row 1 = 'a ' (2), row 2 = a chunk
+    // of bbb... — let's not pin exact wrapping, just verify >= 3 rows
+    // and the buffer is intact.
+    const layout1 = layoutOf(s.value, W12)
+    expect(layout1.rows.length).toBeGreaterThanOrEqual(3)
+
+    // Move up — caret moves through visual rows.
+    const visCaret1 = layout1.logicalToVisual(s.caret)
+    s = reduce(s, { type: 'moveCaret', direction: 'up', extend: false }, W12)
+    expect(s.preferredCol).toBe(visCaret1.col)
+    const layout2 = layoutOf(s.value, W12)
+    const visCaret2 = layout2.logicalToVisual(s.caret)
+    expect(visCaret2.row).toBe(visCaret1.row - 1)
+
+    // Insert a char mid-row. preferredCol resets per the outer
+    // reduce wrapper. Buffer grows by one.
+    s = reduce(s, { type: 'insertText', text: 'X' }, W12)
+    expect(s.value.length).toBe(28)
+    expect(s.preferredCol).toBeNull()
+
+    // Move down — preferredCol re-captures from the new caret pos.
+    const layout3 = layoutOf(s.value, W12)
+    const visCaret3 = layout3.logicalToVisual(s.caret)
+    s = reduce(s, { type: 'moveCaret', direction: 'down', extend: false }, W12)
+    expect(s.preferredCol).toBe(visCaret3.col)
+
+    const layout4 = layoutOf(s.value, W12)
+    const visCaret4 = layout4.logicalToVisual(s.caret)
+    expect(visCaret4.row).toBe(visCaret3.row + 1)
+  })
+
+  it('selection-then-replace round-trip: visual position consistent after each step', () => {
+    // Type, select mid-buffer, replace with a longer string, verify
+    // the caret + selection state and visual position all line up.
+    let s = initialState('hello world hello world')
+    // Place caret on row 0 col 6 (start of first 'world'). Width 20
+    // wraps to two rows: 'hello world hello ' (18 chars + trailing
+    // space stays past width per HTML/CSS pre-wrap convention) +
+    // 'world' (5).
+    s = reduce(s, { type: 'setCaret', charIdx: 6, extend: false }, W20)
+    s = reduce(s, { type: 'setCaret', charIdx: 17, extend: true }, W20)
+    expect(selectedText(s)).toBe('world hello')
+
+    // Replace the selection.
+    s = reduce(s, { type: 'insertText', text: 'BYE' }, W20)
+    expect(s.value).toBe('hello BYE world')
+    expect(s.caret).toBe(9)
+    expect(s.selection).toBeNull()
+
+    const layout = layoutOf(s.value, W20)
+    expect(layout.rows.length).toBe(1) // 15 chars now fits
+    expect(layout.logicalToVisual(s.caret)).toEqual({ row: 0, col: 9 })
+  })
+})

--- a/packages/renderer/src/components/TextInput/clipboard-action.test.ts
+++ b/packages/renderer/src/components/TextInput/clipboard-action.test.ts
@@ -8,6 +8,7 @@
 import { describe, expect, it } from 'vitest'
 import { type ClipboardKeyInput, clipboardKeyAction } from './clipboard-action.js'
 import { type TextInputState, initialState, reduce } from './state.js'
+import { buildWrapLayout } from './wrap-math.js'
 
 // width is required by ReducerOptions but irrelevant here — these
 // tests only build state via setCaret to seed selection ranges.
@@ -126,6 +127,164 @@ describe('clipboardKeyAction', () => {
       // → selectedText returns ''. Should fall through.
       const s = withCaret('hello', 3)
       expect(clipboardKeyAction(ctrlC, s, false)).toEqual({ kind: 'fallthrough' })
+    })
+  })
+
+  describe('selection spanning visual rows (soft-wrap)', () => {
+    // Architectural invariant: cut/copy operates on the LOGICAL char
+    // buffer (`state.value.slice(start, end)`), never on the rendered
+    // visual rows. Visual wrapping is purely a render-time concern;
+    // the selection state stores logical char indices and the
+    // clipboard sees raw buffer text.
+    //
+    // These tests construct buffers + selections that DEMONSTRABLY
+    // span multiple visual rows under a known wrap width, verify the
+    // visual-row spread via buildWrapLayout, and assert the clipboard
+    // text is the contiguous buffer slice — uncorrupted by any wrap
+    // artifact (no row separators injected, no indent decoration
+    // bleeding in, no atomic-span boundary trickery).
+
+    it('word-wrapped: selection across two visual rows of one logical line', () => {
+      // 'aaaa bbbb cccc dddd' (19 chars). Width 10 wraps to:
+      //   row 0: 'aaaa bbbb '  (chars 0-10)   ← trailing space stays at break
+      //   row 1: 'cccc dddd'   (chars 10-19)
+      // Selection [5, 14] = 'bbbb cccc' spans both rows.
+      const s = withSelection('aaaa bbbb cccc dddd', 5, 14)
+      const layout = buildWrapLayout(s.value, { width: 10 })
+      expect(layout.rows.length).toBe(2)
+      expect(layout.logicalToVisual(5).row).toBe(0)
+      expect(layout.logicalToVisual(14).row).toBe(1)
+      expect(clipboardKeyAction(ctrlC, s, false)).toEqual({ kind: 'copy', text: 'bbbb cccc' })
+    })
+
+    it('char-wrapped: selection across visual rows of a single long token', () => {
+      // 18 a's at width 10 wraps to:
+      //   row 0: 'aaaaaaaaaa'  (chars 0-10)
+      //   row 1: 'aaaaaaaa'    (chars 10-18)
+      // Selection [3, 15] crosses row boundary at char 10.
+      const s = withSelection('a'.repeat(18), 3, 15)
+      const layout = buildWrapLayout(s.value, { width: 10 })
+      expect(layout.rows.length).toBe(2)
+      expect(layout.logicalToVisual(3).row).toBe(0)
+      expect(layout.logicalToVisual(15).row).toBe(1)
+      expect(clipboardKeyAction(ctrlC, s, false)).toEqual({ kind: 'copy', text: 'a'.repeat(12) })
+    })
+
+    it('cuts across visual rows: clipboard receives buffer slice + delete uses same range', () => {
+      // 'hello world hello world' (23 chars). Width 12 wraps to:
+      //   row 0: 'hello world '  (chars 0-12)
+      //   row 1: 'hello world'   (chars 12-23)
+      // Cut [6, 17] = 'world hello' spans both rows. Verify the
+      // returned text is exactly that — and that a follow-up reduce
+      // with deleteBackward removes precisely that range from the
+      // buffer (no off-by-one from visual-row mismath).
+      const s = withSelection('hello world hello world', 6, 17)
+      const layout = buildWrapLayout(s.value, { width: 12 })
+      expect(layout.rows.length).toBe(2)
+      const cut = clipboardKeyAction(ctrlX, s, false)
+      expect(cut).toEqual({ kind: 'cut', text: 'world hello' })
+
+      // The React shell does `copy(text); dispatch(deleteBackward)`.
+      // Simulate the dispatch and verify the buffer is what we'd
+      // expect: the [6,17) range removed, caret at 6.
+      const opts = { multiline: true, maxLength: undefined, width: 12 }
+      const after = reduce(s, { type: 'deleteBackward' }, opts)
+      expect(after.value).toBe('hello  world')
+      expect(after.caret).toBe(6)
+      expect(after.selection).toBeNull()
+    })
+
+    it('selection spans both a wrap continuation AND a hard \\n boundary', () => {
+      // Logical line 0: 'aaaaaa bbbbbb' (13 chars; wraps at width 8 to
+      // 'aaaaaa ' + 'bbbbbb'). \n at idx 13. Logical line 1: 'cccc'.
+      // Buffer = 'aaaaaa bbbbbb\ncccc' (18 chars).
+      // Selection [4, 16] = 'aa bbbbbb\ncc' touches:
+      //   row 0 of logical line 0 (the 'aa ')
+      //   row 1 of logical line 0 (the 'bbbbbb')
+      //   row 2 — logical line 1 (the 'cc')
+      // newline preserved verbatim.
+      const value = 'aaaaaa bbbbbb\ncccc'
+      const s = withSelection(value, 4, 16)
+      const layout = buildWrapLayout(value, { width: 8 })
+      expect(layout.rows.length).toBeGreaterThanOrEqual(3)
+      expect(clipboardKeyAction(ctrlC, s, false)).toEqual({ kind: 'copy', text: 'aa bbbbbb\ncc' })
+    })
+
+    it('indented-wrap continuation: clipboard text excludes the visual indent decoration', () => {
+      // '    apple banana' has 4 leading spaces (chars 0-3). With
+      // indentedWrap + width 12, the layout decorates continuation
+      // rows with 4 indent cells (rendered as spaces by the renderer,
+      // NOT in the buffer). selectedText must NOT pick up that
+      // decoration. Selection [6, 16) = 'ple banana' — the 'ple' is
+      // in row 0, 'banana' is in the continuation row.
+      const value = '    apple banana'
+      const s = withSelection(value, 6, 16)
+      const layout = buildWrapLayout(value, { width: 12, indentedWrap: true })
+      // Sanity: there's at least one continuation row carrying the
+      // indent decoration. Without it, the test wouldn't be exercising
+      // anything wrap-specific.
+      const continuation = layout.rows.find((r) => r.isWrapContinuation)
+      expect(continuation?.indentCells).toBeGreaterThan(0)
+      // Clipboard text is the raw [6, 16) buffer slice. No injected
+      // indent spaces, no row joiners.
+      expect(clipboardKeyAction(ctrlC, s, false)).toEqual({ kind: 'copy', text: 'ple banana' })
+    })
+
+    it('hint-protected atomic span inside a multi-row selection: text is verbatim buffer', () => {
+      // Wrap hints affect WHERE rows break, never WHAT bytes a
+      // selection captures. Construct a selection that fully contains
+      // a hinted atomic span ('chit-abc-123') plus surrounding text;
+      // verify the copied text is the unaltered buffer slice
+      // regardless of how the hint shifted the wrap.
+      //
+      // Buffer: 'see chit-abc-123 for more' (25 chars). At width 14
+      // with hint covering 'chit-abc-123' (chars 4-16), the wrap must
+      // not break inside the hint — so the natural break shifts.
+      const value = 'see chit-abc-123 for more'
+      const s = withSelection(value, 0, 20) // 'see chit-abc-123 for'
+      const layout = buildWrapLayout(value, {
+        width: 14,
+        hints: [{ start: 4, end: 16 }],
+      })
+      // No row should split the hinted span.
+      for (const row of layout.rows) {
+        const rowEnd = row.endCharIdx
+        const hintStart = 4
+        const hintEnd = 16
+        expect(rowEnd > hintStart && rowEnd < hintEnd).toBe(false)
+      }
+      expect(clipboardKeyAction(ctrlC, s, false)).toEqual({
+        kind: 'copy',
+        text: 'see chit-abc-123 for',
+      })
+    })
+
+    it('CJK at row boundary: selection across the boundary returns full graphemes', () => {
+      // CJK chars are 2 cells each. '中文测试日本' (6 chars, 12 cells).
+      // Width 8 packs 4 chars (8 cells) per row:
+      //   row 0: '中文测试' (chars 0-4)
+      //   row 1: '日本'     (chars 4-6)
+      // Selection [2, 5] = '测试日' crosses row boundary mid-grapheme
+      // group. Buffer slice is correct because we slice by char idx,
+      // not cell idx.
+      const value = '中文测试日本'
+      const s = withSelection(value, 2, 5)
+      const layout = buildWrapLayout(value, { width: 8 })
+      expect(layout.rows.length).toBe(2)
+      expect(layout.logicalToVisual(2).row).toBe(0)
+      expect(layout.logicalToVisual(5).row).toBe(1)
+      expect(clipboardKeyAction(ctrlC, s, false)).toEqual({ kind: 'copy', text: '测试日' })
+    })
+
+    it('password mode + multi-row selection: still falls through, text never reaches clipboard', () => {
+      // Same architectural rule applies regardless of wrap state:
+      // password mode never copies. Visual-row span doesn't change
+      // that — the gate is on `password`, not on the selection shape.
+      const s = withSelection('a'.repeat(30), 5, 25)
+      const layout = buildWrapLayout(s.value, { width: 10 })
+      expect(layout.rows.length).toBeGreaterThan(2) // truly spans 3+ rows
+      expect(clipboardKeyAction(ctrlC, s, true)).toEqual({ kind: 'fallthrough' })
+      expect(clipboardKeyAction(ctrlX, s, true)).toEqual({ kind: 'cut-no-copy' })
     })
   })
 })

--- a/packages/renderer/src/components/TextInput/state.test.ts
+++ b/packages/renderer/src/components/TextInput/state.test.ts
@@ -7,7 +7,14 @@
  */
 
 import { describe, expect, it } from 'vitest'
-import { type Action, type ReducerOptions, initialState, reduce, selectedText } from './state.js'
+import {
+  type Action,
+  type ReducerOptions,
+  type TextInputState,
+  initialState,
+  reduce,
+  selectedText,
+} from './state.js'
 
 // Width is required by ReducerOptions because visual-row navigation
 // (`up` / `down` post-C4) needs to know where lines wrap. The value
@@ -506,5 +513,179 @@ describe('reduce: visual-row nav (up / down)', () => {
     s = reduce(s, { type: 'moveCaret', direction: 'down', extend: false }, MULTI)
     expect(s.caret).toBe(8)
     expect(s.preferredCol).toBe(2)
+  })
+})
+
+// ── visual-row nav: preferredCol regression coverage ─────────────────
+
+describe('reduce: preferredCol resets across non-vertical actions', () => {
+  // Catches "I added a new action and forgot to clear preferredCol"
+  // regressions. Each test seeds a state where preferredCol is non-null
+  // (set by a prior Down), dispatches the action under test, and
+  // asserts preferredCol returned to null. The outer `reduce` wrapper
+  // is the single source of truth here — every action EXCEPT vertical
+  // move-caret should land on the reset path.
+
+  function withPreferredCol(): TextInputState {
+    // Standard fixture: 3 wide logical lines, caret at row 0 col 5,
+    // then Down — preferredCol captured as 5. Wide enough that EVERY
+    // delete variant has something to delete (Ctrl+K and Ctrl+U
+    // would no-op at line ends, and the outer `reduce` wrapper
+    // preserves preferredCol on no-ops by referential identity for
+    // React memoization — so a fixture parked at line-end would
+    // produce false negatives on those branches).
+    let s = init('aaaaaaaaaa\nbbbbbbbbbb\ncccccccccc')
+    s = reduce(s, { type: 'setCaret', charIdx: 5, extend: false }, MULTI)
+    s = reduce(s, { type: 'moveCaret', direction: 'down', extend: false }, MULTI)
+    expect(s.preferredCol).toBe(5)
+    expect(s.caret).toBe(16) // line 1 'bbbbbbbbbb' col 5
+    return s
+  }
+
+  // Every horizontal / jump caret direction. Table-driven so adding a
+  // new direction without clearing preferredCol gets caught here.
+  const horizontalDirections = [
+    'left',
+    'right',
+    'home',
+    'end',
+    'wordLeft',
+    'wordRight',
+    'docStart',
+    'docEnd',
+  ] as const
+
+  for (const direction of horizontalDirections) {
+    it(`resets after moveCaret(${direction})`, () => {
+      let s = withPreferredCol()
+      s = reduce(s, { type: 'moveCaret', direction, extend: false }, MULTI)
+      expect(s.preferredCol).toBeNull()
+    })
+  }
+
+  // Every delete variant.
+  const deleteActions: Action[] = [
+    { type: 'deleteBackward' },
+    { type: 'deleteForward' },
+    { type: 'deleteWordBackward' },
+    { type: 'deleteLineBackward' },
+    { type: 'deleteLineForward' },
+  ]
+
+  for (const action of deleteActions) {
+    it(`resets after ${action.type}`, () => {
+      let s = withPreferredCol()
+      s = reduce(s, action, MULTI)
+      expect(s.preferredCol).toBeNull()
+    })
+  }
+
+  it('resets after setCaret (click / programmatic positioning)', () => {
+    let s = withPreferredCol()
+    s = reduce(s, { type: 'setCaret', charIdx: 0, extend: false }, MULTI)
+    expect(s.preferredCol).toBeNull()
+  })
+
+  it('resets after selectAll', () => {
+    let s = withPreferredCol()
+    s = reduce(s, { type: 'selectAll' }, MULTI)
+    expect(s.preferredCol).toBeNull()
+  })
+
+  it('resets after redo (symmetric to undo)', () => {
+    // Build a state where redo is meaningful: edit, undo, then enter
+    // a vertical chain, then redo. preferredCol should clear.
+    let s = init('aaaaaaa\nbb\ncccccc')
+    s = reduce(s, { type: 'setCaret', charIdx: 5, extend: false }, MULTI)
+    s = reduce(s, { type: 'insertText', text: 'X' }, MULTI)
+    s = reduce(s, { type: 'undo' }, MULTI)
+    s = reduce(s, { type: 'moveCaret', direction: 'down', extend: false }, MULTI)
+    expect(s.preferredCol).not.toBeNull()
+    s = reduce(s, { type: 'redo' }, MULTI)
+    expect(s.preferredCol).toBeNull()
+  })
+})
+
+describe('reduce: preferredCol persistence across mixed-row layouts', () => {
+  // Width 10 wraps long lines; multi-line content layered on top
+  // exercises the interaction between visual-row nav and \n boundaries.
+  const W10: ReducerOptions = { multiline: true, maxLength: undefined, width: 10 }
+
+  it('Up through a SHORT intermediate visual row preserves preferredCol (mirror of Down test)', () => {
+    // 3 logical lines of decreasing width: 'aaaaaaa' (7) / 'bb' (2) /
+    // 'cccccc' (6). Width 80 keeps each as one visual row. Start
+    // caret at row 2 col 5, press Up twice — clamps on row 1, then
+    // returns to col 5 on row 0 because preferredCol stuck.
+    let s = init('aaaaaaa\nbb\ncccccc')
+    s = reduce(s, { type: 'setCaret', charIdx: 16, extend: false }, MULTI) // col 5 of 'cccccc'
+    s = reduce(s, { type: 'moveCaret', direction: 'up', extend: false }, MULTI)
+    expect(s.caret).toBe(10) // end of 'bb'
+    expect(s.preferredCol).toBe(5)
+    s = reduce(s, { type: 'moveCaret', direction: 'up', extend: false }, MULTI)
+    expect(s.caret).toBe(5) // 'aaaaaaa' col 5
+    expect(s.preferredCol).toBe(5)
+  })
+
+  it('preferredCol persists across a hard \\n boundary mid-vertical-chain', () => {
+    // Logical line 0 wraps to 2 visual rows, logical line 1 is one
+    // row. Chain Down across the wrap continuation AND the \n; the
+    // captured col carries through both transitions.
+    //
+    //   buffer: 'aaaaaaaaaaaaa\nbbbbbbbbbb' (24 chars)
+    //   width 10:
+    //     row 0: 'aaaaaaaaaa' (idx 0-10)   ← logical line 0, first visual row
+    //     row 1: 'aaa'        (idx 10-13)  ← logical line 0, continuation
+    //     row 2: 'bbbbbbbbbb' (idx 14-24)  ← logical line 1
+    //
+    // Start at row 0 col 5 (idx 5). Down once → row 1 col 3 (clamped,
+    // row 1 is only 3 cells); preferredCol still 5. Down again → row 2
+    // col 5 (idx 19), back to preferred col after crossing \n.
+    let s = init('aaaaaaaaaaaaa\nbbbbbbbbbb')
+    s = reduce(s, { type: 'setCaret', charIdx: 5, extend: false }, W10)
+    s = reduce(s, { type: 'moveCaret', direction: 'down', extend: false }, W10)
+    expect(s.caret).toBe(13) // end of row 1 (clamped)
+    expect(s.preferredCol).toBe(5)
+    s = reduce(s, { type: 'moveCaret', direction: 'down', extend: false }, W10)
+    expect(s.caret).toBe(19) // 'bbbbbbbbbb' col 5
+    expect(s.preferredCol).toBe(5)
+  })
+
+  it('indentedWrap=true: preferredCol captured from DISPLAY col (not text-internal col)', () => {
+    // '    apple banana' (16 chars, 4 leading spaces). Width 12 with
+    // indentedWrap → row 0 'apple' starts at display col 4 (first row
+    // includes the indent in its text), continuation 'banana' has 4
+    // indent decoration cells + 'banana'. Caret at idx 6 (the second
+    // 'p' in 'apple') — display col 6. Press Down → preferredCol 6.
+    const opts: ReducerOptions = {
+      ...W10,
+      width: 12,
+      indentedWrap: true,
+    }
+    let s = init('    apple banana')
+    s = reduce(s, { type: 'setCaret', charIdx: 6, extend: false }, opts)
+    s = reduce(s, { type: 'moveCaret', direction: 'down', extend: false }, opts)
+    // preferredCol is the DISPLAY col (4 indent + 2 content = 6 on
+    // row 0), captured before the move. Continuation row 1 has 4
+    // indent decoration; visualToLogical at display col 6 = text col 2
+    // within 'banana' = idx 12.
+    expect(s.preferredCol).toBe(6)
+    expect(s.caret).toBe(12)
+  })
+
+  it('vertical move that lands at the same caret (no-op edge) leaves a captured preferredCol set', () => {
+    // Caret at row 0 col 0 (idx 0). Up at row 0 returns to start of
+    // buffer (caret 0) — no actual movement. The reducer still treats
+    // this as a vertical action and captures the visual col (0).
+    // Verify the no-movement case doesn't accidentally null the col.
+    let s = init('hello\nworld')
+    s = reduce(s, { type: 'setCaret', charIdx: 0, extend: false }, MULTI)
+    expect(s.preferredCol).toBeNull()
+    s = reduce(s, { type: 'moveCaret', direction: 'up', extend: false }, MULTI)
+    expect(s.caret).toBe(0)
+    expect(s.preferredCol).toBe(0)
+    // A SECOND Up still respects the captured col (which is 0 here).
+    s = reduce(s, { type: 'moveCaret', direction: 'up', extend: false }, MULTI)
+    expect(s.caret).toBe(0)
+    expect(s.preferredCol).toBe(0)
   })
 })

--- a/packages/renderer/src/components/TextInput/wrap-math.test.ts
+++ b/packages/renderer/src/components/TextInput/wrap-math.test.ts
@@ -908,6 +908,60 @@ describe('wrap hints (programmatic atomic spans)', () => {
       }
     })
 
+    it('word-mode atomic-span overflow when span exceeds width (regression)', () => {
+      // Symmetric coverage to char-mode: word-wrap must also honor the
+      // atomic-span contract when the span is wider than `width`. Before
+      // the fix, word-mode hit overflow inside the hint with no break
+      // candidate and char-wrapped through the span (splitting at idx 14).
+      //
+      // Layout BEFORE fix (broken):
+      //   row 0: 'pre '
+      //   row 1: 'veryLongAt'   ← split inside hint at idx 14
+      //   row 2: 'omicWord '
+      //   row 3: 'post'
+      //
+      // Layout AFTER fix:
+      //   row 0: 'pre '
+      //   row 1: 'veryLongAtomicWord '  ← span stays atomic, accepts overflow
+      //   row 2: 'post'
+      const input = 'pre veryLongAtomicWord post'
+      const layout = buildWrapLayout(input, {
+        width: 10,
+        hints: [{ start: 4, end: 22 }], // 'veryLongAtomicWord'
+      })
+      // Rejoin invariant.
+      expect(layout.rows.map((r) => r.text).join('')).toBe(input)
+      // No row's break point lands strictly inside the hint range.
+      for (const row of layout.rows) {
+        const splitsHint = row.endCharIdx > 4 && row.endCharIdx < 22
+        expect(splitsHint).toBe(false)
+      }
+      // Pin the exact rows so a regression in either direction (over-
+      // splitting OR over-merging into one row) shows up.
+      expect(layout.rows.map((r) => r.text)).toEqual([
+        'pre ',
+        'veryLongAtomicWord ',
+        'post',
+      ])
+    })
+
+    it('word-mode atomic-span overflow at start of buffer (no prior safe break)', () => {
+      // Edge case: span starts at idx 0, so there is literally NO safe
+      // break before it. The deferred-wrap branch must still terminate
+      // (just emits the over-wide span on row 0).
+      const input = 'veryLongAtomicWord post'
+      const layout = buildWrapLayout(input, {
+        width: 10,
+        hints: [{ start: 0, end: 18 }], // 'veryLongAtomicWord'
+      })
+      expect(layout.rows.map((r) => r.text).join('')).toBe(input)
+      for (const row of layout.rows) {
+        const splitsHint = row.endCharIdx > 0 && row.endCharIdx < 18
+        expect(splitsHint).toBe(false)
+      }
+      expect(layout.rows.map((r) => r.text)).toEqual(['veryLongAtomicWord ', 'post'])
+    })
+
     it('joinWith field is accepted but not yet active (deferred to follow-up)', () => {
       // The TYPE accepts joinWith; the implementation ignores it for
       // this PR (renderer-side glyph injection comes later). Verify

--- a/packages/renderer/src/components/TextInput/wrap-math.test.ts
+++ b/packages/renderer/src/components/TextInput/wrap-math.test.ts
@@ -938,11 +938,7 @@ describe('wrap hints (programmatic atomic spans)', () => {
       }
       // Pin the exact rows so a regression in either direction (over-
       // splitting OR over-merging into one row) shows up.
-      expect(layout.rows.map((r) => r.text)).toEqual([
-        'pre ',
-        'veryLongAtomicWord ',
-        'post',
-      ])
+      expect(layout.rows.map((r) => r.text)).toEqual(['pre ', 'veryLongAtomicWord ', 'post'])
     })
 
     it('word-mode atomic-span overflow at start of buffer (no prior safe break)', () => {

--- a/packages/renderer/src/components/TextInput/wrap-math.ts
+++ b/packages/renderer/src/components/TextInput/wrap-math.ts
@@ -456,6 +456,19 @@ export function wrapByWords(
         rowAbsStart += lastBreakIdx
         row = overhang + segment
         rowWidth = stringWidth(row)
+      } else if (isInsideRange(allAtomicSpans, absPosBefore)) {
+        // Overflow with no break candidate AND we're inside an atomic
+        // span. Splitting here would violate the atomic-span contract
+        // ("NEVER break inside; if span > width, overflow on its own
+        // row" — same rule wrapByCells honors via lastSafeBreakIdx
+        // rollback). Defer the wrap by accepting the overflow in the
+        // current row; we'll push at the next safe break (whitespace
+        // exiting the span, or end of buffer).
+        row += segment
+        rowWidth += w
+        hasContent = true
+        prevChar = segment[segment.length - 1]
+        continue
       } else {
         // No break candidate — char-wrap fallback.
         if (row.length > 0) {


### PR DESCRIPTION
## Summary

Phase F of the soft-wrap multiline TextInput plan — cross-cutting tests + a real production bug surfaced and fixed while writing them.

**5 commits** (originally planned as 3; F1.5 added because the integration tests caught a contract violation, format fix split per granular-commit rule):

| # | Commit | Lines |
|---|---|---|
| F1 | `test(TextInput): cut/copy across visual line boundaries` | +159 in `clipboard-action.test.ts` |
| F1.5 | `fix(wrap-math): word-mode atomic-span overflow stays atomic` | +12 in `wrap-math.ts`, +55 tests |
| F2 | `test(TextInput): wrap edge cases end-to-end` | +429 new file `TextInput.wrap.test.ts` |
| F3 | `test(TextInput): caret nav across wraps preserves preferred column` | +182 in `state.test.ts` |
| - | `chore: biome single-line format on wrap-math.test.ts toEqual` | -4 |

Total: **45 new test cases**. Suite is now **655 tests passing** across 24 files (was 597 before Phase F).

## Why a fix in F1.5

The hint contract is documented as *"atomic spans NEVER break inside; if span > width, overflow on its own row"* (see `WrapHint` docstring). `wrapByCells` (char mode) honors it via `lastSafeBreakIdx` rollback. `wrapByWords` (default word mode) didn't — overflow with no break candidate fell through to char-wrap fallback, splitting the span mid-grapheme. Trace at width 10 with hint over `'veryLongAtomicWord'`:

```
BEFORE: row 1 = 'veryLongAt' ← split inside hint at idx 14
AFTER:  row 1 = 'veryLongAtomicWord ' ← stays atomic, accepts overflow
```

Three-line fix: a third branch in `wrapByWords`' overflow handler that checks `isInsideRange(allAtomicSpans, absPosBefore)` and defers the wrap until the next safe break. Two regression tests in `wrap-math.test.ts`: canonical case (mid-buffer) and edge case (span at buffer start with no prior safe break).

## What F2 covers

`TextInput.wrap.test.ts` is a new integration boundary — pinning behaviors that emerge when `state.ts` (reducer) and `wrap-math.ts` (pure helpers) compose via `ReducerOptions`. The pure layers each have exhaustive unit suites; this file pins the *combined* contract.

17 cases across 5 describe blocks: editing across wrap boundaries, selection across wrap, wrap-mode plumbing (identifier mode + hints + indentedWrap), edge cases (CJK, emoji, long single token, empty rows from `\n\n`, width=0), and a realistic editing flow.

## What F3 covers

State-machine tests for `preferredCol` — the field that lets the caret pass through SHORT visual rows on a vertical chain and snap back to its original column when a wider row appears. 18 new cases, mostly table-driven across:

- All 8 horizontal `moveCaret` directions
- All 5 delete variants
- `setCaret` / `selectAll` / `redo`
- Symmetric Up case (existing tests covered Down)
- Crossing a hard `\n` mid-vertical-chain
- `indentedWrap=true` captures *display col* (includes indent decoration)
- Vertical no-op edge (Up at row 0)

Fixture deliberately parks the caret in the middle of a wide line so each delete actually deletes — the outer `reduce` wrapper preserves `preferredCol` on no-ops by referential identity (intentional, for React memoization), and a fixture parked at line-end would mask Ctrl+K / Ctrl+U regressions.

## Test plan

- [ ] `pnpm test` — 655 passing
- [ ] `pnpm typecheck` — clean
- [ ] `pnpm lint` — clean
- [ ] `pnpm build` — clean
- [ ] CI green