### PR TITLE
feat(TextInput): validation rendering (roadmap 1.4)

### DIFF
--- a/docs/components/text-input.md
+++ b/docs/components/text-input.md
@@ -35,6 +35,9 @@ Component-specific props. All `<Box>` props are accepted EXCEPT `onKeyDown`, `on
 | `indentedWrap` | `boolean` | `true` | Hanging indent: continuation rows of an indented logical line align under the first non-whitespace char. See [Advanced wrap control](#advanced-wrap-control). |
 | `wordBoundaries` | `'whitespace' \| 'identifier'` | `'whitespace'` | Where wrap is allowed to break. `'identifier'` adds snake_case / kebab-case / camelCase break candidates and treats URLs as atomic. See [Advanced wrap control](#advanced-wrap-control). |
 | `wrapHints` | `ReadonlyArray<WrapHint>` | — | Programmatic atomic spans — buffer-relative ranges the wrap algorithm must NOT break inside. Memoize the array reference. See [Advanced wrap control](#advanced-wrap-control). |
+| `validate` | `(value: string) => string \| null` | — | Validation function. Return a non-empty message to mark the input invalid (border swaps to `errorColor`, message renders below the content). Return `null` or `''` for valid. See [Validation](#validation). |
+| `errorColor` | `Color` | `'red'` | Border + default message color when validation fails. Border-color precedence: error > focus > idle. |
+| `renderError` | `(message: string) => ReactNode` | dim red `<Text>` | Custom error-message renderer. Called only when `validate` returned a non-null message. |
 
 ## Examples
 
@@ -215,6 +218,75 @@ These are documented gaps, not bugs:
 
 - **`joinWith` on hints** — renderer-side glyph injection at wrap continuations (e.g., showing a `↪` at the start of a wrapped row inside a hint). The type field is accepted but ignored.
 - **Configurable `tabWidth`** — tabs currently report 0 cells via `stringWidth`. A future option would let consumers pick a tab width for measurement (and unblock tab-only hanging indent).
+
+## Validation
+
+Pass a `validate` function to mark the input invalid based on its current value. The border swaps to `errorColor` and the message renders below the input content (inside the bordered box, via the input's existing `flexDirection="column"`).
+
+```tsx
+<TextInput
+  value={slug}
+  onChange={setSlug}
+  borderStyle="round"
+  validate={(v) => {
+    if (v.length === 0) return null            // don't show error before user types
+    if (v.length < 3) return `${v.length}/3 characters minimum`
+    if (!/^[a-z0-9-]+$/.test(v)) return 'lowercase letters, digits, and hyphens only'
+    return null
+  }}
+/>
+```
+
+### Behavior
+
+- **Render-only.** `onSubmit` still fires when invalid. To block submit on error, check the validation result in your `onSubmit` handler before acting:
+  ```tsx
+  onSubmit={(v) => {
+    if (validate(v)) return
+    save(v)
+  }}
+  ```
+- **Runs every render.** No internal debounce — if the check is expensive, debounce inside the function (e.g., with a memoized regex) or gate it on a parent state condition.
+- **Empty string is treated as null.** Returning `''` from `validate` does NOT show an error with no message — that's almost always a bug. Be explicit: return `null` when valid.
+- **Border-color precedence**: error > focus > idle. A focused, invalid input keeps the red border (the focus-color swap is suppressed) so the validation state stays visible.
+- **Show-when-touched pattern**: return `null` while the buffer is empty / pristine, then start returning real errors once the user has typed. Yokai doesn't track a "touched" flag for you — manage it in the parent if you need that semantic.
+
+### Custom message rendering
+
+The default message renders as a dim `<Text color={errorColor}>`. Pass `renderError` for full control — icons, multi-line, layout:
+
+```tsx
+<TextInput
+  value={x}
+  onChange={setX}
+  validate={(v) => v.length === 0 ? 'required' : null}
+  renderError={(msg) => (
+    <Text color="red">⚠ {msg}</Text>
+  )}
+/>
+```
+
+For error rendering OUTSIDE the bordered box (above the input, in a sibling status bar, etc.), call `validate` yourself in the parent and render a `<Text>` separately — `validate` on `<TextInput>` is for the inside-the-box default, not a general validation framework.
+
+### Async validation
+
+Not built in. The signature is sync (`string | null`), not `Promise<string | null>`. Async validation needs debouncing, race-condition handling, and a "validating…" intermediate state — those decisions belong in your parent state, not in `<TextInput>`. Pattern:
+
+```tsx
+const [asyncError, setAsyncError] = useState<string | null>(null)
+useEffect(() => {
+  const id = setTimeout(async () => {
+    setAsyncError(await checkAvailability(value))
+  }, 300)
+  return () => clearTimeout(id)
+}, [value])
+
+<TextInput
+  value={value}
+  onChange={setValue}
+  validate={() => asyncError}
+/>
+```
 
 ## Scrolling
 

--- a/examples/text-input/text-input.tsx
+++ b/examples/text-input/text-input.tsx
@@ -3,7 +3,8 @@
  *
  *   pnpm demo:text-input
  *
- * Five text inputs covering every prop the soft-wrap work added:
+ * Six text inputs covering every prop the soft-wrap + validation work
+ * added:
  *
  *   - Name      single-line. wrap='none' default (h-scroll past width).
  *   - Bio       multiline. wrap='soft' default + hanging indent. Type
@@ -20,6 +21,11 @@
  *               surrounding text would otherwise break inside them.
  *               Hints are hardcoded against the initial value's char
  *               positions; a real app would derive them from a parser.
+ *   - Slug      single-line + validate. Border swaps red and an error
+ *               message renders below the input when the value is
+ *               outside the allowed kebab-case + length window.
+ *               Validation is render-only — the field still submits
+ *               on Enter (consumer is responsible for blocking).
  *   - Password  single-line, masked. wrap='none' default (h-scroll).
  *
  * Tab between fields. Editing: type, Backspace, Delete, Ctrl+W (word
@@ -57,6 +63,7 @@ function App(): React.ReactNode {
   const [bio, setBio] = useState(
     'Multiline soft-wrap. Long lines wrap onto continuation rows; ↓/↑ walk visual rows including wraps.\n  * Hanging indent: continuation rows of an indented line align under the first non-whitespace char.\nShift+arrow extends selection across rows as one continuous stripe.',
   )
+  const [slug, setSlug] = useState('')
   const [command, setCommand] = useState(
     '/sling --target=backend-engineer --chit=chit-abc-123 --link=https://github.com/foo/bar',
   )
@@ -144,6 +151,25 @@ function App(): React.ReactNode {
             />
           </Field>
 
+          <Field label="Slug (single-line + validate — kebab-case lowercase, 3-20 chars)">
+            <TextInput
+              value={slug}
+              onChange={setSlug}
+              placeholder="my-cool-slug"
+              validate={(v) => {
+                if (v.length === 0) return null // don't show error before user types
+                if (v.length < 3) return `${v.length}/3 characters minimum`
+                if (v.length > 20) return `${v.length}/20 characters maximum`
+                if (!/^[a-z0-9-]+$/.test(v)) return 'lowercase letters, digits, and hyphens only'
+                return null
+              }}
+              onSubmit={(v) => setSubmitted(`slug = ${JSON.stringify(v)}`)}
+              borderStyle="round"
+              paddingX={1}
+              width={50}
+            />
+          </Field>
+
           <Field label="Password (single-line, masked — h-scroll default)">
             <TextInput
               value={password}
@@ -170,6 +196,9 @@ function App(): React.ReactNode {
           </Text>
           <Text dim>
             mentions length: <Text bold>{mentions.length}</Text>
+          </Text>
+          <Text dim>
+            slug: <Text bold>{JSON.stringify(slug)}</Text>
           </Text>
           <Text dim>
             password length: <Text bold>{password.length}</Text>

--- a/packages/renderer/src/components/TextInput/TextInput.test.tsx
+++ b/packages/renderer/src/components/TextInput/TextInput.test.tsx
@@ -1,0 +1,143 @@
+/**
+ * TextInput component-level prop-surface tests.
+ *
+ * The deep behavior tests live in the focused suites:
+ *   - state.test.ts          — reducer mechanics
+ *   - wrap-math.test.ts      — pure wrap helpers
+ *   - TextInput.wrap.test.ts — reducer + wrap-math composed
+ *   - clipboard-action.test.ts — Ctrl+C / Ctrl+X helper
+ *   - caret-math.test.ts / scroll-math.test.ts — pure helpers
+ *
+ * This file pins the constructibility of the React surface — every
+ * documented prop combination must instantiate cleanly. Real focus
+ * transitions, validation rendering, and click-to-position need
+ * React's render loop to flow through; we exercise those via the
+ * `pnpm demo:text-input` demo, which now includes a validation
+ * field.
+ *
+ * Pattern matches Checkbox.test.tsx — call React.createElement with
+ * documented prop sets and assert no throw. Catches typos in default
+ * args, prop renames, and accidental required-prop additions
+ * surface-level fast.
+ */
+
+import React from 'react'
+import { describe, expect, it } from 'vitest'
+import TextInput from './TextInput.js'
+
+describe('TextInput — prop surface', () => {
+  it('constructs with no props (uncontrolled, single-line, default everything)', () => {
+    expect(() => React.createElement(TextInput, {})).not.toThrow()
+  })
+
+  it('constructs controlled with the minimum (value + onChange)', () => {
+    expect(() => React.createElement(TextInput, { value: '', onChange: () => {} })).not.toThrow()
+  })
+
+  it('constructs the documented soft-wrap prop quartet (wrap + indentedWrap + wordBoundaries + wrapHints)', () => {
+    expect(() =>
+      React.createElement(TextInput, {
+        defaultValue: 'hello world',
+        multiline: true,
+        wrap: 'soft',
+        indentedWrap: true,
+        wordBoundaries: 'identifier',
+        wrapHints: [{ start: 0, end: 5 }],
+      }),
+    ).not.toThrow()
+  })
+
+  it('constructs with all cursor / focus chrome props', () => {
+    expect(() =>
+      React.createElement(TextInput, {
+        autoFocus: true,
+        cursorStyle: 'bar',
+        cursorBlink: true,
+        cursorColor: '#00ff00',
+        borderStyle: 'round',
+        borderColor: 'gray',
+        borderColorFocus: 'green',
+        selectionColor: 'blue',
+      }),
+    ).not.toThrow()
+  })
+})
+
+describe('TextInput — validation prop surface', () => {
+  it('constructs with a validate function alone (defaults: errorColor=red, default text renderer)', () => {
+    expect(() =>
+      React.createElement(TextInput, {
+        defaultValue: 'a',
+        validate: (v: string) => (v.length < 3 ? 'too short' : null),
+      }),
+    ).not.toThrow()
+  })
+
+  it('constructs with validate + custom errorColor', () => {
+    expect(() =>
+      React.createElement(TextInput, {
+        defaultValue: '',
+        validate: (v: string) => (v ? null : 'required'),
+        errorColor: 'magenta',
+      }),
+    ).not.toThrow()
+  })
+
+  it('constructs with validate + custom renderError slot', () => {
+    expect(() =>
+      React.createElement(TextInput, {
+        defaultValue: '',
+        validate: () => 'oops',
+        renderError: (msg: string) => React.createElement('ink-text', null, `⚠ ${msg}`),
+      }),
+    ).not.toThrow()
+  })
+
+  it('constructs without validate (validate path is opt-in; absence renders nothing)', () => {
+    expect(() =>
+      React.createElement(TextInput, {
+        defaultValue: 'no validation',
+        errorColor: 'red', // setting errorColor without validate is a no-op but should not throw
+      }),
+    ).not.toThrow()
+  })
+
+  it('accepts validate that returns null (valid)', () => {
+    expect(() =>
+      React.createElement(TextInput, {
+        defaultValue: 'valid',
+        validate: () => null,
+      }),
+    ).not.toThrow()
+  })
+
+  it('accepts validate that returns empty string (treated as null per docs)', () => {
+    expect(() =>
+      React.createElement(TextInput, {
+        defaultValue: 'valid',
+        validate: () => '',
+      }),
+    ).not.toThrow()
+  })
+
+  it('accepts validate that always returns a message (immediately invalid)', () => {
+    expect(() =>
+      React.createElement(TextInput, {
+        defaultValue: '',
+        validate: () => 'always invalid',
+      }),
+    ).not.toThrow()
+  })
+
+  it('composes with multiline + soft-wrap + validation', () => {
+    expect(() =>
+      React.createElement(TextInput, {
+        defaultValue: 'a multiline value\nspanning a couple lines',
+        multiline: true,
+        wrap: 'soft',
+        validate: (v: string) => (v.length > 100 ? 'too long' : null),
+        errorColor: 'yellow',
+      }),
+    ).not.toThrow()
+  })
+})

--- a/packages/renderer/src/components/TextInput/TextInput.tsx
+++ b/packages/renderer/src/components/TextInput/TextInput.tsx
@@ -202,6 +202,44 @@ export type TextInputProps = Except<
   autoFocus?: boolean
   /** Maximum history entries kept for undo/redo. Default 100. */
   historyCap?: number
+  /**
+   * Validation function. Called with the current buffer on every
+   * render; return a non-empty string to mark the input invalid (the
+   * border swaps to `errorColor` and the message renders below the
+   * input content), or `null` / `''` for valid.
+   *
+   * Validation is purely a RENDER concern — `onSubmit` still fires when
+   * invalid. To block submit on error, check the validation result in
+   * your `onSubmit` handler before acting.
+   *
+   * Runs every render. If the check is expensive, debounce / memoize
+   * inside the function — the component doesn't try to be clever about
+   * skipping calls.
+   *
+   * Empty string is treated as `null` (valid) so consumers can't
+   * accidentally enable error styling with no message — be explicit
+   * and return null when valid.
+   */
+  validate?: (value: string) => string | null
+  /**
+   * Border + default message color when validation fails. Default
+   * `'red'`. Border-color precedence: error > focus > idle.
+   *
+   * Only honored when `validate` is set AND returns a non-empty
+   * message; otherwise the input renders with its normal focus / idle
+   * border color.
+   */
+  errorColor?: Color
+  /**
+   * Custom error-message renderer. When omitted, the message renders
+   * as a dim `<Text color={errorColor}>` below the input content
+   * (inside the bordered box).
+   *
+   * Use for icons (`⚠ ${message}`), multi-line messages, or any layout
+   * the default text node can't express. The function is called only
+   * when `validate` returned a non-null message.
+   */
+  renderError?: (message: string) => React.ReactNode
 }
 
 /**
@@ -253,6 +291,9 @@ export default function TextInput({
   cursorColor,
   autoFocus = false,
   historyCap,
+  validate,
+  errorColor = 'red',
+  renderError,
   ...boxProps
 }: PropsWithChildren<TextInputProps>): React.ReactNode {
   const isControlled = value !== undefined
@@ -767,8 +808,17 @@ export default function TextInput({
   // otherwise fall through to whatever the consumer provided as the
   // idle `borderColor` (or terminal default if undefined). The swap is
   // a no-op when no `borderStyle` is set — there's no border to color.
+  //
+  // Validation precedence: error wins over focus wins over idle. The
+  // non-empty-message coercion below makes empty-string returns from
+  // `validate` indistinguishable from null (valid) — see prop docstring.
   const { borderColor: idleBorderColor, ...restBoxProps } = boxProps
-  const renderedBorderColor = isFocused ? borderColorFocus : idleBorderColor
+  const validationMessage = validate ? validate(state.value) || null : null
+  const renderedBorderColor = validationMessage
+    ? errorColor
+    : isFocused
+      ? borderColorFocus
+      : idleBorderColor
 
   return (
     <Box
@@ -783,6 +833,14 @@ export default function TextInput({
       borderColor={renderedBorderColor}
     >
       {renderedLines}
+      {validationMessage &&
+        (renderError ? (
+          renderError(validationMessage)
+        ) : (
+          <Text color={errorColor} dim>
+            {validationMessage}
+          </Text>
+        ))}
     </Box>
   )
 }


### PR DESCRIPTION
## Summary

Roadmap item 1.4 — validation rendering. Three commits.

| # | Commit | What it adds |
|---|---|---|
| 1 | \`feat(TextInput): validate prop with default error rendering\` | The \`validate\` / \`errorColor\` / \`renderError\` props in TextInput.tsx + 12 prop-surface tests in new TextInput.test.tsx. |
| 2 | \`demo(text-input): showcase validate with a slug field\` | Slug field with kebab-case + length-window validation in the existing demo. |
| 3 | \`docs(TextInput): validation section + props\` | Props table additions + new "Validation" section in docs/components/text-input.md. |

## Design decisions (locked before coding)

- **Render-only contract.** \`onSubmit\` still fires when invalid. Component's responsibility is "show the error state"; submit-blocking lives in consumer's onSubmit handler. Keeps the prop scope narrow and lets consumers express their own submit semantics.
- **Sync \`(value: string) => string | null\` signature.** Async validation needs debouncing + race handling + intermediate state — all parent-state concerns. Docs include the recommended useState + useEffect async pattern.
- **Inside-the-box rendering.** Error message renders below the input content, inside the bordered box, via the existing \`flexDirection="column"\`. No wrapper, no prop-splitting; backwards compatible. For above-the-box / sibling rendering, consumers call \`validate\` themselves.
- **Border-color precedence: error > focus > idle.** Focused + invalid keeps the red border; the focus-color swap is suppressed so the validation state stays visible.
- **Empty-string return coerced to null.** \`''\` to mean "valid" is almost always a bug; explicit \`null\` is the documented contract. Coercion makes the bug invisible instead of producing styling-without-text.

## Test plan

- [ ] \`pnpm test\` — 667 passing (655 + 12 new)
- [ ] \`pnpm typecheck\` / \`pnpm lint\` / \`pnpm build\` — clean
- [ ] \`pnpm demo:text-input\` — the new Slug field shows the border swap + message on invalid input; submitting fires onSubmit (consumer would gate)