### PR TITLE
fix(renderer): make gesture capture leaf-first

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@
 - `<ScrollBox>` now defaults to vertical content layout (`flexDirection: 'column'`) so ordinary lists/logs scroll without an explicit workaround.
 - `<ScrollBox>` `scrollTo` / `scrollBy` clamp to content bounds, preventing overscroll into blank space.
 - `<ScrollBox>` now auto-scrolls on mouse wheel when the cursor is over the box, with `wheelStep` and `disableWheel` props for tuning/opt-out.
+- `MouseDownEvent.captureGesture(...)` is now leaf-first: once a descendant captures a press, ancestors cannot overwrite that gesture.
 
 Tagged releases of `@yokai-tui/renderer` and `@yokai-tui/shared`. The full commit graph is preserved on `main` — `git log vPREV..vNEXT` shows everything between any two tags.
 

--- a/docs/components/box.md
+++ b/docs/components/box.md
@@ -75,7 +75,7 @@ Layout props (all Yoga flexbox properties: `width`, `height`, `flexDirection`, `
 - `onClick` and `onMouseDown` bubble; call `event.stopImmediatePropagation()` to halt.
 - `onMouseEnter` / `onMouseLeave` do not bubble — moving between children does not re-fire on the parent.
 - `zIndex` only applies to nodes with `position: 'absolute'`; it is silently ignored on in-flow children (a dev-mode warning fires). Stacking is flat per parent — siblings sort against each other, not against arbitrarily distant cousins.
-- Inside an `onMouseDown` handler, calling `event.captureGesture({ onMove, onUp })` claims subsequent motion and the release for that drag, suppressing selection extension.
+- Inside an `onMouseDown` handler, calling `event.captureGesture({ onMove, onUp })` claims subsequent motion and the release for that drag, suppressing selection extension. Capture is first-call-wins: a descendant that captures the press prevents ancestors from stealing it.
 - `overflowX` and `overflowY` fall back to `overflow` if unset, then to `'visible'`.
 
 ## Related

--- a/docs/reference/events.md
+++ b/docs/reference/events.md
@@ -55,11 +55,11 @@ Inherits from internal `MouseEvent` base.
 **Methods**:
 
 - `stopImmediatePropagation()`.
-- `captureGesture(handlers: GestureHandlers): void` — claim subsequent mouse-motion events and the eventual release for this drag. After capture, motion routes to `handlers.onMove` even when the cursor leaves the originally pressed element; release fires `handlers.onUp` and clears the capture. The normal release path (onClick, selection finish) is skipped for that release. Selection extension is suppressed for the gesture's lifetime. Calling multiple times within one dispatch overwrites — last call wins. Cannot be retargeted mid-flight.
+- `captureGesture(handlers: GestureHandlers): void` — claim subsequent mouse-motion events and the eventual release for this drag. After capture, motion routes to `handlers.onMove` even when the cursor leaves the originally pressed element; release fires `handlers.onUp` and clears the capture. The normal release path (onClick, selection finish) is skipped for that release. Selection extension is suppressed for the gesture's lifetime. Capture is first-call-wins within one dispatch: once a descendant claims the press, later calls are ignored and ancestors do not receive the remaining `onMouseDown` bubble.
 
 **Fires when**: mouse press, while mouse tracking is active.
 
-**Propagation**: bubbles from deepest hit node up via `parentNode`.
+**Propagation**: bubbles from deepest hit node up via `parentNode` until `stopImmediatePropagation()` is called or a handler captures the gesture.
 
 ## MouseMoveEvent
 

--- a/examples/gesture-capture/gesture-capture.tsx
+++ b/examples/gesture-capture/gesture-capture.tsx
@@ -1,0 +1,131 @@
+/**
+ * Gesture capture demo.
+ *
+ *   pnpm demo:gesture-capture
+ *
+ * The button inside the Draggable claims its press with captureGesture()
+ * but does NOT call stopImmediatePropagation(). With leaf-first capture,
+ * the parent Draggable cannot steal the gesture. Drag the panel from
+ * anywhere else to confirm parent drags still work.
+ *
+ * Press q, Escape, or Ctrl+C to quit.
+ */
+
+import {
+  AlternateScreen,
+  Box,
+  Draggable,
+  type MouseDownEvent,
+  Text,
+  render,
+  useApp,
+  useInput,
+} from '@yokai-tui/renderer'
+import type React from 'react'
+import { useCallback, useState } from 'react'
+
+const PANEL_WIDTH = 58
+const PANEL_HEIGHT = 13
+
+function ClaimButton({
+  onClaim,
+}: {
+  onClaim: () => void
+}): React.ReactNode {
+  const [pressed, setPressed] = useState(false)
+
+  const handleMouseDown = useCallback(
+    (event: MouseDownEvent) => {
+      setPressed(true)
+      event.captureGesture({
+        onUp: () => {
+          setPressed(false)
+          onClaim()
+        },
+      })
+    },
+    [onClaim],
+  )
+
+  return (
+    <Box
+      width={28}
+      height={3}
+      alignItems="center"
+      justifyContent="center"
+      borderStyle="round"
+      borderColor={pressed ? '#fbbf24' : '#38bdf8'}
+      backgroundColor={pressed ? '#451a03' : '#082f49'}
+      onMouseDown={handleMouseDown}
+    >
+      <Text bold color={pressed ? '#fde68a' : '#bae6fd'}>
+        claim press
+      </Text>
+    </Box>
+  )
+}
+
+function App(): React.ReactNode {
+  const { exit } = useApp()
+  useInput((input, key) => {
+    if (input === 'q' || key.escape || (key.ctrl && input === 'c')) exit()
+  })
+
+  const [claims, setClaims] = useState(0)
+  const [drags, setDrags] = useState(0)
+  const [last, setLast] = useState('Ready. Press the button, then drag the panel body.')
+
+  return (
+    <AlternateScreen mouseTracking>
+      <Box flexDirection="column" width="100%" height="100%" padding={1}>
+        <Text bold>yokai gesture capture demo</Text>
+        <Text dim>
+          The button captures without stopImmediatePropagation. q / Escape exits.
+        </Text>
+
+        <Draggable
+          initialPos={{ left: 6, top: 5 }}
+          width={PANEL_WIDTH}
+          height={PANEL_HEIGHT}
+          borderStyle="single"
+          borderColor="#64748b"
+          backgroundColor="#020617"
+          flexDirection="column"
+          paddingX={1}
+          paddingTop={1}
+          onDragStart={() => {
+            setDrags((count) => count + 1)
+            setLast('Parent Draggable started a drag.')
+          }}
+        >
+          <Text bold>Draggable parent</Text>
+          <Text dim>
+            Press the blue button: child capture should win, and the panel should not drag.
+          </Text>
+          <Text dim>Drag the empty panel body: parent Draggable should move.</Text>
+
+          <Box marginTop={1}>
+            <ClaimButton
+              onClaim={() => {
+                setClaims((count) => count + 1)
+                setLast('Child claimed press and received release.')
+              }}
+            />
+          </Box>
+
+          <Box flexDirection="column" marginTop={1}>
+            <Text>
+              child claims: <Text bold>{claims}</Text>
+            </Text>
+            <Text>
+              parent drags: <Text bold>{drags}</Text>
+            </Text>
+            <Text color="#a7f3d0">{last}</Text>
+          </Box>
+        </Draggable>
+      </Box>
+    </AlternateScreen>
+  )
+}
+
+render(<App />)

--- a/examples/gesture-capture/package.json
+++ b/examples/gesture-capture/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@yokai-example/gesture-capture",
+  "version": "0.0.0",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "start": "tsx gesture-capture.tsx"
+  },
+  "dependencies": {
+    "@yokai-tui/renderer": "workspace:*",
+    "react": "^19.2.5"
+  },
+  "devDependencies": {
+    "tsx": "^4.21.0"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "demo:focus-nav": "pnpm --filter @yokai-example/focus-nav start",
     "demo:text-input": "pnpm --filter @yokai-example/text-input start",
     "demo:cursor-styles": "pnpm --filter @yokai-example/cursor-styles start",
+    "demo:gesture-capture": "pnpm --filter @yokai-example/gesture-capture start",
     "demo:scrollbox-wheel": "pnpm --filter @yokai-example/scrollbox-wheel start",
     "demo:scratchpad": "pnpm --filter @yokai-example/scratchpad start"
   },

--- a/packages/renderer/src/components/Box.tsx
+++ b/packages/renderer/src/components/Box.tsx
@@ -53,8 +53,9 @@ export type Props = Except<Styles, 'textWrap'> & {
    * `event.captureGesture({ onMove, onUp })` to start a drag — the
    * renderer will route subsequent mouse-motion events to your `onMove`
    * handler (instead of extending the text selection) and the eventual
-   * release to `onUp`. Only works inside `<AlternateScreen>` where
-   * mouse tracking is enabled.
+   * release to `onUp`. Capture is first-call-wins: once a descendant
+   * captures the press, ancestors cannot overwrite it. Only works inside
+   * `<AlternateScreen>` where mouse tracking is enabled.
    */
   onMouseDown?: (event: MouseDownEvent) => void
   /**

--- a/packages/renderer/src/components/Draggable.test.tsx
+++ b/packages/renderer/src/components/Draggable.test.tsx
@@ -17,13 +17,14 @@
  */
 
 import { describe, expect, it, vi } from 'vitest'
-import { type DOMElement, createNode, setStyle } from '../dom.js'
+import { type DOMElement, appendChildNode, createNode, setStyle } from '../dom.js'
 import {
   _resetDragRegistryForTesting,
   registerDropTarget,
   unregisterDropTarget,
 } from '../drag-registry.js'
 import { MouseDownEvent, MouseMoveEvent, MouseUpEvent } from '../events/mouse-event.js'
+import { dispatchMouseDown } from '../hit-test.js'
 import { nodeCache } from '../node-cache.js'
 import {
   type DragBounds,
@@ -352,6 +353,31 @@ describe('handleDragPress', () => {
     // No gesture captured → no onUp to call. Sanity-check the contract.
     expect(e._capturedHandlers).toBeNull()
     expect(onDragEnd).not.toHaveBeenCalled()
+  })
+
+  it("does not steal a descendant's captured press", () => {
+    _resetDraggableZForTesting()
+    const root = createNode('ink-root')
+    nodeCache.set(root, { x: 0, y: 0, width: 20, height: 10, top: 0 })
+    const draggable = createNode('ink-box')
+    appendChildNode(root, draggable)
+    nodeCache.set(draggable, { x: 0, y: 0, width: 20, height: 10, top: 0 })
+    const child = createNode('ink-box')
+    appendChildNode(draggable, child)
+    nodeCache.set(child, { x: 1, y: 1, width: 8, height: 3, top: 1 })
+
+    const childMove = vi.fn()
+    const deps = makeDeps()
+    child._eventHandlers = {
+      onMouseDown: (e: MouseDownEvent) => e.captureGesture({ onMove: childMove }),
+    }
+    draggable._eventHandlers = {
+      onMouseDown: (e: MouseDownEvent) => handleDragPress(e, deps),
+    }
+
+    const captured = dispatchMouseDown(root, 2, 2, 0)
+    expect(captured?.onMove).toBe(childMove)
+    expect(deps.setPersistedZ).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/renderer/src/events/event-handlers.ts
+++ b/packages/renderer/src/events/event-handlers.ts
@@ -41,8 +41,9 @@ export type EventHandlerProps = {
    * `event.captureGesture({ onMove, onUp })` to claim subsequent
    * mouse-motion events and the eventual release for this drag — the
    * renderer will route motion events to your `onMove` handler instead
-   * of extending the text selection. See MouseDownEvent.captureGesture
-   * docs for the full lifecycle.
+   * of extending the text selection. Capture is first-call-wins: once a
+   * descendant captures the press, ancestors cannot overwrite it. See
+   * MouseDownEvent.captureGesture docs for the full lifecycle.
    *
    * Only fires inside `<AlternateScreen>` where mouse tracking is on.
    */

--- a/packages/renderer/src/events/mouse-event.test.ts
+++ b/packages/renderer/src/events/mouse-event.test.ts
@@ -34,15 +34,22 @@ describe('MouseDownEvent', () => {
     expect(e._capturedHandlers?.onUp).toBeUndefined()
   })
 
-  it('last captureGesture call wins when called multiple times', () => {
-    // Matches web pointer-events setPointerCapture semantics — repeat
-    // calls during the same press silently overwrite, no error.
+  it('keeps the first captureGesture call when called multiple times', () => {
+    // The press is claimed once. Later calls during the same dispatch are
+    // ignored so an ancestor cannot steal a descendant's gesture.
     const e = new MouseDownEvent(0, 0, 0)
     const first = vi.fn()
     const second = vi.fn()
     e.captureGesture({ onMove: first })
     e.captureGesture({ onMove: second })
-    expect(e._capturedHandlers?.onMove).toBe(second)
+    expect(e._capturedHandlers?.onMove).toBe(first)
+  })
+
+  it('reports when a gesture has been captured', () => {
+    const e = new MouseDownEvent(0, 0, 0)
+    expect(e.gestureCaptured).toBe(false)
+    e.captureGesture({ onMove: vi.fn() })
+    expect(e.gestureCaptured).toBe(true)
   })
 
   describe('modifier key decoding', () => {
@@ -153,6 +160,26 @@ describe('dispatchMouseDown', () => {
 
     dispatchMouseDown(root, 2, 2, 0)
     expect(order).toEqual(['child', 'root'])
+  })
+
+  it('stops bubbling after the first captured gesture', () => {
+    const root = createNode('ink-root')
+    setRect(root, 0, 0, 10, 5)
+    const child = createNode('ink-box')
+    appendChildNode(root, child)
+    setRect(child, 0, 0, 5, 5)
+
+    const childMove = vi.fn()
+    const rootMove = vi.fn()
+    const rootHandler = vi.fn((e: MouseDownEvent) => e.captureGesture({ onMove: rootMove }))
+    child._eventHandlers = {
+      onMouseDown: (e: MouseDownEvent) => e.captureGesture({ onMove: childMove }),
+    }
+    root._eventHandlers = { onMouseDown: rootHandler }
+
+    const result = dispatchMouseDown(root, 2, 2, 0)
+    expect(rootHandler).not.toHaveBeenCalled()
+    expect(result?.onMove).toBe(childMove)
   })
 
   it('stops bubbling when a handler calls stopImmediatePropagation', () => {

--- a/packages/renderer/src/events/mouse-event.ts
+++ b/packages/renderer/src/events/mouse-event.ts
@@ -98,12 +98,18 @@ export class MouseDownEvent extends MouseEvent {
    * `handlers.onMove` even when the cursor leaves this element's
    * bounds; release fires `handlers.onUp` and clears the capture.
    *
-   * Calling this multiple times during one onMouseDown dispatch
-   * silently overwrites — last call wins. Matches web pointer-events
-   * `setPointerCapture` semantics.
+   * Calling this multiple times during one onMouseDown dispatch is
+   * first-call-wins: the deepest handler that claims the press owns the
+   * gesture, and later ancestor handlers do not get to steal it.
    */
   captureGesture(handlers: GestureHandlers): void {
+    if (this._capturedHandlers) return
     this._capturedHandlers = handlers
+  }
+
+  /** True once any handler has claimed this press via captureGesture(). */
+  get gestureCaptured(): boolean {
+    return this._capturedHandlers !== null
   }
 }
 

--- a/packages/renderer/src/hit-test.ts
+++ b/packages/renderer/src/hit-test.ts
@@ -158,7 +158,8 @@ export function dispatchClick(
  * Hit-test the root at (col, row) and bubble a MouseDownEvent from the
  * deepest containing node up through parentNode. Only nodes with an
  * onMouseDown handler fire. Stops when a handler calls
- * stopImmediatePropagation().
+ * stopImmediatePropagation() or captures the gesture. Capture is
+ * leaf-first so descendants cannot be overwritten by ancestors.
  *
  * Returns the GestureHandlers installed via event.captureGesture() if
  * any handler called it, or null otherwise. The caller (App) is
@@ -191,6 +192,7 @@ export function dispatchMouseDown(
         event.localRow = row - rect.y
       }
       handler(event)
+      if (event.gestureCaptured) break
       if (event.didStopImmediatePropagation()) break
     }
     target = target.parentNode

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,19 @@ importers:
         specifier: ^4.21.0
         version: 4.21.0
 
+  examples/gesture-capture:
+    dependencies:
+      '@yokai-tui/renderer':
+        specifier: workspace:*
+        version: link:../../packages/renderer
+      react:
+        specifier: ^19.2.5
+        version: 19.2.5
+    devDependencies:
+      tsx:
+        specifier: ^4.21.0
+        version: 4.21.0
+
   examples/resizable:
     dependencies:
       '@yokai-tui/renderer':


### PR DESCRIPTION
## Summary
- make `MouseDownEvent.captureGesture(...)` first-call-wins instead of last-call-wins
- stop `onMouseDown` bubbling once a descendant captures the gesture, preventing ancestor Draggable wrappers from stealing it
- add dispatcher and Draggable regression coverage plus docs/changelog updates for the new leaf-first contract

## Notes
This closes the A21 semantic bug. It also improves the A3 workaround shape: a child inside `<Draggable>` can now claim a press with `captureGesture` without also calling `stopImmediatePropagation()`.

Plain `onClick` inside an eagerly-capturing `<Draggable>` still needs A22's deferred-capture work before A3 can be fully closed.

## Verification
- pnpm test -- packages/renderer/src/events/mouse-event.test.ts packages/renderer/src/components/Draggable.test.tsx
- pnpm --filter @yokai-tui/renderer typecheck
- pnpm --filter @yokai-tui/renderer lint
- pnpm test
- pnpm --filter @yokai-tui/renderer build
- git diff --check

Closes #71
Refs #55
Refs #72