### PR TITLE
docs(Text): document nested-text + flex-parent truncation gotcha

### DIFF
--- a/docs/components/text.md
+++ b/docs/components/text.md
@@ -54,6 +54,52 @@ import { Text } from '@yokai-tui/renderer'
 - Embedded ANSI escape sequences in children are parsed and merged with the surrounding style stack at render time.
 - A `<Text>` itself acts as a flex row leaf; nested `<Text>` inherits color/style from ancestors unless overridden.
 
+## Known issue: nested-text + flex parent silent truncation
+
+A `<Text>` containing other `<Text>` nodes inside a flex-row parent can render with trailing content silently truncated, even when the parent has plenty of available space.
+
+Repro:
+
+```tsx
+<Box flexDirection="row" width="100%">
+  <Box flexGrow={1} />
+  <Box flexShrink={0}>
+    <Text wrap="truncate">
+      <Text bold>13:47:04</Text>
+      <Text>{' · '}</Text>
+      <Text>May 3</Text>
+    </Text>
+  </Box>
+</Box>
+```
+
+Expected: `13:47:04 · May 3` flush against the right edge.
+Actual: `13:47:04 · May…` (or `13:47:04 · May` with no signal) — even at full-screen widths where there's >100 cells of slack.
+
+Root cause hypothesis (not fully confirmed): yoga's flex basis pass calls the outer `<Text>`'s `measureFunc` with an AtMost width that's narrower than the squashed natural width, and the returned wrapped/truncated dimensions become the node's basis for distribution. The wrapper Box's `flexShrink={0}` reserves the basis-width but the text inside is sized to that already-truncated value. The render-time per-text clamp is a red herring — it doesn't engage in this case.
+
+Workarounds:
+
+1. **Explicit `width` on the wrapper Box**, sized to the maximum natural width of the contents. Bypasses flex-distribution entirely:
+   ```tsx
+   <Box flexShrink={0} width={16}>
+     <Text>{...nested...}</Text>
+   </Box>
+   ```
+
+2. **Split the nested `<Text>` into sibling Texts** in the parent flex row, with `gap` for the visual spacing the inline separator was carrying. Each fragment claims its own natural width independently:
+   ```tsx
+   <Box flexDirection="row" gap={1}>
+     <Text bold>13:47:04</Text>
+     <Text>·</Text>
+     <Text>May 3</Text>
+   </Box>
+   ```
+
+3. **`justifyContent="flex-end"` on the parent** (drop the spacer Box) — no flex-distribute math, no overflow path.
+
+Tracking issue: [yokai #51](https://github.com/re-marked/yokai/issues/51)
+
 ## Related
 - [Box](box.md), [Link](link.md), [RawAnsi](raw-ansi.md)
 - [Colors and styles](../concepts/colors.md)


### PR DESCRIPTION
Documents the known issue tracked in #51 — nested `<Text>` inside a flex-row parent silently truncates trailing content even with abundant slack.

Adds a "Known issue" section to `docs/components/text.md` with:
- Repro
- Root cause hypothesis
- Three documented workarounds (explicit width, split into siblings, justifyContent='flex-end')
- Link to tracking issue #51

No code change. Surface workarounds for consumers until the underlying flex-basis interaction is properly fixed in the yoga port.