### PR TITLE
fix(types): allow children on drag resize props

### DIFF
--- a/packages/renderer/src/components/Draggable.test.tsx
+++ b/packages/renderer/src/components/Draggable.test.tsx
@@ -29,10 +29,24 @@ import {
   type DragBounds,
   type DragInfo,
   type DragPos,
+  type DraggableProps,
   _resetDraggableZForTesting,
   computeDraggedPos,
   handleDragPress,
 } from './Draggable.js'
+
+// ── type contract ────────────────────────────────────────────────────
+
+describe('DraggableProps', () => {
+  it('accepts children in the exported prop type', () => {
+    const props = {
+      initialPos: { top: 0, left: 0 },
+      children: 'drag me',
+    } satisfies DraggableProps
+
+    expect(props.children).toBe('drag me')
+  })
+})
 
 // ── pure math ────────────────────────────────────────────────────────
 

--- a/packages/renderer/src/components/Draggable.tsx
+++ b/packages/renderer/src/components/Draggable.tsx
@@ -96,6 +96,8 @@ export type DraggableProps = Except<
    * fight every JSX call site. Cast on the receiving side.
    */
   dragData?: unknown
+  /** Children render inside the draggable Box; runtime already forwards them via boxProps. */
+  children?: React.ReactNode
 }
 
 /**

--- a/packages/renderer/src/components/Resizable.test.tsx
+++ b/packages/renderer/src/components/Resizable.test.tsx
@@ -14,12 +14,26 @@
 import { describe, expect, it, vi } from 'vitest'
 import { MouseDownEvent, MouseMoveEvent, MouseUpEvent } from '../events/mouse-event.js'
 import {
+  type ResizableProps,
   type ResizeHandleDirection,
   type ResizeInfo,
   type ResizeSize,
   computeResizedSize,
   handleResizePress,
 } from './Resizable.js'
+
+// ── type contract ────────────────────────────────────────────────────
+
+describe('ResizableProps', () => {
+  it('accepts children in the exported prop type', () => {
+    const props = {
+      initialSize: { width: 10, height: 5 },
+      children: 'resize me',
+    } satisfies ResizableProps
+
+    expect(props.children).toBe('resize me')
+  })
+})
 
 // ── pure math ────────────────────────────────────────────────────────
 

--- a/packages/renderer/src/components/Resizable.tsx
+++ b/packages/renderer/src/components/Resizable.tsx
@@ -1,5 +1,5 @@
 import type React from 'react'
-import { type PropsWithChildren, useCallback, useRef, useState } from 'react'
+import { useCallback, useRef, useState } from 'react'
 import type { Except } from 'type-fest'
 import type { MouseDownEvent, MouseMoveEvent, MouseUpEvent } from '../events/mouse-event.js'
 import type { Color } from '../styles.js'
@@ -65,6 +65,8 @@ export type ResizableProps = Except<BoxProps, 'width' | 'height' | 'onMouseDown'
   onResize?: (info: ResizeInfo) => void
   /** Fires once at release if the gesture became a resize. */
   onResizeEnd?: (info: ResizeInfo) => void
+  /** Children render as the resizable content; handles are layered alongside them. */
+  children?: React.ReactNode
 }
 
 /**
@@ -116,7 +118,7 @@ export default function Resizable({
   onResizeEnd,
   children,
   ...boxProps
-}: PropsWithChildren<ResizableProps>): React.ReactNode {
+}: ResizableProps): React.ReactNode {
   const [size, setSize] = useState<ResizeSize>(initialSize)
   const [hoveredHandle, setHoveredHandle] = useState<ResizeHandleDirection | null>(null)
 


### PR DESCRIPTION
## Summary
- add children to exported DraggableProps and ResizableProps
- keep runtime behavior unchanged; children were already forwarded/rendered
- add type-contract regression tests for both prop types

Closes #63.

## Verification
- pnpm test -- packages/renderer/src/components/Draggable.test.tsx packages/renderer/src/components/Resizable.test.tsx
- pnpm --filter @yokai-tui/renderer typecheck
- pnpm --filter @yokai-tui/renderer lint