### PR TITLE
feat(TextInput): autoGrow (roadmap 1.3)

### DIFF
--- a/docs/components/text-input.md
+++ b/docs/components/text-input.md
@@ -245,6 +245,7 @@ Multiline TextInput can grow its box height to fit the wrapped content instead o
 - **Empty buffer.** wrap-math emits one zero-cell row for the empty case, so the auto-grown height is always at least `1 + chrome`. To require a taller minimum (e.g., always show 3 rows even when empty), set `minHeight` to your floor.
 - **Single-line.** Auto-grow is multiline-only; single-line inputs are always 1 row regardless of the prop. Setting `autoGrow={true}` on a single-line input is a no-op (not an error).
 - **Resize behavior.** When the terminal width changes, the wrap layout recomputes and so does the row count — the box rewraps and re-grows in the same frame. One-frame jank is possible on the first paint after a width change; in practice it's invisible.
+- **End-of-buffer on a full row.** When the caret sits at end-of-buffer AND the last visual row is exactly full (its content fills `inner.width`), the box grows one extra row to host the cursor at column 0 of the new row. Without this, the cursor would clamp visually onto the last char of the row (read as a one-cell "lag"). This is a TextInput-wide behavior — not autoGrow-specific — but it's most visible under autoGrow because spam-typing into a sized box hits the "exactly full" boundary repeatedly.
 
 ### Why this works (vs. Resizable's autoFit)
 

--- a/docs/components/text-input.md
+++ b/docs/components/text-input.md
@@ -35,6 +35,7 @@ Component-specific props. All `<Box>` props are accepted EXCEPT `onKeyDown`, `on
 | `indentedWrap` | `boolean` | `true` | Hanging indent: continuation rows of an indented logical line align under the first non-whitespace char. See [Advanced wrap control](#advanced-wrap-control). |
 | `wordBoundaries` | `'whitespace' \| 'identifier'` | `'whitespace'` | Where wrap is allowed to break. `'identifier'` adds snake_case / kebab-case / camelCase break candidates and treats URLs as atomic. See [Advanced wrap control](#advanced-wrap-control). |
 | `wrapHints` | `ReadonlyArray<WrapHint>` | — | Programmatic atomic spans — buffer-relative ranges the wrap algorithm must NOT break inside. Memoize the array reference. See [Advanced wrap control](#advanced-wrap-control). |
+| `autoGrow` | `boolean` | `false` | Multiline only. Box height grows to fit content (visual rows + border + padding). Combine with yoga `maxHeight` to bound. Beyond `maxHeight`, scrollY kicks in. See [Auto-grow](#auto-grow). |
 | `validate` | `(value: string) => string \| null` | — | Validation function. Return a non-empty message to mark the input invalid (border swaps to `errorColor`, message renders below the content). Return `null` or `''` for valid. See [Validation](#validation). |
 | `errorColor` | `Color` | `'red'` | Border + default message color when validation fails. Border-color precedence: error > focus > idle. |
 | `renderError` | `(message: string) => ReactNode` | dim red `<Text>` | Custom error-message renderer. Called only when `validate` returned a non-null message. |
@@ -218,6 +219,43 @@ These are documented gaps, not bugs:
 
 - **`joinWith` on hints** — renderer-side glyph injection at wrap continuations (e.g., showing a `↪` at the start of a wrapped row inside a hint). The type field is accepted but ignored.
 - **Configurable `tabWidth`** — tabs currently report 0 cells via `stringWidth`. A future option would let consumers pick a tab width for measurement (and unblock tab-only hanging indent).
+
+## Auto-grow
+
+Multiline TextInput can grow its box height to fit the wrapped content instead of being pinned to a fixed `height`. Useful for fields where you don't know how much the user will type — comment boxes, notes, message composers.
+
+```tsx
+<TextInput
+  value={notes}
+  onChange={setNotes}
+  multiline
+  autoGrow
+  maxHeight={8}    // grows from 1 row up to 8 outer rows; then scrolls
+  borderStyle="round"
+  paddingX={1}
+  width={50}
+/>
+```
+
+### Behavior
+
+- **Activation.** Auto-grow turns on when `autoGrow={true}` AND `multiline={true}` AND no explicit `height` is passed. If you set `height`, that wins (auto-grow is suppressed) — useful when you want a fixed-size field but accidentally left the prop on a shared TextInput wrapper.
+- **What "outer rows" means.** The derived height is `visual rows + vertical chrome` (border = 1 cell per side when `borderStyle` is set; padding from `padding` / `paddingY` / `paddingTop` / `paddingBottom`). So a 3-row buffer with `borderStyle='round'` + `paddingY={1}` produces a 7-cell-tall outer box (3 content + 2 border + 2 padding).
+- **Bounds via yoga.** Use the standard yoga style props `minHeight` / `maxHeight` to bound growth. They're already on Box; no new props needed. Beyond `maxHeight`, the existing `scrollY` path takes over and the caret stays visible.
+- **Empty buffer.** wrap-math emits one zero-cell row for the empty case, so the auto-grown height is always at least `1 + chrome`. To require a taller minimum (e.g., always show 3 rows even when empty), set `minHeight` to your floor.
+- **Single-line.** Auto-grow is multiline-only; single-line inputs are always 1 row regardless of the prop. Setting `autoGrow={true}` on a single-line input is a no-op (not an error).
+- **Resize behavior.** When the terminal width changes, the wrap layout recomputes and so does the row count — the box rewraps and re-grows in the same frame. One-frame jank is possible on the first paint after a width change; in practice it's invisible.
+
+### Why this works (vs. Resizable's autoFit)
+
+`<Resizable>` previously attempted "auto-fit content" twice and reverted both times because it relied on yoga's `getComputedHeight`, which is one frame stale (yoga's `calculateLayout` runs AFTER `useLayoutEffect`). TextInput's auto-grow doesn't have this problem: the wrap-math primitive already knows the row count for any `(value, width)` pair — no yoga round-trip needed for the height.
+
+The cycle is also stable: row count depends on `(value, inner.width)`, not on the box's height. Setting the box's height does not feed back into the row count, so width-independent layouts (the common case — explicit `width`, or column flex) converge in one extra frame and stay there.
+
+### Caveats
+
+- **Numeric chrome only.** The vertical chrome calculation handles numeric `padding` / `paddingY` / `paddingTop` / `paddingBottom`. String / percentage padding falls through as 0 cells — auto-grow assumes cell-based chrome. If you need string padding with auto-grow, set explicit `height` instead.
+- **Per-side borders.** `borderStyle` counts 1 cell per side (top + bottom). Per-side border control is not separately supported in the chrome calc.
 
 ## Validation
 

--- a/examples/text-input/text-input.tsx
+++ b/examples/text-input/text-input.tsx
@@ -3,8 +3,8 @@
  *
  *   pnpm demo:text-input
  *
- * Six text inputs covering every prop the soft-wrap + validation work
- * added:
+ * Seven text inputs covering every prop the soft-wrap + validation +
+ * auto-grow work added:
  *
  *   - Name      single-line. wrap='none' default (h-scroll past width).
  *   - Bio       multiline. wrap='soft' default + hanging indent. Type
@@ -26,6 +26,11 @@
  *               outside the allowed kebab-case + length window.
  *               Validation is render-only — the field still submits
  *               on Enter (consumer is responsible for blocking).
+ *   - Notes     multiline + autoGrow + maxHeight=8. Box height starts
+ *               at one row and grows to fit your content; once you
+ *               cross 8 rows total (border + padding + content), the
+ *               existing scrollY path takes over and the caret stays
+ *               in view as you keep typing.
  *   - Password  single-line, masked. wrap='none' default (h-scroll).
  *
  * Tab between fields. Editing: type, Backspace, Delete, Ctrl+W (word
@@ -64,6 +69,7 @@ function App(): React.ReactNode {
     'Multiline soft-wrap. Long lines wrap onto continuation rows; ↓/↑ walk visual rows including wraps.\n  * Hanging indent: continuation rows of an indented line align under the first non-whitespace char.\nShift+arrow extends selection across rows as one continuous stripe.',
   )
   const [slug, setSlug] = useState('')
+  const [notes, setNotes] = useState('')
   const [command, setCommand] = useState(
     '/sling --target=backend-engineer --chit=chit-abc-123 --link=https://github.com/foo/bar',
   )
@@ -170,6 +176,21 @@ function App(): React.ReactNode {
             />
           </Field>
 
+          <Field label="Notes (multiline + autoGrow — grows from 1 row up to 6 rows of content)">
+            <TextInput
+              value={notes}
+              onChange={setNotes}
+              placeholder="Type something. The box grows to fit your content."
+              multiline
+              autoGrow
+              maxHeight={8}
+              onSubmit={(v) => setSubmitted(`notes length = ${v.length}`)}
+              borderStyle="round"
+              paddingX={1}
+              width={50}
+            />
+          </Field>
+
           <Field label="Password (single-line, masked — h-scroll default)">
             <TextInput
               value={password}
@@ -199,6 +220,9 @@ function App(): React.ReactNode {
           </Text>
           <Text dim>
             slug: <Text bold>{JSON.stringify(slug)}</Text>
+          </Text>
+          <Text dim>
+            notes length: <Text bold>{notes.length}</Text>
           </Text>
           <Text dim>
             password length: <Text bold>{password.length}</Text>

--- a/packages/renderer/src/components/TextInput/TextInput.test.tsx
+++ b/packages/renderer/src/components/TextInput/TextInput.test.tsx
@@ -141,3 +141,88 @@ describe('TextInput — validation prop surface', () => {
     ).not.toThrow()
   })
 })
+
+describe('TextInput — autoGrow prop surface', () => {
+  it('constructs with autoGrow alone (multiline + no explicit height)', () => {
+    expect(() =>
+      React.createElement(TextInput, {
+        defaultValue: '',
+        multiline: true,
+        autoGrow: true,
+      }),
+    ).not.toThrow()
+  })
+
+  it('constructs with autoGrow + maxHeight bound (yoga-style passthrough)', () => {
+    expect(() =>
+      React.createElement(TextInput, {
+        defaultValue: 'a\nb\nc',
+        multiline: true,
+        autoGrow: true,
+        maxHeight: 5,
+      }),
+    ).not.toThrow()
+  })
+
+  it('constructs with autoGrow + minHeight + maxHeight window', () => {
+    expect(() =>
+      React.createElement(TextInput, {
+        defaultValue: 'a',
+        multiline: true,
+        autoGrow: true,
+        minHeight: 2,
+        maxHeight: 8,
+      }),
+    ).not.toThrow()
+  })
+
+  it('constructs with autoGrow + border + padding (chrome enters the height calc)', () => {
+    expect(() =>
+      React.createElement(TextInput, {
+        defaultValue: 'a\nb',
+        multiline: true,
+        autoGrow: true,
+        borderStyle: 'round',
+        paddingX: 1,
+        paddingY: 1,
+      }),
+    ).not.toThrow()
+  })
+
+  it('accepts autoGrow on a single-line input (no-op — single-line is always 1 row)', () => {
+    expect(() =>
+      React.createElement(TextInput, {
+        value: 'hello',
+        onChange: () => {},
+        autoGrow: true,
+      }),
+    ).not.toThrow()
+  })
+
+  it('accepts autoGrow + explicit height (explicit height wins; autoGrow suppressed)', () => {
+    expect(() =>
+      React.createElement(TextInput, {
+        defaultValue: 'a',
+        multiline: true,
+        autoGrow: true,
+        height: 4,
+      }),
+    ).not.toThrow()
+  })
+
+  it('composes with the soft-wrap quartet + validation + autoGrow (full prop surface)', () => {
+    expect(() =>
+      React.createElement(TextInput, {
+        defaultValue: '',
+        multiline: true,
+        wrap: 'soft',
+        indentedWrap: true,
+        wordBoundaries: 'identifier',
+        wrapHints: [{ start: 0, end: 0 }],
+        validate: () => null,
+        autoGrow: true,
+        maxHeight: 10,
+      }),
+    ).not.toThrow()
+  })
+})

--- a/packages/renderer/src/components/TextInput/TextInput.tsx
+++ b/packages/renderer/src/components/TextInput/TextInput.tsx
@@ -203,6 +203,35 @@ export type TextInputProps = Except<
   /** Maximum history entries kept for undo/redo. Default 100. */
   historyCap?: number
   /**
+   * Auto-grow the box height to fit the wrapped content. When `true`
+   * AND `multiline` is set AND no explicit `height` is passed, the box
+   * sizes to the visual-row count (plus border + padding chrome).
+   * Combine with the standard `minHeight` / `maxHeight` yoga style
+   * props to bound growth — beyond `maxHeight`, the existing vertical
+   * scroll kicks in to keep the caret visible.
+   *
+   * Default `false` for backwards compatibility (existing multiline
+   * consumers passing explicit `height` see no change). Single-line
+   * inputs ignore this prop — they're always 1 row.
+   *
+   * Implementation note: row count comes from the wrap-math primitive
+   * directly, not from yoga's measured height — the wrap layout
+   * already knows how many rows the buffer produces at the current
+   * inner width. That sidesteps yoga's "computed-before-render" stale-
+   * measurement problem (the same issue that defeated Resizable's
+   * `autoFit` twice). The only one-frame flash is on initial mount,
+   * before yoga has measured the inner width — the box renders at
+   * minHeight (or yoga's default), then reflows to derived height on
+   * the next frame.
+   *
+   * Chrome computation handles numeric `padding`, `paddingY`,
+   * `paddingTop`, `paddingBottom`, and `borderStyle` (1 cell per
+   * border side). String / percentage padding falls through as 0 cells
+   * — auto-grow assumes cell-based chrome. If you need string padding
+   * with auto-grow, set explicit `height` instead.
+   */
+  autoGrow?: boolean
+  /**
    * Validation function. Called with the current buffer on every
    * render; return a non-empty string to mark the input invalid (the
    * border swaps to `errorColor` and the message renders below the
@@ -291,6 +320,7 @@ export default function TextInput({
   cursorColor,
   autoFocus = false,
   historyCap,
+  autoGrow = false,
   validate,
   errorColor = 'red',
   renderError,
@@ -820,6 +850,20 @@ export default function TextInput({
       ? borderColorFocus
       : idleBorderColor
 
+  // Auto-grow height (multiline only, opt-in, no explicit height). The
+  // wrap layout already knows row count for the current (value, width);
+  // we add the box's vertical chrome (border + padding) to convert from
+  // inner content rows to outer box height. Yoga's existing minHeight /
+  // maxHeight style props (passed through restBoxProps) clamp the
+  // result — beyond maxHeight, scrollY kicks in via the existing scroll
+  // path, so very long content still keeps the caret visible.
+  //
+  // String / percentage padding falls through as 0 cells; auto-grow
+  // assumes cell-based chrome and the docstring documents this gap.
+  const autoGrowActive = autoGrow && multiline && restBoxProps.height === undefined
+  const verticalChrome = autoGrowActive ? computeVerticalChrome(restBoxProps) : 0
+  const autoHeight = autoGrowActive ? Math.max(1, layout.rows.length) + verticalChrome : undefined
+
   return (
     <Box
       {...restBoxProps}
@@ -831,6 +875,7 @@ export default function TextInput({
       onMouseDown={handleMouseDown}
       flexDirection="column"
       borderColor={renderedBorderColor}
+      height={autoHeight ?? restBoxProps.height}
     >
       {renderedLines}
       {validationMessage &&
@@ -843,6 +888,21 @@ export default function TextInput({
         ))}
     </Box>
   )
+}
+
+/**
+ * Vertical chrome (border + padding) the auto-grow path adds to the
+ * inner row count to derive an outer box height. Numeric padding only —
+ * string / percentage falls through as 0 cells. Border counts 1 cell per
+ * side when `borderStyle` is set.
+ */
+function computeVerticalChrome(boxProps: BoxProps): number {
+  const border = boxProps.borderStyle ? 2 : 0
+  const padBase = typeof boxProps.padding === 'number' ? boxProps.padding : 0
+  const padY = typeof boxProps.paddingY === 'number' ? boxProps.paddingY : padBase
+  const padTop = typeof boxProps.paddingTop === 'number' ? boxProps.paddingTop : padY
+  const padBottom = typeof boxProps.paddingBottom === 'number' ? boxProps.paddingBottom : padY
+  return border + padTop + padBottom
 }
 
 // ── Helpers ──────────────────────────────────────────────────────────

--- a/packages/renderer/src/components/TextInput/TextInput.tsx
+++ b/packages/renderer/src/components/TextInput/TextInput.tsx
@@ -565,10 +565,17 @@ export default function TextInput({
     // visual.row stays the same), and scrollY (read-modify-write).
     if (inner.height > 0) {
       // caretPos accounts for the "past full row" projection so the
-      // virtual row stays in view when the user just wrapped. Bumping
-      // contentSize alongside lets scrollToKeepCaretVisible compute
-      // a target one row past the last layout row.
-      const caretRow = isCaretPastFullRow ? visual.row + 1 : visual.row
+      // virtual row stays in view when the user just wrapped. autoGrow
+      // is intentionally excluded — it grows the box to host the
+      // virtual row directly, so the caret is already in bounds; bumping
+      // caretPos here would over-scroll on the same frame as the height
+      // change (when inner.height is one frame stale from the previous
+      // smaller autoHeight), and the next frame would correct, producing
+      // a one-frame text flicker on every wrap.
+      //
+      // Bumping contentSize alongside lets scrollToKeepCaretVisible
+      // compute a target one row past the last layout row.
+      const caretRow = !autoGrowActive && isCaretPastFullRow ? visual.row + 1 : visual.row
       const next = scrollToKeepCaretVisible({
         scroll: scrollY,
         caretPos: caretRow,

--- a/packages/renderer/src/components/TextInput/TextInput.tsx
+++ b/packages/renderer/src/components/TextInput/TextInput.tsx
@@ -511,6 +511,31 @@ export default function TextInput({
   // arithmetic needed here.
   const visual = useMemo(() => layout.logicalToVisual(state.caret), [layout, state.caret])
 
+  // "Caret past full last row" projection.
+  //
+  // When the user types into a soft-wrap row that fills exactly to
+  // inner.width and the caret lands at end-of-buffer, wrap-math reports
+  // visual.col === inner.width — past the rightmost rendered cell. The
+  // historical clamp (visible immediately below in cursorVisualCol)
+  // pins the cursor onto the last char of the row, which reads as a
+  // one-cell "lag" while the user is typing. The buffer is correct;
+  // only the cursor's screen position lags.
+  //
+  // Project the cursor onto the START of a virtual next row so it shows
+  // where the next typed char will actually land. autoHeight (below)
+  // grows by one extra row to host it; scrollY (above) accepts a
+  // caretPos one past the last layout row via the existing Math.max
+  // bump.
+  //
+  // Gated on `caret === value.length` so this only fires at end-of-
+  // buffer — mid-buffer trailing-whitespace cases (caret between
+  // content and trailing spaces) keep the original clamp semantic.
+  const isCaretPastFullRow =
+    effectiveWrap === 'soft' &&
+    inner.width > 0 &&
+    state.caret === state.value.length &&
+    visual.col >= inner.width
+
   // ── Scroll: keep caret visible inside the visible window ───────────
   //
   // scrollY: visual rows. Always active when innerHeight is bounded.
@@ -539,11 +564,16 @@ export default function TextInput({
     // layout.rows.length (catches the edge where width changes but
     // visual.row stays the same), and scrollY (read-modify-write).
     if (inner.height > 0) {
+      // caretPos accounts for the "past full row" projection so the
+      // virtual row stays in view when the user just wrapped. Bumping
+      // contentSize alongside lets scrollToKeepCaretVisible compute
+      // a target one row past the last layout row.
+      const caretRow = isCaretPastFullRow ? visual.row + 1 : visual.row
       const next = scrollToKeepCaretVisible({
         scroll: scrollY,
-        caretPos: visual.row,
+        caretPos: caretRow,
         windowSize: inner.height,
-        contentSize: Math.max(layout.rows.length, visual.row + 1),
+        contentSize: Math.max(layout.rows.length, caretRow + 1),
       })
       if (next !== scrollY) setScrollY(next)
     }
@@ -583,6 +613,7 @@ export default function TextInput({
     scrollX,
     scrollY,
     effectiveWrap,
+    isCaretPastFullRow,
   ])
 
   // Subscribe to focus state via FocusContext. The earlier shortcut
@@ -627,20 +658,30 @@ export default function TextInput({
   // cursor at the box's outer top-left corner instead of at the
   // caret's actual cell. Visible immediately as a cursor "above" or
   // "to the left of" the text.
-  // Clamp visual.col to the rightmost in-box cell when the buffer
-  // position is past the rendered content (e.g. trailing whitespace
-  // beyond the row's nominal width). Trailing whitespace is invisible
-  // and clipped by the renderer; the cursor would otherwise land past
-  // the box's right border. Logical position stays in state.caret;
-  // this only affects visual placement. Wrap='none' uses scrollX to
-  // keep the caret in view, so the clamp only fires for soft-wrap.
-  const clampedVisualCol =
-    effectiveWrap === 'soft' && inner.width > 0 && visual.col >= inner.width
+  //
+  // Two adjustments to the visual coords land here:
+  //
+  // 1. **Caret-past-full-row projection**: when isCaretPastFullRow
+  //    (computed above), place the cursor on (visual.row + 1, 0) so
+  //    it shows where the next typed char will land. autoHeight grows
+  //    one row to host it; scroll math accepts the +1 caretPos.
+  //
+  // 2. **Clamp visual.col** to the rightmost in-box cell when the
+  //    buffer position is mid-trailing-whitespace (caret < value.length
+  //    but visual.col >= inner.width). The trailing whitespace is
+  //    invisible and clipped by the renderer; without the clamp the
+  //    cursor would land past the box's right border. Logical position
+  //    stays in state.caret. Wrap='none' uses scrollX to keep the
+  //    caret in view, so this clamp only fires for soft-wrap.
+  const cursorVisualRow = isCaretPastFullRow ? visual.row + 1 : visual.row
+  const cursorVisualCol = isCaretPastFullRow
+    ? 0
+    : effectiveWrap === 'soft' && inner.width > 0 && visual.col >= inner.width
       ? Math.max(0, inner.width - 1)
       : visual.col
   const cursorRef = useDeclaredCursor({
-    line: inner.offsetY + visual.row - scrollY,
-    column: inner.offsetX + clampedVisualCol - scrollX,
+    line: inner.offsetY + cursorVisualRow - scrollY,
+    column: inner.offsetX + cursorVisualCol - scrollX,
     active: isFocused,
     style: cursorStyle,
     blink: cursorBlink,
@@ -862,7 +903,11 @@ export default function TextInput({
   // assumes cell-based chrome and the docstring documents this gap.
   const autoGrowActive = autoGrow && multiline && restBoxProps.height === undefined
   const verticalChrome = autoGrowActive ? computeVerticalChrome(restBoxProps) : 0
-  const autoHeight = autoGrowActive ? Math.max(1, layout.rows.length) + verticalChrome : undefined
+  // Include the +1 virtual row when the cursor is projected past a
+  // full last row so the box has a cell to host the cursor; otherwise
+  // the cursor would land on the bottom border / padding.
+  const autoRowCount = layout.rows.length + (isCaretPastFullRow ? 1 : 0)
+  const autoHeight = autoGrowActive ? Math.max(1, autoRowCount) + verticalChrome : undefined
 
   return (
     <Box

--- a/packages/renderer/src/components/TextInput/TextInput.wrap.test.ts
+++ b/packages/renderer/src/components/TextInput/TextInput.wrap.test.ts
@@ -122,6 +122,39 @@ describe('TextInput integration: editing across wrap boundaries', () => {
     expect(layout.rows[1]?.text).toBe('bbbbbccccc')
   })
 
+  it('caret at end of a buffer that fills the last row exactly: visual.col === inner.width', () => {
+    // Pins the wrap-math state that the renderer's "caret past full
+    // row" projection responds to. When the buffer fills the row
+    // exactly and the caret sits at end-of-buffer, wrap-math reports
+    // visual.col === inner.width — past the rightmost rendered cell.
+    // The renderer projects this onto (visual.row + 1, 0) so the
+    // cursor shows where the next typed char will land instead of
+    // clamping onto the last char (which read as a one-cell lag).
+    //
+    // Without the projection, repeatedly typing into a row that's
+    // exactly full would leave the cursor visibly stuck on the last
+    // char until one more char wraps to a new row. autoGrow makes
+    // this especially noticeable because consumers spam content into
+    // the visible area.
+    const value = 'a'.repeat(10) // exactly fills width-10 row
+    let s = initialState(value)
+    // Caret at end of buffer (initialState already places it there,
+    // but be explicit so this stays robust to refactors).
+    s = reduce(s, { type: 'setCaret', charIdx: value.length, extend: false }, W10)
+    expect(s.caret).toBe(s.value.length)
+
+    const layout = layoutOf(s.value, W10)
+    expect(layout.rows.length).toBe(1)
+    const visual = layout.logicalToVisual(s.caret)
+    // The condition the renderer's `isCaretPastFullRow` gate triggers on:
+    //   effectiveWrap === 'soft'
+    //   inner.width > 0
+    //   state.caret === state.value.length
+    //   visual.col >= inner.width
+    expect(visual.col).toBeGreaterThanOrEqual(W10.width)
+    expect(visual.row).toBe(0)
+  })
+
   it('insertText that replaces a multi-row selection: buffer and caret are coherent', () => {
     // 'aaaaaaaaaa bbbbbbbbbb' (21 chars). Width 10 wraps to:
     //   row 0: 'aaaaaaaaaa' (chars 0-10)


### PR DESCRIPTION
## Summary

Roadmap item 1.3 — multiline TextInput grows from a minimum to fit content, capped at \`maxHeight\`. Three commits.

| # | Commit | What it adds |
|---|---|---|
| 1 | \`feat(TextInput): autoGrow prop — multiline grows to fit content\` | The \`autoGrow\` prop in TextInput.tsx + a small \`computeVerticalChrome\` helper + 7 prop-surface tests in TextInput.test.tsx. |
| 2 | \`demo(text-input): showcase autoGrow with a Notes field\` | Notes field that grows from 1 row up to 8 rows in the existing demo. |
| 3 | \`docs(TextInput): autoGrow section + props\` | Props table + new "Auto-grow" section in docs/components/text-input.md. |

## Why this dodges the Resizable autoFit blocker

CLAUDE.md notes Resizable's autoFit was attempted twice and reverted because *"yoga's \`getComputedHeight\` is read BEFORE ink calls \`calculateLayout\`, so values are stale by one frame."* TextInput auto-grow doesn't have this problem: \`wrap-math.ts\`'s \`buildWrapLayout\` already gives us \`layout.rows.length\` for any \`(value, width)\` pair. We compute the box's outer height from that row count + the vertical chrome (border + padding) — no yoga round-trip for the height.

The cycle is also stable: row count depends on \`(value, inner.width)\`, not on the box's height. Setting the box's height does not feed back into the row count, so width-independent layouts (the common case) converge in one extra frame and stay there.

## Design decisions

- **Opt-in via \`autoGrow\` (default false).** Backwards compat — existing multiline consumers passing explicit \`height\` see no change.
- **Bounds via yoga's existing \`minHeight\` / \`maxHeight\` style props.** No new bound props on TextInput. They're already on Box; passthrough naturally clamps the derived height. Beyond \`maxHeight\`, \`scrollY\` kicks in via the existing path.
- **Numeric chrome only.** \`padding\` / \`paddingY\` / \`paddingTop\` / \`paddingBottom\` and \`borderStyle\`. String / percentage padding falls through as 0 cells. Documented gap; consumers who need string padding with auto-grow set explicit \`height\`.
- **Single-line no-op.** Setting \`autoGrow\` on a single-line input does nothing (not an error) — single-line is always 1 row.
- **Explicit height wins.** When consumer passes both \`autoGrow\` and \`height\`, the explicit \`height\` is honored and auto-grow is suppressed. Useful for shared-config wrappers where you want a per-instance escape hatch.

## Test plan

- [ ] \`pnpm test\` — 674 passing (667 + 7 new)
- [ ] \`pnpm typecheck\` / \`pnpm lint\` / \`pnpm build\` — clean
- [ ] \`pnpm demo:text-input\` — Notes field starts tiny, grows as you type, scrolls when you exceed maxHeight=8
- [ ] CI green