### PR TITLE
fix(renderer): make ScrollBox defaults sane

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## Unreleased
+
+**Fixed**
+
+- `<ScrollBox>` now defaults to vertical content layout (`flexDirection: 'column'`) so ordinary lists/logs scroll without an explicit workaround.
+- `<ScrollBox>` `scrollTo` / `scrollBy` clamp to content bounds, preventing overscroll into blank space.
+
 Tagged releases of `@yokai-tui/renderer` and `@yokai-tui/shared`. The full commit graph is preserved on `main` — `git log vPREV..vNEXT` shows everything between any two tags.
 
 ## v0.6.0 — 2026-04-27

--- a/docs/components/scrollbox.md
+++ b/docs/components/scrollbox.md
@@ -9,7 +9,7 @@ import { ScrollBox, type ScrollBoxHandle } from '@yokai-tui/renderer'
 
 ## Props
 
-All `<Box>` props are accepted (see [Box](box.md)) except `textWrap`, `overflow`, `overflowX`, `overflowY` (forced to `scroll`).
+All `<Box>` props are accepted (see [Box](box.md)) except `textWrap`, `overflow`, `overflowX`, `overflowY` (forced to `scroll`). Unlike `<Box>`, ScrollBox defaults `flexDirection` to `'column'` because vertical lists/logs are the common scroll case; pass `flexDirection="row"` for horizontal layouts.
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
@@ -20,8 +20,8 @@ All `<Box>` props are accepted (see [Box](box.md)) except `textWrap`, `overflow`
 
 | Method | Signature | Notes |
 |--------|-----------|-------|
-| `scrollTo` | `(y: number) => void` | Set absolute `scrollTop`; clears stickiness |
-| `scrollBy` | `(dy: number) => void` | Accumulates into `pendingScrollDelta`; renderer drains at capped rate |
+| `scrollTo` | `(y: number) => void` | Set absolute `scrollTop`, clamped to content bounds; clears stickiness |
+| `scrollBy` | `(dy: number) => void` | Accumulates a clamped target into `pendingScrollDelta`; renderer drains at capped rate |
 | `scrollToBottom` | `() => void` | Set sticky; forces a React render |
 | `scrollToElement` | `(el: DOMElement, offset?: number) => void` | Defer-resolves the element's top during the next Yoga pass — race-free against streaming content |
 | `getScrollTop` | `() => number` | Current `scrollTop` |
@@ -40,14 +40,14 @@ All `<Box>` props are accepted (see [Box](box.md)) except `textWrap`, `overflow`
 ```tsx
 const ref = useRef<ScrollBoxHandle>(null)
 
-<ScrollBox ref={ref} height={10} flexDirection="column">
+<ScrollBox ref={ref} height={10}>
   {lines.map((l, i) => <Text key={i}>{l}</Text>)}
 </ScrollBox>
 ```
 
 ### Sticky log tail
 ```tsx
-<ScrollBox stickyScroll height={20} flexDirection="column">
+<ScrollBox stickyScroll height={20}>
   {logs.map((l) => <Text key={l.id}>{l.text}</Text>)}
 </ScrollBox>
 ```
@@ -63,6 +63,7 @@ boxRef.current?.scrollToElement(itemRef.current!, -1)
 ## Behavior
 
 - `scrollTo` / `scrollBy` mutate the DOM node directly and bypass React; updates are coalesced via microtask before scheduling a render.
+- Imperative scroll targets are clamped to `[0, scrollHeight - viewportHeight]`; callers do not need to duplicate bounds checks.
 - Only children intersecting `[scrollTop, scrollTop + height]` are emitted to the screen buffer (viewport culling).
 - Inner content uses `flexGrow: 1, flexShrink: 0, width: '100%'` so flexbox spacers can pin children to the bottom of the viewport.
 - `stickyScroll` is set as a DOM attribute so the first frame already knows it; ref callbacks fire too late.

--- a/docs/components/scrollbox.md
+++ b/docs/components/scrollbox.md
@@ -20,8 +20,8 @@ All `<Box>` props are accepted (see [Box](box.md)) except `textWrap`, `overflow`
 
 | Method | Signature | Notes |
 |--------|-----------|-------|
-| `scrollTo` | `(y: number) => void` | Set absolute `scrollTop`, clamped to content bounds; clears stickiness |
-| `scrollBy` | `(dy: number) => void` | Accumulates a clamped target into `pendingScrollDelta`; renderer drains at capped rate |
+| `scrollTo` | `(y: number) => void` | Set absolute scroll target; render clamps to content bounds with fresh layout; clears stickiness |
+| `scrollBy` | `(dy: number) => void` | Accumulates into `pendingScrollDelta`; renderer drains at capped rate |
 | `scrollToBottom` | `() => void` | Set sticky; forces a React render |
 | `scrollToElement` | `(el: DOMElement, offset?: number) => void` | Defer-resolves the element's top during the next Yoga pass — race-free against streaming content |
 | `getScrollTop` | `() => number` | Current `scrollTop` |
@@ -63,7 +63,7 @@ boxRef.current?.scrollToElement(itemRef.current!, -1)
 ## Behavior
 
 - `scrollTo` / `scrollBy` mutate the DOM node directly and bypass React; updates are coalesced via microtask before scheduling a render.
-- Imperative scroll targets are clamped to `[0, scrollHeight - viewportHeight]`; callers do not need to duplicate bounds checks.
+- Imperative scroll targets are preserved until render time, then clamped against fresh Yoga bounds (`[0, scrollHeight - viewportHeight]`); callers do not need to duplicate bounds checks.
 - Only children intersecting `[scrollTop, scrollTop + height]` are emitted to the screen buffer (viewport culling).
 - Inner content uses `flexGrow: 1, flexShrink: 0, width: '100%'` so flexbox spacers can pin children to the bottom of the viewport.
 - `stickyScroll` is set as a DOM attribute so the first frame already knows it; ref callbacks fire too late.

--- a/packages/renderer/src/components/ScrollBox.test.tsx
+++ b/packages/renderer/src/components/ScrollBox.test.tsx
@@ -1,0 +1,98 @@
+import { PassThrough } from 'node:stream'
+import { createRef } from 'react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { createNode } from '../dom.js'
+import { type Instance, renderSync } from '../root.js'
+import Box from './Box.js'
+import ScrollBox, {
+  clampScrollTop,
+  computeClampedPendingDelta,
+  type ScrollBoxHandle,
+} from './ScrollBox.js'
+import Text from './Text.js'
+
+function scrollNode(
+  opts: {
+    scrollTop?: number
+    pendingScrollDelta?: number
+    scrollHeight?: number
+    scrollViewportHeight?: number
+  } = {},
+) {
+  const node = createNode('ink-box')
+  node.scrollTop = opts.scrollTop
+  node.pendingScrollDelta = opts.pendingScrollDelta
+  node.scrollHeight = opts.scrollHeight
+  node.scrollViewportHeight = opts.scrollViewportHeight
+  return node
+}
+
+function fakeStdout(columns = 20, rows = 10): NodeJS.WriteStream {
+  const stdout = new PassThrough() as unknown as NodeJS.WriteStream
+  stdout.columns = columns
+  stdout.rows = rows
+  stdout.isTTY = false
+  return stdout
+}
+
+describe('ScrollBox clamp helpers', () => {
+  it('clamps scrollTo targets to the legal scroll range', () => {
+    const node = scrollNode({ scrollHeight: 10, scrollViewportHeight: 3 })
+
+    expect(clampScrollTop(node, -12)).toBe(0)
+    expect(clampScrollTop(node, 4)).toBe(4)
+    expect(clampScrollTop(node, 99)).toBe(7)
+  })
+
+  it('clamps scrollBy pending deltas against the final target', () => {
+    const node = scrollNode({ scrollTop: 4, scrollHeight: 10, scrollViewportHeight: 3 })
+
+    expect(computeClampedPendingDelta(node, 99)).toBe(3)
+  })
+
+  it('includes existing pending delta before clamping a new scrollBy', () => {
+    const node = scrollNode({
+      scrollTop: 2,
+      pendingScrollDelta: 3,
+      scrollHeight: 10,
+      scrollViewportHeight: 3,
+    })
+
+    expect(computeClampedPendingDelta(node, 99)).toBe(5)
+  })
+
+  it('clears pending delta when the clamped target is the current position', () => {
+    const node = scrollNode({ scrollTop: 7, scrollHeight: 10, scrollViewportHeight: 3 })
+
+    expect(computeClampedPendingDelta(node, 1)).toBeUndefined()
+  })
+})
+
+describe('ScrollBox rendering defaults', () => {
+  const instances: Instance[] = []
+
+  afterEach(() => {
+    for (const instance of instances.splice(0)) {
+      instance.unmount()
+      instance.cleanup()
+    }
+  })
+
+  it('stacks children vertically by default so content can exceed the viewport height', () => {
+    const ref = createRef<ScrollBoxHandle>()
+    const instance = renderSync(
+      <Box width={8} height={2}>
+        <ScrollBox ref={ref} width={8} height={2}>
+          <Text>A</Text>
+          <Text>B</Text>
+          <Text>C</Text>
+        </ScrollBox>
+      </Box>,
+      { stdout: fakeStdout(8, 4), patchConsole: false, exitOnCtrlC: false },
+    )
+    instances.push(instance)
+
+    expect(ref.current?.getViewportHeight()).toBe(2)
+    expect(ref.current?.getScrollHeight()).toBe(3)
+  })
+})

--- a/packages/renderer/src/components/ScrollBox.test.tsx
+++ b/packages/renderer/src/components/ScrollBox.test.tsx
@@ -5,8 +5,8 @@ import { createNode } from '../dom.js'
 import { type Instance, renderSync } from '../root.js'
 import Box from './Box.js'
 import ScrollBox, {
-  clampScrollTop,
-  computeClampedPendingDelta,
+  computePendingScrollDelta,
+  normalizeScrollTarget,
   type ScrollBoxHandle,
 } from './ScrollBox.js'
 import Text from './Text.js'
@@ -36,21 +36,23 @@ function fakeStdout(columns = 20, rows = 10): NodeJS.WriteStream {
 }
 
 describe('ScrollBox clamp helpers', () => {
-  it('clamps scrollTo targets to the legal scroll range', () => {
-    const node = scrollNode({ scrollHeight: 10, scrollViewportHeight: 3 })
-
-    expect(clampScrollTop(node, -12)).toBe(0)
-    expect(clampScrollTop(node, 4)).toBe(4)
-    expect(clampScrollTop(node, 99)).toBe(7)
+  it('normalizes negative and non-finite scrollTo targets', () => {
+    expect(normalizeScrollTarget(-12)).toBe(0)
+    expect(normalizeScrollTarget(Number.NaN)).toBe(0)
+    expect(normalizeScrollTarget(4.8)).toBe(4)
   })
 
-  it('clamps scrollBy pending deltas against the final target', () => {
+  it('preserves requested scrollTo targets above cached layout bounds', () => {
+    expect(normalizeScrollTarget(99)).toBe(99)
+  })
+
+  it('preserves requested scrollBy deltas above cached layout bounds', () => {
     const node = scrollNode({ scrollTop: 4, scrollHeight: 10, scrollViewportHeight: 3 })
 
-    expect(computeClampedPendingDelta(node, 99)).toBe(3)
+    expect(computePendingScrollDelta(node, 99)).toBe(99)
   })
 
-  it('includes existing pending delta before clamping a new scrollBy', () => {
+  it('includes existing pending delta before computing a new scrollBy target', () => {
     const node = scrollNode({
       scrollTop: 2,
       pendingScrollDelta: 3,
@@ -58,13 +60,13 @@ describe('ScrollBox clamp helpers', () => {
       scrollViewportHeight: 3,
     })
 
-    expect(computeClampedPendingDelta(node, 99)).toBe(5)
+    expect(computePendingScrollDelta(node, 99)).toBe(102)
   })
 
-  it('clears pending delta when the clamped target is the current position', () => {
-    const node = scrollNode({ scrollTop: 7, scrollHeight: 10, scrollViewportHeight: 3 })
+  it('clears pending delta when the normalized target is the current position', () => {
+    const node = scrollNode({ scrollTop: 0 })
 
-    expect(computeClampedPendingDelta(node, 1)).toBeUndefined()
+    expect(computePendingScrollDelta(node, -1)).toBeUndefined()
   })
 })
 

--- a/packages/renderer/src/components/ScrollBox.tsx
+++ b/packages/renderer/src/components/ScrollBox.tsx
@@ -68,6 +68,26 @@ export type ScrollBoxProps = Except<Styles, 'textWrap' | 'overflow' | 'overflowX
   stickyScroll?: boolean
 }
 
+export function getScrollMax(el: DOMElement): number {
+  return Math.max(0, (el.scrollHeight ?? 0) - (el.scrollViewportHeight ?? 0))
+}
+
+export function clampScrollTop(el: DOMElement, y: number): number {
+  const target = Math.floor(y)
+  if (!Number.isFinite(target)) return 0
+  return Math.max(0, Math.min(getScrollMax(el), target))
+}
+
+export function computeClampedPendingDelta(el: DOMElement, dy: number): number | undefined {
+  const delta = Math.floor(dy)
+  if (!Number.isFinite(delta)) return undefined
+
+  const current = el.scrollTop ?? 0
+  const target = clampScrollTop(el, current + (el.pendingScrollDelta ?? 0) + delta)
+  const pending = target - current
+  return pending === 0 ? undefined : pending
+}
+
 /**
  * A Box with `overflow: scroll` and an imperative scroll API.
  *
@@ -125,7 +145,7 @@ function ScrollBox({
         el.stickyScroll = false
         el.pendingScrollDelta = undefined
         el.scrollAnchor = undefined
-        el.scrollTop = Math.max(0, Math.floor(y))
+        el.scrollTop = clampScrollTop(el, y)
         scrollMutated(el)
       },
       scrollToElement(el: DOMElement, offset = 0) {
@@ -148,7 +168,7 @@ function ScrollBox({
         // Accumulate in pendingScrollDelta; renderer drains it at a capped
         // rate so fast flicks show intermediate frames. Pure accumulator:
         // scroll-up followed by scroll-down naturally cancels.
-        el.pendingScrollDelta = (el.pendingScrollDelta ?? 0) + Math.floor(dy)
+        el.pendingScrollDelta = computeClampedPendingDelta(el, dy)
         scrollMutated(el)
       },
       scrollToBottom() {
@@ -224,7 +244,7 @@ function ScrollBox({
       }}
       style={{
         flexWrap: 'nowrap',
-        flexDirection: style.flexDirection ?? 'row',
+        flexDirection: style.flexDirection ?? 'column',
         flexGrow: style.flexGrow ?? 0,
         flexShrink: style.flexShrink ?? 1,
         ...style,

--- a/packages/renderer/src/components/ScrollBox.tsx
+++ b/packages/renderer/src/components/ScrollBox.tsx
@@ -68,22 +68,18 @@ export type ScrollBoxProps = Except<Styles, 'textWrap' | 'overflow' | 'overflowX
   stickyScroll?: boolean
 }
 
-export function getScrollMax(el: DOMElement): number {
-  return Math.max(0, (el.scrollHeight ?? 0) - (el.scrollViewportHeight ?? 0))
-}
-
-export function clampScrollTop(el: DOMElement, y: number): number {
+export function normalizeScrollTarget(y: number): number {
   const target = Math.floor(y)
   if (!Number.isFinite(target)) return 0
-  return Math.max(0, Math.min(getScrollMax(el), target))
+  return Math.max(0, target)
 }
 
-export function computeClampedPendingDelta(el: DOMElement, dy: number): number | undefined {
+export function computePendingScrollDelta(el: DOMElement, dy: number): number | undefined {
   const delta = Math.floor(dy)
   if (!Number.isFinite(delta)) return undefined
 
   const current = el.scrollTop ?? 0
-  const target = clampScrollTop(el, current + (el.pendingScrollDelta ?? 0) + delta)
+  const target = normalizeScrollTarget(current + (el.pendingScrollDelta ?? 0) + delta)
   const pending = target - current
   return pending === 0 ? undefined : pending
 }
@@ -145,7 +141,7 @@ function ScrollBox({
         el.stickyScroll = false
         el.pendingScrollDelta = undefined
         el.scrollAnchor = undefined
-        el.scrollTop = clampScrollTop(el, y)
+        el.scrollTop = normalizeScrollTarget(y)
         scrollMutated(el)
       },
       scrollToElement(el: DOMElement, offset = 0) {
@@ -168,7 +164,7 @@ function ScrollBox({
         // Accumulate in pendingScrollDelta; renderer drains it at a capped
         // rate so fast flicks show intermediate frames. Pure accumulator:
         // scroll-up followed by scroll-down naturally cancels.
-        el.pendingScrollDelta = computeClampedPendingDelta(el, dy)
+        el.pendingScrollDelta = computePendingScrollDelta(el, dy)
         scrollMutated(el)
       },
       scrollToBottom() {


### PR DESCRIPTION
## Summary
- Default `<ScrollBox>` layout to `flexDirection: 'column'` so normal vertical lists/logs produce scrollable content without a workaround.
- Clamp `scrollTo` and `scrollBy` targets to `[0, scrollHeight - viewportHeight]` while preserving the existing pending-delta drain path for smooth wheel scrolling.
- Add ScrollBox regression tests and update ScrollBox docs/changelog notes.

Closes #54.
Closes #74.

## Verification
- `pnpm test -- packages/renderer/src/components/ScrollBox.test.tsx`
- `pnpm --filter @yokai-tui/renderer typecheck`
- `pnpm --filter @yokai-tui/renderer lint`
- `pnpm --filter @yokai-tui/renderer build`
- `git diff --check`