### PR TITLE
fix(shared): recheck debug logging flag

### DIFF
--- a/docs/guides/debugging.md
+++ b/docs/guides/debugging.md
@@ -21,8 +21,9 @@ tail -f /tmp/yokai.log
 
 `@yokai-tui/shared` exposes `logForDebugging(message, { level })` which is gated on:
 
-- `DEBUG=1` or `DEBUG=true` in the environment
+- truthy `DEBUG` values in the environment (`1`, `true`, `yes`, `on`, trimmed and case-insensitive)
 - `--debug` in `process.argv`
+- `enableDebugLogging()` at runtime
 
 Source: `packages/shared/src/debug.ts`.
 
@@ -30,7 +31,7 @@ Source: `packages/shared/src/debug.ts`.
 DEBUG=1 node app.js 2> /tmp/yokai.log
 ```
 
-Output format: `2026-04-26T12:34:56.789Z [DEBUG] message`. Levels: `verbose`, `debug`, `info`, `warn`, `error`. `enableDebugLogging()` flips the flag at runtime.
+Output format: `2026-04-26T12:34:56.789Z [DEBUG] message`. Levels: `verbose`, `debug`, `info`, `warn`, `error`. `enableDebugLogging()` flips the runtime override on; `disableDebugLogging()` flips that override off. `DEBUG` is read when each log call runs, so long-running processes can enable logging after startup by setting `process.env.DEBUG` before calling `logForDebugging`.
 
 ## Frame capture
 

--- a/packages/shared/src/debug.test.ts
+++ b/packages/shared/src/debug.test.ts
@@ -1,0 +1,59 @@
+import { type MockInstance, afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { disableDebugLogging, enableDebugLogging, logForDebugging } from './debug'
+
+describe('logForDebugging', () => {
+  let originalDebug: string | undefined
+  let stderrWrite: MockInstance<typeof process.stderr.write>
+
+  beforeEach(() => {
+    originalDebug = process.env.DEBUG
+    Reflect.deleteProperty(process.env, 'DEBUG')
+    disableDebugLogging()
+    stderrWrite = vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+  })
+
+  afterEach(() => {
+    if (originalDebug === undefined) {
+      Reflect.deleteProperty(process.env, 'DEBUG')
+    } else {
+      process.env.DEBUG = originalDebug
+    }
+    disableDebugLogging()
+    stderrWrite.mockRestore()
+  })
+
+  it('does not write when debugging is disabled', () => {
+    logForDebugging('quiet')
+
+    expect(stderrWrite).not.toHaveBeenCalled()
+  })
+
+  it('re-reads DEBUG on each call', () => {
+    logForDebugging('before')
+    process.env.DEBUG = '1'
+    logForDebugging('after')
+
+    expect(stderrWrite).toHaveBeenCalledTimes(1)
+    expect(String(stderrWrite.mock.calls[0]?.[0])).toContain('[DEBUG] after')
+  })
+
+  it('accepts trimmed truthy DEBUG values', () => {
+    process.env.DEBUG = ' true '
+
+    logForDebugging('trimmed')
+
+    expect(stderrWrite).toHaveBeenCalledTimes(1)
+    expect(String(stderrWrite.mock.calls[0]?.[0])).toContain('[DEBUG] trimmed')
+  })
+
+  it('can be enabled and disabled at runtime', () => {
+    enableDebugLogging()
+    logForDebugging('enabled')
+
+    disableDebugLogging()
+    logForDebugging('disabled')
+
+    expect(stderrWrite).toHaveBeenCalledTimes(1)
+    expect(String(stderrWrite.mock.calls[0]?.[0])).toContain('[DEBUG] enabled')
+  })
+})

--- a/packages/shared/src/debug.ts
+++ b/packages/shared/src/debug.ts
@@ -2,20 +2,29 @@
  * Lightweight debug logging for @yokai packages.
  */
 
+import { isEnvTruthy } from './envUtils'
+
 export type DebugLogLevel = 'verbose' | 'debug' | 'info' | 'warn' | 'error'
 
-let debugEnabled =
-  process.env.DEBUG === '1' || process.env.DEBUG === 'true' || process.argv.includes('--debug')
+let debugEnabledOverride = false
+
+function isDebugEnabled(): boolean {
+  return debugEnabledOverride || isEnvTruthy(process.env.DEBUG) || process.argv.includes('--debug')
+}
 
 export function enableDebugLogging(): void {
-  debugEnabled = true
+  debugEnabledOverride = true
+}
+
+export function disableDebugLogging(): void {
+  debugEnabledOverride = false
 }
 
 export function logForDebugging(
   message: string,
   { level }: { level: DebugLogLevel } = { level: 'debug' },
 ): void {
-  if (!debugEnabled) return
+  if (!isDebugEnabled()) return
   const timestamp = new Date().toISOString()
   process.stderr.write(`${timestamp} [${level.toUpperCase()}] ${message.trim()}\n`)
 }

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,5 +1,10 @@
 // Debug & logging
-export { logForDebugging, enableDebugLogging, type DebugLogLevel } from './debug'
+export {
+  logForDebugging,
+  enableDebugLogging,
+  disableDebugLogging,
+  type DebugLogLevel,
+} from './debug'
 export { logError } from './log'
 
 // Environment


### PR DESCRIPTION
## Summary
- re-read DEBUG each time logForDebugging runs instead of snapshotting at module load
- support trimmed truthy DEBUG values through the shared env helper
- add disableDebugLogging() and export it for runtime/test cleanup
- document the runtime debug logging contract

Closes #70.

## Verification
- pnpm test -- packages/shared/src/debug.test.ts
- pnpm --filter @yokai-tui/shared typecheck
- pnpm --filter @yokai-tui/shared lint
- pnpm --filter @yokai-tui/shared build