### PR TITLE
fix(renderer): auto-bind ScrollBox wheel input

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,6 +6,7 @@
 
 - `<ScrollBox>` now defaults to vertical content layout (`flexDirection: 'column'`) so ordinary lists/logs scroll without an explicit workaround.
 - `<ScrollBox>` `scrollTo` / `scrollBy` clamp to content bounds, preventing overscroll into blank space.
+- `<ScrollBox>` now auto-scrolls on mouse wheel when the cursor is over the box, with `wheelStep` and `disableWheel` props for tuning/opt-out.
 
 Tagged releases of `@yokai-tui/renderer` and `@yokai-tui/shared`. The full commit graph is preserved on `main` — `git log vPREV..vNEXT` shows everything between any two tags.
 

--- a/docs/components/scrollbox.md
+++ b/docs/components/scrollbox.md
@@ -14,7 +14,9 @@ All `<Box>` props are accepted (see [Box](box.md)) except `textWrap`, `overflow`
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
 | `ref` | `Ref<ScrollBoxHandle>` | — | Imperative handle — see API below |
-| `stickyScroll` | `boolean` | `false` | Auto-pin to bottom when content grows; cleared by manual `scrollTo` / `scrollBy` |
+| `stickyScroll` | `boolean` | `false` | Auto-pin to bottom when content grows; cleared by `scrollTo` / `scrollBy` / built-in wheel scrolling |
+| `disableWheel` | `boolean` | `false` | Disable built-in wheel scrolling, useful when a consumer owns wheel input manually |
+| `wheelStep` | `number` | `3` | Rows to scroll per terminal wheel tick |
 
 ## ScrollBoxHandle
 
@@ -64,11 +66,12 @@ boxRef.current?.scrollToElement(itemRef.current!, -1)
 
 - `scrollTo` / `scrollBy` mutate the DOM node directly and bypass React; updates are coalesced via microtask before scheduling a render.
 - Imperative scroll targets are preserved until render time, then clamped against fresh Yoga bounds (`[0, scrollHeight - viewportHeight]`); callers do not need to duplicate bounds checks.
+- Mouse wheel events scroll the nearest ScrollBox under the cursor by `wheelStep` rows. Nested ScrollBoxes prefer the innermost ScrollBox; if it has `disableWheel`, the event falls through to an ancestor ScrollBox.
 - Only children intersecting `[scrollTop, scrollTop + height]` are emitted to the screen buffer (viewport culling).
 - Inner content uses `flexGrow: 1, flexShrink: 0, width: '100%'` so flexbox spacers can pin children to the bottom of the viewport.
 - `stickyScroll` is set as a DOM attribute so the first frame already knows it; ref callbacks fire too late.
 - `scrollToBottom` and explicit `scrollToElement` cancel any in-flight `pendingScrollDelta`.
-- Mouse-wheel events are dispatched as `ParsedKey` wheel events when inside `<AlternateScreen>` with mouse tracking; the consumer wires them to `scrollBy`.
+- Mouse-wheel events are still dispatched as `ParsedKey` wheel events for `useInput` compatibility. If you already wire `key.wheelUp` / `key.wheelDown` manually for a ScrollBox, set `disableWheel` to avoid double-scrolling.
 - `setClampBounds` lets a consumer pin the scroll range to a specific bound, useful when virtualising long lists where the natural max scroll lags React's async re-render.
 
 ## Related

--- a/docs/patterns/log-viewer.md
+++ b/docs/patterns/log-viewer.md
@@ -129,7 +129,7 @@ render(<App />)
 
 1. **`useInterval` produces fake lines at 250ms**: stand-in for whatever real source you'd attach (subprocess stdout, websocket, file tail). Lines are immutable and id-keyed so React diffs cheaply.
 2. **Bounded buffer**: the producer caps `lines` at 5000 entries by slicing the tail. Without this, a long-lived viewer grows the React tree unbounded; viewport culling makes it cheap to render but the tree itself still costs memory.
-3. **`<ScrollBox stickyScroll>` auto-follows**: while sticky, every new line pushes the viewport down so the latest entry stays visible. Manual `scrollBy` from the wheel detaches sticky automatically — the user scrolls up to inspect, the tail pauses on its own, scrolling back to the bottom re-pins.
+3. **`<ScrollBox stickyScroll>` auto-follows**: while sticky, every new line pushes the viewport down so the latest entry stays visible. A wheel scroll detaches sticky automatically — the user scrolls up to inspect, the tail pauses on its own, scrolling back to the bottom re-pins.
 4. **Pause / resume is imperative**: `togglePause` calls `scrollTo(getScrollTop())` to break stickiness without moving the view, and `scrollToBottom()` to re-engage it. The `stickyScroll={!paused}` prop reflects state so the prop and the imperative call agree.
 5. **Level color via lookup**: `LEVEL_COLOR` keeps the row branch-free; padding the level name to 5 chars keeps columns aligned without a fixed-width Box.
 6. **`useSearchHighlight().setQuery` inverts matches**: every visible occurrence of the current query is highlighted via SGR 7 on the next frame. Empty string clears. Effect cleanup clears on unmount so the highlight doesn't outlive the viewer.

--- a/examples/scrollbox-wheel/package.json
+++ b/examples/scrollbox-wheel/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@yokai-example/scrollbox-wheel",
+  "version": "0.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "start": "tsx scrollbox-wheel.tsx"
+  },
+  "dependencies": {
+    "@yokai-tui/renderer": "workspace:*",
+    "react": "^19.2.5"
+  },
+  "devDependencies": {
+    "tsx": "^4.21.0"
+  }
+}

--- a/examples/scrollbox-wheel/scrollbox-wheel.tsx
+++ b/examples/scrollbox-wheel/scrollbox-wheel.tsx
@@ -1,0 +1,172 @@
+/**
+ * ScrollBox wheel demo.
+ *
+ *   pnpm demo:scrollbox-wheel
+ *
+ * Move the mouse over each panel and use the wheel:
+ * - left panel scrolls with the default step
+ * - right panel scrolls faster via wheelStep={6}
+ * - nested panel handles wheel before its parent
+ * - disabled nested panel falls through to the outer ScrollBox
+ *
+ * Press q, Escape, or Ctrl+C to quit.
+ */
+
+import {
+  AlternateScreen,
+  Box,
+  ScrollBox,
+  type ScrollBoxHandle,
+  Text,
+  render,
+  useApp,
+  useInput,
+} from '@yokai-tui/renderer'
+import type React from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
+
+function useScrollTop(ref: React.RefObject<ScrollBoxHandle | null>): number {
+  const [top, setTop] = useState(0)
+
+  useEffect(() => {
+    const box = ref.current
+    if (!box) return
+
+    setTop(box.getScrollTop())
+    return box.subscribe(() => setTop(box.getScrollTop() + box.getPendingDelta()))
+  }, [ref])
+
+  return top
+}
+
+function Row({ index, tone }: { index: number; tone: 'cyan' | 'green' | 'yellow' }): React.ReactNode {
+  return (
+    <Box>
+      <Text color={tone}>{String(index).padStart(2, '0')}</Text>
+      <Text dim>  The quick brown yokai scrolls over the lazy terminal.</Text>
+    </Box>
+  )
+}
+
+function PlainRows({
+  count,
+  keyPrefix,
+  tone,
+}: {
+  count: number
+  keyPrefix: string
+  tone: 'cyan' | 'green' | 'yellow'
+}): React.ReactNode {
+  return Array.from({ length: count }, (_, i) => (
+    <Row key={`${keyPrefix}-${i}`} index={i + 1} tone={tone} />
+  ))
+}
+
+function Panel({
+  title,
+  hint,
+  top,
+  children,
+}: {
+  title: string
+  hint: string
+  top: number
+  children: React.ReactNode
+}): React.ReactNode {
+  return (
+    <Box flexDirection="column" width={48} height={18} borderStyle="single" borderColor="gray">
+      <Box justifyContent="space-between" paddingX={1}>
+        <Text bold>{title}</Text>
+        <Text dim>scrollTop {top}</Text>
+      </Box>
+      <Box paddingX={1}>
+        <Text dim>{hint}</Text>
+      </Box>
+      {children}
+    </Box>
+  )
+}
+
+function App(): React.ReactNode {
+  const { exit } = useApp()
+  useInput((input, key) => {
+    if (input === 'q' || key.escape || (key.ctrl && input === 'c')) exit()
+  })
+
+  const defaultRef = useRef<ScrollBoxHandle>(null)
+  const fastRef = useRef<ScrollBoxHandle>(null)
+  const outerRef = useRef<ScrollBoxHandle>(null)
+  const innerRef = useRef<ScrollBoxHandle>(null)
+  const disabledOuterRef = useRef<ScrollBoxHandle>(null)
+
+  const defaultTop = useScrollTop(defaultRef)
+  const fastTop = useScrollTop(fastRef)
+  const outerTop = useScrollTop(outerRef)
+  const innerTop = useScrollTop(innerRef)
+  const disabledOuterTop = useScrollTop(disabledOuterRef)
+
+  const rows = useMemo(() => PlainRows({ count: 40, keyPrefix: 'default', tone: 'cyan' }), [])
+  const fastRows = useMemo(() => PlainRows({ count: 40, keyPrefix: 'fast', tone: 'green' }), [])
+
+  return (
+    <AlternateScreen mouseTracking>
+      <Box flexDirection="column" width="100%" height="100%" padding={1}>
+        <Text bold>yokai ScrollBox wheel demo</Text>
+        <Text dim>
+          Hover a panel and use the mouse wheel. q / Escape exits. Existing useInput wheel events
+          still fire; ScrollBox just owns the default scroll behavior now.
+        </Text>
+
+        <Box flexDirection="row" gap={2} marginTop={1}>
+          <Panel title="default wheel" hint="wheelStep defaults to 3 rows" top={defaultTop}>
+            <ScrollBox ref={defaultRef} height={14} paddingX={1}>
+              {rows}
+            </ScrollBox>
+          </Panel>
+
+          <Panel title="fast wheel" hint="wheelStep={6}" top={fastTop}>
+            <ScrollBox ref={fastRef} height={14} paddingX={1} wheelStep={6}>
+              {fastRows}
+            </ScrollBox>
+          </Panel>
+        </Box>
+
+        <Box flexDirection="row" gap={2} marginTop={1}>
+          <Panel title="nested wins" hint={`outer ${outerTop} / inner ${innerTop}`} top={outerTop}>
+            <ScrollBox ref={outerRef} height={14} paddingX={1}>
+              <Text dim>Outer content above the nested ScrollBox.</Text>
+              {PlainRows({ count: 6, keyPrefix: 'nested-outer-before', tone: 'cyan' })}
+              <Box borderStyle="round" borderColor="green" marginY={1} paddingX={1}>
+                <ScrollBox ref={innerRef} height={6} wheelStep={1}>
+                  {PlainRows({ count: 20, keyPrefix: 'nested-inner', tone: 'green' })}
+                </ScrollBox>
+              </Box>
+              <Text dim>Outer content below the nested ScrollBox.</Text>
+              {PlainRows({ count: 18, keyPrefix: 'nested-outer-after', tone: 'cyan' })}
+            </ScrollBox>
+          </Panel>
+
+          <Panel
+            title="disabled inner"
+            hint="wheel over the yellow box; parent scrolls"
+            top={disabledOuterTop}
+          >
+            <ScrollBox ref={disabledOuterRef} height={14} paddingX={1}>
+              <Text dim>This inner ScrollBox has disableWheel.</Text>
+              {PlainRows({ count: 6, keyPrefix: 'disabled-outer-before', tone: 'cyan' })}
+              <Box borderStyle="round" borderColor="yellow" marginY={1} paddingX={1}>
+                <ScrollBox height={6} disableWheel>
+                  {PlainRows({ count: 20, keyPrefix: 'disabled-inner', tone: 'yellow' })}
+                </ScrollBox>
+              </Box>
+              <Text dim>Because inner opts out, wheel falls through upward.</Text>
+              {PlainRows({ count: 18, keyPrefix: 'disabled-outer-after', tone: 'cyan' })}
+            </ScrollBox>
+          </Panel>
+        </Box>
+      </Box>
+    </AlternateScreen>
+  )
+}
+
+render(<App />)

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "demo:focus-nav": "pnpm --filter @yokai-example/focus-nav start",
     "demo:text-input": "pnpm --filter @yokai-example/text-input start",
     "demo:cursor-styles": "pnpm --filter @yokai-example/cursor-styles start",
+    "demo:scrollbox-wheel": "pnpm --filter @yokai-example/scrollbox-wheel start",
     "demo:scratchpad": "pnpm --filter @yokai-example/scratchpad start"
   },
   "engines": {

--- a/packages/renderer/src/components/App.tsx
+++ b/packages/renderer/src/components/App.tsx
@@ -77,6 +77,10 @@ type Props = {
   // DOM elements. Called for mode-1003 motion events with no button held.
   // No-op outside fullscreen (Ink.dispatchHover gates on altScreenActive).
   readonly onHoverAt: (col: number, row: number) => void
+  // Apply default wheel behavior at (col, row). Wheel remains a ParsedKey
+  // for useInput compatibility, but ScrollBox's built-in wheel binding is
+  // spatial and follows the box under the cursor.
+  readonly onWheelAt: (col: number, row: number, direction: 'up' | 'down') => boolean
   // Look up the OSC 8 hyperlink at (col, row) synchronously at click
   // time. Returns the URL or undefined. The browser-open is deferred by
   // MULTI_CLICK_TIMEOUT_MS so double-click can cancel it.
@@ -699,6 +703,14 @@ function processKeysInBatch(
     // descendant preventDefault — they're a global subscription, not a
     // targeted handler. App-level shortcuts (Ctrl+C exit, Ctrl+Z
     // suspend) DO defer.
+    if ((item.name === 'wheelup' || item.name === 'wheeldown') && item.mouse) {
+      app.props.onWheelAt(
+        item.mouse.col - 1,
+        item.mouse.row - 1,
+        item.name === 'wheelup' ? 'up' : 'down',
+      )
+    }
+
     const inputEvent = new InputEvent(item)
     app.internal_eventEmitter.emit('input', inputEvent)
     const keyboardEvent = app.props.dispatchKeyboardEvent(item)

--- a/packages/renderer/src/components/ScrollBox.tsx
+++ b/packages/renderer/src/components/ScrollBox.tsx
@@ -63,9 +63,18 @@ export type ScrollBoxProps = Except<Styles, 'textWrap' | 'overflow' | 'overflowX
   ref?: Ref<ScrollBoxHandle>
   /**
    * When true, automatically pins scroll position to the bottom when content
-   * grows. Unset manually via scrollTo/scrollBy to break the stickiness.
+   * grows. Unset by scrollTo/scrollBy or built-in wheel scrolling.
    */
   stickyScroll?: boolean
+  /**
+   * Disable the built-in mouse-wheel binding. Use this when a consumer owns
+   * wheel input manually via useInput or wants a non-scrolling wheel gesture.
+   */
+  disableWheel?: boolean
+  /**
+   * Rows to scroll per terminal wheel tick.
+   */
+  wheelStep?: number
 }
 
 export function normalizeScrollTarget(y: number): number {
@@ -98,6 +107,8 @@ function ScrollBox({
   children,
   ref,
   stickyScroll,
+  disableWheel,
+  wheelStep = 3,
   ...style
 }: PropsWithChildren<ScrollBoxProps>): React.ReactNode {
   const domRef = useRef<DOMElement>(null)
@@ -112,8 +123,9 @@ function ScrollBox({
   const [, forceRender] = useState(0)
   const listenersRef = useRef(new Set<() => void>())
   const renderQueuedRef = useRef(false)
-  const notify = () => {
-    for (const l of listenersRef.current) l()
+  const notify = (el?: DOMElement) => {
+    const listeners = el?.scrollListeners ?? listenersRef.current
+    for (const l of listeners) l()
   }
   function scrollMutated(el: DOMElement): void {
     // Signal background intervals (IDE poll, LSP poll, GCS fetch, orphan
@@ -121,7 +133,7 @@ function ScrollBox({
     // contributed to 1402ms max frame gaps during scroll drain.
     markDirty(el)
     markCommitStart()
-    notify()
+    notify(el)
     if (renderQueuedRef.current) return
     renderQueuedRef.current = true
     queueMicrotask(() => {
@@ -236,7 +248,10 @@ function ScrollBox({
     <ink-box
       ref={(el) => {
         domRef.current = el
-        if (el) el.scrollTop ??= 0
+        if (el) {
+          el.scrollTop ??= 0
+          el.scrollListeners = listenersRef.current
+        }
       }}
       style={{
         flexWrap: 'nowrap',
@@ -252,6 +267,9 @@ function ScrollBox({
             stickyScroll: true,
           }
         : {})}
+      scrollBox
+      disableWheel={disableWheel}
+      scrollWheelStep={wheelStep}
     >
       <Box flexDirection="column" flexGrow={1} flexShrink={0} width="100%">
         {children}

--- a/packages/renderer/src/dom.ts
+++ b/packages/renderer/src/dom.ts
@@ -74,6 +74,8 @@ export type DOMElement = {
   scrollViewportHeight?: number
   scrollViewportTop?: number
   stickyScroll?: boolean
+  scrollListeners?: Set<() => void>
+  scrollRenderQueued?: boolean
   // Set by ScrollBox.scrollToElement; render-node-to-output reads
   // el.yogaNode.getComputedTop() (FRESH — same Yoga pass as scrollHeight)
   // and sets scrollTop = top + offset, then clears this. Unlike an

--- a/packages/renderer/src/events/mouse-event.test.ts
+++ b/packages/renderer/src/events/mouse-event.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { type DOMElement, appendChildNode, createNode } from '../dom.js'
-import { dispatchMouseDown } from '../hit-test.js'
+import { dispatchMouseDown, dispatchWheel } from '../hit-test.js'
 import { nodeCache } from '../node-cache.js'
 import { MouseDownEvent } from './mouse-event.js'
 
@@ -237,5 +237,157 @@ describe('dispatchMouseDown', () => {
       { who: 'child', localCol: 2, localRow: 1 },
       { who: 'root', localCol: 5, localRow: 3 },
     ])
+  })
+})
+
+describe('dispatchWheel', () => {
+  it('scrolls the nearest ScrollBox ancestor under the cursor', () => {
+    const root = createNode('ink-root')
+    setRect(root, 0, 0, 20, 10)
+    const outer = createNode('ink-box')
+    outer.attributes.scrollBox = true
+    outer.attributes.scrollWheelStep = 3
+    outer.scrollTop = 0
+    appendChildNode(root, outer)
+    setRect(outer, 0, 0, 20, 10)
+    const child = createNode('ink-box')
+    appendChildNode(outer, child)
+    setRect(child, 1, 1, 10, 4)
+
+    expect(dispatchWheel(root, 2, 2, 'down')).toBe(true)
+    expect(outer.pendingScrollDelta).toBe(3)
+    expect(outer.stickyScroll).toBe(false)
+  })
+
+  it('uses the innermost ScrollBox when ScrollBoxes are nested', () => {
+    const root = createNode('ink-root')
+    setRect(root, 0, 0, 20, 10)
+    const outer = createNode('ink-box')
+    outer.attributes.scrollBox = true
+    outer.attributes.scrollWheelStep = 3
+    outer.scrollTop = 0
+    appendChildNode(root, outer)
+    setRect(outer, 0, 0, 20, 10)
+    const inner = createNode('ink-box')
+    inner.attributes.scrollBox = true
+    inner.attributes.scrollWheelStep = 5
+    inner.scrollTop = 0
+    appendChildNode(outer, inner)
+    setRect(inner, 1, 1, 10, 4)
+
+    expect(dispatchWheel(root, 2, 2, 'down')).toBe(true)
+    expect(inner.pendingScrollDelta).toBe(5)
+    expect(outer.pendingScrollDelta).toBeUndefined()
+  })
+
+  it('falls through to an ancestor ScrollBox when the inner one disables wheel', () => {
+    const root = createNode('ink-root')
+    setRect(root, 0, 0, 20, 10)
+    const outer = createNode('ink-box')
+    outer.attributes.scrollBox = true
+    outer.attributes.scrollWheelStep = 3
+    outer.scrollTop = 0
+    appendChildNode(root, outer)
+    setRect(outer, 0, 0, 20, 10)
+    const inner = createNode('ink-box')
+    inner.attributes.scrollBox = true
+    inner.attributes.disableWheel = true
+    inner.attributes.scrollWheelStep = 5
+    inner.scrollTop = 0
+    appendChildNode(outer, inner)
+    setRect(inner, 1, 1, 10, 4)
+
+    expect(dispatchWheel(root, 2, 2, 'down')).toBe(true)
+    expect(inner.pendingScrollDelta).toBeUndefined()
+    expect(outer.pendingScrollDelta).toBe(3)
+  })
+
+  it('does not scroll when no ScrollBox ancestor is under the cursor', () => {
+    const root = createNode('ink-root')
+    setRect(root, 0, 0, 20, 10)
+    const child = createNode('ink-box')
+    appendChildNode(root, child)
+    setRect(child, 1, 1, 10, 4)
+
+    expect(dispatchWheel(root, 2, 2, 'down')).toBe(false)
+  })
+
+  it('normalizes wheel-up at the top to no pending delta', () => {
+    const root = createNode('ink-root')
+    setRect(root, 0, 0, 20, 10)
+    const box = createNode('ink-box')
+    box.attributes.scrollBox = true
+    box.attributes.scrollWheelStep = 3
+    box.scrollTop = 0
+    appendChildNode(root, box)
+    setRect(box, 0, 0, 20, 10)
+
+    expect(dispatchWheel(root, 2, 2, 'up')).toBe(true)
+    expect(box.pendingScrollDelta).toBeUndefined()
+  })
+
+  it('falls back to the default wheel step when configured step is invalid', () => {
+    const root = createNode('ink-root')
+    setRect(root, 0, 0, 20, 10)
+    const box = createNode('ink-box')
+    box.attributes.scrollBox = true
+    box.attributes.scrollWheelStep = -1
+    box.scrollTop = 0
+    appendChildNode(root, box)
+    setRect(box, 0, 0, 20, 10)
+
+    expect(dispatchWheel(root, 2, 2, 'down')).toBe(true)
+    expect(box.pendingScrollDelta).toBe(3)
+  })
+
+  it('notifies ScrollBox subscribers when wheel changes pending scroll', () => {
+    const root = createNode('ink-root')
+    setRect(root, 0, 0, 20, 10)
+    const box = createNode('ink-box')
+    box.attributes.scrollBox = true
+    box.attributes.scrollWheelStep = 3
+    box.scrollTop = 0
+    const listener = vi.fn()
+    box.scrollListeners = new Set([listener])
+    appendChildNode(root, box)
+    setRect(box, 0, 0, 20, 10)
+
+    expect(dispatchWheel(root, 2, 2, 'down')).toBe(true)
+    expect(listener).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not notify subscribers for a wheel that leaves scroll state unchanged', () => {
+    const root = createNode('ink-root')
+    setRect(root, 0, 0, 20, 10)
+    const box = createNode('ink-box')
+    box.attributes.scrollBox = true
+    box.attributes.scrollWheelStep = 3
+    box.scrollTop = 0
+    const listener = vi.fn()
+    box.scrollListeners = new Set([listener])
+    appendChildNode(root, box)
+    setRect(box, 0, 0, 20, 10)
+
+    expect(dispatchWheel(root, 2, 2, 'up')).toBe(true)
+    expect(listener).not.toHaveBeenCalled()
+  })
+
+  it('notifies subscribers when wheel only breaks sticky state', () => {
+    const root = createNode('ink-root')
+    setRect(root, 0, 0, 20, 10)
+    const box = createNode('ink-box')
+    box.attributes.scrollBox = true
+    box.attributes.scrollWheelStep = 3
+    box.scrollTop = 0
+    box.stickyScroll = true
+    const listener = vi.fn()
+    box.scrollListeners = new Set([listener])
+    appendChildNode(root, box)
+    setRect(box, 0, 0, 20, 10)
+
+    expect(dispatchWheel(root, 2, 2, 'up')).toBe(true)
+    expect(box.pendingScrollDelta).toBeUndefined()
+    expect(box.stickyScroll).toBe(false)
+    expect(listener).toHaveBeenCalledTimes(1)
   })
 })

--- a/packages/renderer/src/hit-test.ts
+++ b/packages/renderer/src/hit-test.ts
@@ -1,8 +1,11 @@
-import type { DOMElement } from './dom'
+import { type DOMElement, markDirty, scheduleRenderFrom } from './dom'
 import { ClickEvent } from './events/click-event'
 import type { EventHandlerProps } from './events/event-handlers'
 import { type GestureHandlers, MouseDownEvent } from './events/mouse-event'
 import { nodeCache } from './node-cache'
+import { markCommitStart } from './reconciler'
+
+const DEFAULT_WHEEL_STEP = 3
 
 /** Effective z-index for hit-testing — mirrors the renderer's
  *  effectiveZ in render-node-to-output.ts. Only absolutes participate
@@ -193,6 +196,79 @@ export function dispatchMouseDown(
     target = target.parentNode
   }
   return event._capturedHandlers
+}
+
+function scrollBoxWheelStep(node: DOMElement): number {
+  const raw = node.attributes.scrollWheelStep
+  if (typeof raw !== 'number' || !Number.isFinite(raw) || raw <= 0) return DEFAULT_WHEEL_STEP
+  return Math.floor(raw)
+}
+
+function scrollBoxAcceptsWheel(node: DOMElement): boolean {
+  return node.attributes.scrollBox === true && node.attributes.disableWheel !== true
+}
+
+function scheduleScrollRender(node: DOMElement): void {
+  if (node.scrollRenderQueued) return
+  node.scrollRenderQueued = true
+  queueMicrotask(() => {
+    node.scrollRenderQueued = false
+    scheduleRenderFrom(node)
+  })
+}
+
+function notifyScrollListeners(node: DOMElement): void {
+  for (const listener of node.scrollListeners ?? []) listener()
+}
+
+function applyWheelScroll(node: DOMElement, dy: number): void {
+  const previousSticky = node.stickyScroll
+  const wasSticky = previousSticky ?? Boolean(node.attributes.stickyScroll)
+  const previousAnchor = node.scrollAnchor
+  node.stickyScroll = false
+  node.scrollAnchor = undefined
+  const current = node.scrollTop ?? 0
+  const delta = Math.floor(dy)
+  if (!Number.isFinite(delta)) return
+
+  const target = Math.max(0, current + (node.pendingScrollDelta ?? 0) + delta)
+  const pending = target - current
+  const previousPending = node.pendingScrollDelta
+  node.pendingScrollDelta = pending === 0 ? undefined : pending
+  const stateChanged =
+    node.pendingScrollDelta !== previousPending || wasSticky || previousAnchor !== undefined
+  if (!stateChanged) return
+
+  markDirty(node)
+  markCommitStart()
+  notifyScrollListeners(node)
+  scheduleScrollRender(node)
+}
+
+/**
+ * Hit-test a terminal wheel event and apply the default ScrollBox behavior.
+ *
+ * Wheel remains a ParsedKey for `useInput` backwards compatibility, but the
+ * default scroll target is spatial: the nearest ScrollBox viewport under the
+ * cursor should scroll, with nested ScrollBoxes naturally winning over
+ * ancestors. Returns true when a ScrollBox accepted the wheel.
+ */
+export function dispatchWheel(
+  root: DOMElement,
+  col: number,
+  row: number,
+  direction: 'up' | 'down',
+): boolean {
+  let target: DOMElement | undefined = hitTest(root, col, row) ?? undefined
+  while (target) {
+    if (scrollBoxAcceptsWheel(target)) {
+      const step = scrollBoxWheelStep(target)
+      applyWheelScroll(target, direction === 'up' ? -step : step)
+      return true
+    }
+    target = target.parentNode
+  }
+  return false
 }
 
 /**

--- a/packages/renderer/src/ink.tsx
+++ b/packages/renderer/src/ink.tsx
@@ -21,7 +21,7 @@ import type { GestureHandlers } from './events/mouse-event'
 import { PasteEvent } from './events/paste-event'
 import { FocusManager } from './focus'
 import { type Frame, type FrameEvent, emptyFrame } from './frame'
-import { dispatchClick, dispatchHover, dispatchMouseDown } from './hit-test'
+import { dispatchClick, dispatchHover, dispatchMouseDown, dispatchWheel } from './hit-test'
 import instances from './instances'
 import { noop, throttle } from './lodash-replacements'
 import { LogUpdate } from './log-update'
@@ -1552,6 +1552,10 @@ export default class Ink {
     if (!this.altScreenActive) return
     dispatchHover(this.rootNode, col, row, this.hoveredNodes)
   }
+  dispatchWheel(col: number, row: number, direction: 'up' | 'down'): boolean {
+    if (!this.altScreenActive) return false
+    return dispatchWheel(this.rootNode, col, row, direction)
+  }
   dispatchKeyboardEvent(parsedKey: ParsedKey): KeyboardEvent {
     const target = this.focusManager.activeElement ?? this.rootNode
     const event = new KeyboardEvent(parsedKey)
@@ -1835,6 +1839,7 @@ export default class Ink {
         onClickAt={this.dispatchClick}
         onMouseDownAt={this.dispatchMouseDown}
         onHoverAt={this.dispatchHover}
+        onWheelAt={this.dispatchWheel}
         getHyperlinkAt={this.getHyperlinkAt}
         onOpenHyperlink={this.openHyperlink}
         onMultiClick={this.handleMultiClick}

--- a/packages/renderer/src/parse-keypress.test.ts
+++ b/packages/renderer/src/parse-keypress.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { INITIAL_STATE, parseMultipleKeypresses } from './parse-keypress.js'
+
+describe('parseMultipleKeypresses mouse wheel', () => {
+  it('preserves SGR wheel coordinates on the ParsedKey', () => {
+    const [items] = parseMultipleKeypresses(INITIAL_STATE, '\x1b[<65;12;4M')
+
+    expect(items).toEqual([
+      expect.objectContaining({
+        kind: 'key',
+        name: 'wheeldown',
+        mouse: {
+          button: 65,
+          col: 12,
+          row: 4,
+        },
+      }),
+    ])
+  })
+
+  it('preserves X10 wheel coordinates on the ParsedKey', () => {
+    const [items] = parseMultipleKeypresses(INITIAL_STATE, '\x1b[M`%#')
+
+    expect(items).toEqual([
+      expect.objectContaining({
+        kind: 'key',
+        name: 'wheelup',
+        mouse: {
+          button: 64,
+          col: 5,
+          row: 3,
+        },
+      }),
+    ])
+  })
+})

--- a/packages/renderer/src/parse-keypress.ts
+++ b/packages/renderer/src/parse-keypress.ts
@@ -530,6 +530,11 @@ export type ParsedKey = {
   raw: string | undefined
   code?: string
   isPasted: boolean
+  mouse?: {
+    button: number
+    col: number
+    row: number
+  }
 }
 
 /** A terminal response sequence (DECRPM, DA1, OSC reply, etc.) parsed
@@ -657,8 +662,13 @@ function parseKeypress(s = ''): ParsedKey {
   // should still be recognized as wheelup/wheeldown.
   if ((match = SGR_MOUSE_RE.exec(s))) {
     const button = Number.parseInt(match[1]!, 10)
-    if ((button & 0x43) === 0x40) return createNavKey(s, 'wheelup', false)
-    if ((button & 0x43) === 0x41) return createNavKey(s, 'wheeldown', false)
+    const mouse = {
+      button,
+      col: Number.parseInt(match[2]!, 10),
+      row: Number.parseInt(match[3]!, 10),
+    }
+    if ((button & 0x43) === 0x40) return createNavKey(s, 'wheelup', false, mouse)
+    if ((button & 0x43) === 0x41) return createNavKey(s, 'wheeldown', false, mouse)
     // Shouldn't reach here (parseMouseEvent catches non-wheel) but be safe
     return createNavKey(s, 'mouse', false)
   }
@@ -670,8 +680,13 @@ function parseKeypress(s = ''): ParsedKey {
   // tracking in alt-screen and only need wheel for ScrollBox.
   if (s.length === 6 && s.startsWith('\x1b[M')) {
     const button = s.charCodeAt(3) - 32
-    if ((button & 0x43) === 0x40) return createNavKey(s, 'wheelup', false)
-    if ((button & 0x43) === 0x41) return createNavKey(s, 'wheeldown', false)
+    const mouse = {
+      button,
+      col: s.charCodeAt(4) - 32,
+      row: s.charCodeAt(5) - 32,
+    }
+    if ((button & 0x43) === 0x40) return createNavKey(s, 'wheelup', false, mouse)
+    if ((button & 0x43) === 0x41) return createNavKey(s, 'wheeldown', false, mouse)
     return createNavKey(s, 'mouse', false)
   }
 
@@ -759,7 +774,12 @@ function parseKeypress(s = ''): ParsedKey {
   return key
 }
 
-function createNavKey(s: string, name: string, ctrl: boolean): ParsedKey {
+function createNavKey(
+  s: string,
+  name: string,
+  ctrl: boolean,
+  mouse?: ParsedKey['mouse'],
+): ParsedKey {
   return {
     kind: 'key',
     name,
@@ -772,5 +792,6 @@ function createNavKey(s: string, name: string, ctrl: boolean): ParsedKey {
     sequence: s,
     raw: s,
     isPasted: false,
+    ...(mouse ? { mouse } : {}),
   }
 }

--- a/packages/renderer/src/render-node-to-output.test.ts
+++ b/packages/renderer/src/render-node-to-output.test.ts
@@ -14,7 +14,7 @@
 import { describe, expect, it } from 'vitest'
 import { type DOMElement, appendChildNode, createNode, createTextNode, setStyle } from './dom.js'
 import Output from './output.js'
-import renderNodeToOutput from './render-node-to-output.js'
+import renderNodeToOutput, { getScrollHint, resetScrollHint } from './render-node-to-output.js'
 import { CharPool, HyperlinkPool, type Screen, StylePool, cellAt, createScreen } from './screen.js'
 import applyStyles, { type Styles } from './styles.js'
 
@@ -56,6 +56,24 @@ function buildRow(width: number, height: number, ...children: DOMElement[]): DOM
   for (const child of children) appendChildNode(root, child)
   root.yogaNode!.calculateLayout(width, height)
   return root
+}
+
+function scrollBox(width: number, height: number, rows: string[]): DOMElement {
+  const box = el('ink-box', {
+    width,
+    height,
+    overflow: 'scroll',
+    flexDirection: 'column',
+  })
+  const content = el('ink-box', {
+    width: '100%',
+    flexDirection: 'column',
+    flexShrink: 0,
+  })
+  for (const row of rows) appendChildNode(content, txt(row))
+  appendChildNode(box, content)
+  box.scrollTop = 0
+  return box
 }
 
 /**
@@ -161,6 +179,38 @@ function renderNFrames(
 }
 
 // ── baseline: paint order before any z-index logic ───────────────────
+
+describe('renderNodeToOutput - ScrollBox scroll hints', () => {
+  it('does not use the full-row scroll fast path for side-by-side ScrollBoxes', () => {
+    const left = scrollBox(10, 4, ['L0', 'L1', 'L2', 'L3', 'L4', 'L5'])
+    const right = scrollBox(10, 4, ['R0', 'R1', 'R2', 'R3', 'R4', 'R5'])
+    const root = buildRow(20, 4, left, right)
+
+    const stylePool = new StylePool()
+    const charPool = new CharPool()
+    const hyperlinkPool = new HyperlinkPool()
+    const screenA = createScreen(20, 4, stylePool, charPool, hyperlinkPool)
+    const screenB = createScreen(20, 4, stylePool, charPool, hyperlinkPool)
+    const output = new Output({ width: 20, height: 4, stylePool, screen: screenA })
+
+    resetScrollHint()
+    renderNodeToOutput(root, output, { prevScreen: undefined })
+    const frameA = output.get()
+
+    right.scrollTop = 1
+    root.yogaNode!.calculateLayout(20, 4)
+    output.reset(20, 4, screenB)
+    resetScrollHint()
+    renderNodeToOutput(root, output, { prevScreen: frameA })
+    const frameB = output.get()
+
+    expect(getScrollHint()).toBeNull()
+    expect(rowText(frameB, 0).startsWith('L0')).toBe(true)
+    expect(rowText(frameB, 1).startsWith('L1')).toBe(true)
+    expect(rowText(frameB, 2).startsWith('L2')).toBe(true)
+    expect(rowText(frameB, 3).startsWith('L3')).toBe(true)
+  })
+})
 
 describe('renderNodeToOutput — paint order baseline (no zIndex)', () => {
   it('paints a single text node at its computed position', () => {

--- a/packages/renderer/src/render-node-to-output.ts
+++ b/packages/renderer/src/render-node-to-output.ts
@@ -858,11 +858,16 @@ function renderNodeToOutput(
             const delta = contentCached.y - contentY
             const regionTop = Math.floor(y + contentYoga.getComputedTop())
             const regionBottom = regionTop + innerHeight - 1
+            // DECSTBM and Output.shift both operate on full terminal rows.
+            // A partial-width ScrollBox next to siblings would row-shift
+            // its neighbors too, then rely on a fragile repair repaint.
+            const spansFullRow = Math.floor(x) <= 0 && Math.floor(x + width) >= output.width
             if (
               cached?.y === y &&
               cached.height === height &&
               innerHeight > 0 &&
-              Math.abs(delta) < innerHeight
+              Math.abs(delta) < innerHeight &&
+              spansFullRow
             ) {
               hint = { top: regionTop, bottom: regionBottom, delta }
               scrollHint = hint

--- a/packages/renderer/src/types/jsx.d.ts
+++ b/packages/renderer/src/types/jsx.d.ts
@@ -26,6 +26,9 @@ type InkBoxProps = {
   onPaste?: (event: PasteEvent) => void
   onPasteCapture?: (event: PasteEvent) => void
   stickyScroll?: boolean
+  scrollBox?: boolean
+  disableWheel?: boolean
+  scrollWheelStep?: number
   children?: ReactNode
 }
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -106,6 +106,19 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
 
+  examples/scrollbox-wheel:
+    dependencies:
+      '@yokai-tui/renderer':
+        specifier: workspace:*
+        version: link:../../packages/renderer
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+    devDependencies:
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+
   examples/text-input:
     dependencies:
       '@yokai-tui/renderer':


### PR DESCRIPTION
## Summary
- auto-scroll the nearest `<ScrollBox>` under the mouse wheel cursor using the existing hit-test/z-order model
- preserve legacy `useInput` wheel events by attaching parsed mouse coordinates instead of swallowing wheel keypresses
- add `wheelStep` and `disableWheel` props, subscriber notification for wheel scrolls, and docs for nested/double-scroll behavior

## Verification
- pnpm test -- packages/renderer/src/events/mouse-event.test.ts packages/renderer/src/parse-keypress.test.ts packages/renderer/src/components/ScrollBox.test.tsx
- pnpm --filter @yokai-tui/renderer typecheck
- pnpm --filter @yokai-tui/renderer lint
- pnpm --filter @yokai-tui/renderer build
- pnpm test
- git diff --check

Closes #62