### PR TITLE
shakedown round 2: docs + chainable Draggable.onMouseDown

### DIFF
--- a/docs/components/box.md
+++ b/docs/components/box.md
@@ -15,7 +15,7 @@ Layout props (all Yoga flexbox properties: `width`, `height`, `flexDirection`, `
 |------|------|---------|-------------|
 | `flexDirection` | `'row' \| 'column' \| ...` | `'row'` | Main axis direction |
 | `flexGrow` | `number` | `0` | Yoga flex-grow |
-| `flexShrink` | `number` | `1` | Yoga flex-shrink |
+| `flexShrink` | `number` | `1` | Yoga flex-shrink. Set `flexShrink={0}` on chrome (titlebars, footers, status rows) that should always render — see [layout pitfalls](../concepts/layout.md#chrome-rows-disappear-when-content-has-large-natural-size). |
 | `flexWrap` | `'nowrap' \| 'wrap' \| 'wrap-reverse'` | `'nowrap'` | Wrap behavior |
 | `tabIndex` | `number` | — | `>= 0` joins Tab cycle; `-1` is programmatically focusable only |
 | `autoFocus` | `boolean` | — | Focus on mount (during reconciler `commitMount`) |

--- a/docs/components/draggable.md
+++ b/docs/components/draggable.md
@@ -51,6 +51,7 @@ Gesture capture suppresses `onClick` for the press that initiated the drag. A pr
 ## Related
 - [`DropTarget`](./drop-target.md)
 - [`Box`](./box.md)
+- [Window pattern](../patterns/window.md) — interim recipe for building draggable window-shaped UIs on top of `<Draggable>`
 
 ## Source
 [`packages/renderer/src/components/Draggable.tsx`](../../packages/renderer/src/components/Draggable.tsx)

--- a/docs/components/draggable.md
+++ b/docs/components/draggable.md
@@ -18,10 +18,11 @@ import type { DragPos, DragBounds, DragInfo } from '@yokai-tui/renderer'
 | `onDragStart` | `(info: DragInfo) => void` | — | Fires once on first cursor motion after press (not on press itself). |
 | `onDrag` | `(info: DragInfo) => void` | — | Fires on every cell-crossing motion, after internal pos state updates. |
 | `onDragEnd` | `(info: DragInfo) => void` | — | Fires once at release if the gesture became a drag. `info.dropped` is `true` if a `<DropTarget>` accepted. |
+| `onMouseDown` | `(event: MouseDownEvent) => void` | — | Optional consumer press handler. Fires BEFORE Draggable's internal drag wiring — useful for "raise window on press" / app-level focus updates. Consumer may call `event.captureGesture(...)` to preempt the drag (first-call-wins per [`MouseDownEvent`](../reference/events.md#mousedownevent)). The press-time z-bump still fires either way; use `disabled` to suppress press behavior entirely. |
 
 `DragInfo`: `{ pos, startPos, delta: { dx, dy }, dropped? }`. `delta` is screen-space cell delta from press point, not from previous frame.
 
-All `<Box>` props are accepted except `position`, `top`, `left`, `onMouseDown` (owned internally). See [box.md](./box.md).
+All `<Box>` props are accepted except `position`, `top`, `left` (owned internally). `onMouseDown` IS forwarded; see the row above for the chain semantics. See [box.md](./box.md) for the rest.
 
 ## Examples
 ### Bounded drag with persistence

--- a/docs/components/text.md
+++ b/docs/components/text.md
@@ -44,6 +44,8 @@ import { Text } from '@yokai-tui/renderer'
 </Text>
 ```
 
+Nested `<Text>` is for STYLE SPANS, not for layout. The inner Text becomes `ink-virtual-text` with no Yoga node — the entire nested tree is one flex leaf. For independent layout (each fragment as its own flex child with `gap`, individual `flexShrink`, etc.), use sibling `<Text>` inside a `<Box flexDirection="row">`. See [text concepts: Nested vs sibling Text](../concepts/text.md#nested-vs-sibling-text) for the full explanation and known-issue caveat.
+
 ## Behavior
 
 - String / number children may only appear inside `<Text>`; the reconciler rejects them elsewhere.

--- a/docs/concepts/layout.md
+++ b/docs/concepts/layout.md
@@ -50,6 +50,38 @@ Absolute children are removed from flow and positioned against the nearest posit
 
 `overflow: 'hidden'` clips children to the container's content box. `overflow: 'scroll'` additionally constrains the container's measured size against its children, enabling `<ScrollBox>` virtualization. Per-axis variants `overflowX` / `overflowY` exist; layout uses the union.
 
+## Layout pitfalls
+
+### Chrome rows disappear when content has large natural size
+
+`<Box>` defaults to `flexShrink: 1` (matches CSS-flex spec). In a container with both a small "chrome" element (titlebar, footer, status row) and a large content area, yoga distributes any deficit proportionally to `size × flexShrink`. The chrome element is the small one — it shrinks faster, often to zero, and disappears.
+
+```tsx
+// ❌ Titlebar silently disappears when content's natural width is large.
+<Box flexDirection="column" height="100%">
+  <Box height={1}>
+    <Text>my app</Text>
+  </Box>
+  <ChatLog />  {/* huge natural content */}
+</Box>
+```
+
+The titlebar's `Box` inherits `flexShrink: 1`. The chat log's natural size dominates the deficit calculation; yoga shrinks the chrome to zero rather than push the chat log past viewport. From the consumer's side it looks like the titlebar wasn't rendered.
+
+```tsx
+// ✅ Pin the chrome row out of the shrink pool.
+<Box flexDirection="column" height="100%">
+  <Box height={1} flexShrink={0}>
+    <Text>my app</Text>
+  </Box>
+  <ChatLog />
+</Box>
+```
+
+Apply this on any element that should always render at its natural size — title bars, status bars, footers, fixed-width sidebars, button rows, search affordances. A good heuristic: if collapsing the element would make the UI broken or unrecognizable, it should be `flexShrink={0}`.
+
+The same pitfall applies to `<Text>` (which yokai's component overlays a flex layer on; see [Text component docs](../components/text.md)). When a wrapping `<Text>` sits in a container with a larger sibling, yoga can shrink it below natural width, wrapping the content to a 2nd line that's invisible if the parent has fixed `height: 1`. Same fix: `flexShrink={0}` on the wrapping container.
+
 ## See also
 - [Rendering](../concepts/rendering.md)
 - [Box](../components/box.md)

--- a/docs/concepts/text.md
+++ b/docs/concepts/text.md
@@ -38,6 +38,35 @@ Width is measured per grapheme cluster, not per code point. Combining marks (`é
 
 CJK ideographs, fullwidth forms, and most emoji are width 2. The screen buffer stores them as a `WideHead` cell followed by a `SpacerTail` cell, so a single grapheme occupies exactly two columns. Hit-testing, hyperlink lookup, and selection unify the pair: clicking the spacer resolves to the head cell.
 
+## Nested vs sibling Text
+
+When you nest `<Text>` inside `<Text>`, the inner one is NOT a separate flex child of the outer. The reconciler rewrites it (`packages/renderer/src/reconciler.ts:289-310`): an `ink-text` whose `hostContext.isInsideText` is true becomes `ink-virtual-text`. Virtual-text has no Yoga node — it contributes neither flex basis nor measurement of its own. The whole nested-Text tree is one Yoga leaf, sized by squashing all descendant text into a single string.
+
+Concretely, `squashTextNodesToSegments` walks the tree, collects every `#text` value, and merges sibling-and-descendant style stacks into per-segment styles. Measurement then runs once on the joined string with the merged style attribution applied at render time.
+
+Two consequences worth keeping in mind:
+
+1. **Nested `<Text>` is for STYLE SPANS, not for layout.** Use it when you want a colored / bold / dimmed run inline within larger text:
+   ```tsx
+   <Text>
+     <Text bold>error: </Text>
+     something failed
+   </Text>
+   ```
+   The result is one styled string. The outer Text wraps the whole thing; you can't make the inner runs lay out independently or take part in flex math.
+
+2. **For independent layout, use sibling Texts in a Box.** When you want each text fragment to be its own flex child (for `gap`, `justifyContent`, individual `flexShrink`, hit-testing as separate elements), reach for sibling Texts inside a `<Box flexDirection="row">`:
+   ```tsx
+   <Box flexDirection="row" gap={1}>
+     <Text bold>13:47:04</Text>
+     <Text>·</Text>
+     <Text>May 3</Text>
+   </Box>
+   ```
+   Each `<Text>` is now an independent flex child with its own natural width and measure call. `gap` applies between them. Yoga can distribute / shrink each one independently.
+
+**Known issue:** under certain flex configurations (parent has slack, multiple competing siblings), a nested-Text outer can be measured at sub-natural width during yoga's basis pass, then truncated silently. See [issue #51](https://github.com/re-marked/yokai/issues/51). Until that's fixed, prefer the sibling-Text-in-a-Box pattern when the inner fragments matter.
+
 ## ANSI passthrough
 
 Pre-rendered ANSI strings should use `<RawAnsi>`:

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -6,15 +6,18 @@ Install yokai in a consumer project.
 
 | Package | Version |
 |---------|---------|
-| `react` | `^19.2.5` |
+| `react` | `>=19.0.0` |
+| `react-reconciler` | `>=0.33.0` |
 | `node`  | `>=22`  |
+
+`react-reconciler` is required at runtime (the renderer wires React's commit phase through it directly, see `packages/renderer/src/reconciler.ts`). pnpm doesn't auto-install peer deps and npm only installs them on a clean install — always pass both peers to your install command, or pin them in your `package.json`.
 
 ## From npm (canonical)
 
 ```sh
-pnpm add @yokai-tui/renderer react
+pnpm add @yokai-tui/renderer react react-reconciler
 # or
-npm install @yokai-tui/renderer react
+npm install @yokai-tui/renderer react react-reconciler
 ```
 
 `@yokai-tui/shared` is pulled in transitively. Add it explicitly only if you import its symbols directly.
@@ -29,7 +32,8 @@ If you prefer pinning to source instead of npm:
 {
   "dependencies": {
     "@yokai-tui/renderer": "github:re-marked/yokai#v0.7.1",
-    "react": "^19.2.5"
+    "react": "^19.2.5",
+    "react-reconciler": "^0.33.0"
   }
 }
 ```

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -64,6 +64,50 @@ pnpm build
 
 Subsequent `pnpm build` runs are incremental.
 
+## Local-checkout development (`link:`)
+
+If you're developing a consumer app side-by-side with a local yokai checkout (not a monorepo workspace, not an npm install), use `link:` paths in your consumer's `package.json`:
+
+```jsonc
+{
+  "dependencies": {
+    "@yokai-tui/renderer": "link:../yokai/packages/renderer",
+    "@yokai-tui/shared": "link:../yokai/packages/shared",
+    // CRITICAL — also link react and react-reconciler from yokai's
+    // node_modules. See the "React singleton" note below.
+    "react": "link:../yokai/packages/renderer/node_modules/react",
+    "react-reconciler": "link:../yokai/packages/renderer/node_modules/react-reconciler"
+  }
+}
+```
+
+### Why the explicit react / react-reconciler link
+
+Yokai's renderer declares `react` and `react-reconciler` as PEER dependencies. With a normal npm install, the consumer's app and yokai resolve to the SAME `react` instance (npm dedups peers). With `link:`, they resolve to DIFFERENT module instances — the consumer's `node_modules/react` and yokai's `node_modules/react` are two separate copies.
+
+React enforces a per-module-instance dispatcher singleton. When yokai's renderer creates a Context (`FocusContext`, `TerminalSizeContext`, etc.) using its copy of `react`, and the consumer's component reads it via `useContext` using the consumer's copy of `react`, the singletons don't match — `useContext` returns `null` for everything yokai-provided. Symptoms:
+
+- `useFocus` returns `{ ref: <noop>, isFocused: false, focus: <noop> }`
+- `useTerminalViewport` returns no dimensions
+- Cursor declarations don't fire
+- `<FocusGroup>` doesn't cycle on Tab
+
+The fix is to force the consumer's `react` and `react-reconciler` to resolve to yokai's copies via the explicit `link:` paths above. After this, both sides share one module instance and React's internal checks pass.
+
+### Verify the fix worked
+
+After `pnpm install`, check:
+
+```sh
+ls -la node_modules/react node_modules/@yokai-tui/renderer/node_modules/react
+```
+
+Both should be symlinks pointing to the same target (yokai's `react`). If they're separate directories, the dedup didn't take — re-check the `link:` paths.
+
+### Real-world example
+
+Termos (the testbed app) uses exactly this shape — see [`termos/package.json`](https://github.com/re-marked/termos/blob/main/package.json) for a working reference.
+
 ## Next
 
 - [Your first app](your-first-app.md)

--- a/docs/patterns/window.md
+++ b/docs/patterns/window.md
@@ -118,7 +118,15 @@ render(<App />)
 - **Different titlebar content**: replace the `<Text dim>` with breadcrumbs, tab bar, status indicators, etc. As long as one element captures the close-or-equivalent action via `onMouseDown` + `e.captureGesture`, the rest can stay clickable.
 - **Multiple windows**: render N `<Draggable>` siblings. Each owns its own z-index (Draggable bumps `persistedZ` on press for raise-on-press). The most-recently-pressed window stays in front of the others.
 - **Constrained drag**: pass `bounds={{ width, height }}` so the window can't be dragged past viewport edges. Useful when the WM should keep windows reachable.
-- **Modal mode**: combine with the [Modal](./modal.md) pattern's backdrop — render a full-viewport `<Box position="absolute" backgroundColor="black" zIndex={100}>` behind the window's `<Draggable zIndex={101}>`.
+- **Modal mode**: combine with the [Modal](./modal.md) pattern's backdrop. Note that `<Draggable>` owns its own `zIndex` internally (it bumps `persistedZ` on press, starting around 10 and growing), so passing `zIndex` as a prop is ignored. To put a Draggable above a backdrop, give the BACKDROP a low absolute `zIndex` (e.g. `zIndex={1}`) and let the Draggable's natural press-bumped z float above it. Pressing the window once bumps it well above any low backdrop value:
+  ```tsx
+  {/* Backdrop sits at z=1; press-bumped Draggable lives at z >= 10 */}
+  <Box position="absolute" top={0} left={0} width="100%" height="100%" backgroundColor="black" zIndex={1} />
+  <Draggable initialPos={...} width={W} height={H} borderStyle="single">
+    {/* window content */}
+  </Draggable>
+  ```
+  If you need a guaranteed-stacking ordering without relying on press-bump, track a related issue on yokai for an explicit `baseZIndex` prop on Draggable.
 - **Resizable corners**: not supported in this interim pattern. For resize, you'd compose `<Resizable>` inside `<Draggable>`, but the two don't currently combine cleanly (drag math vs. resize math fight over the rect). Tracked as part of the `<Window>` primitive (issue #56).
 
 ## Known caveats

--- a/docs/patterns/window.md
+++ b/docs/patterns/window.md
@@ -1,0 +1,137 @@
+# Window
+
+A draggable, fixed-size floating panel with a titlebar, optional close button, and arbitrary content. Reach for this when building desktop-style UIs: floating editors, side panels, palettes, tool windows.
+
+> **Interim pattern.** A first-class `<Window>` primitive is on the roadmap (issue #56). Until it ships, this is the canonical way to build a window-shaped element on yokai. The shape below is what `examples/scratchpad/scratchpad.tsx` runs in production.
+
+## Code
+
+```tsx
+import {
+  AlternateScreen,
+  Box,
+  Draggable,
+  type MouseDownEvent,
+  TerminalSizeContext,
+  Text,
+  TextInput,
+  render,
+  useApp,
+  useInput,
+} from '@yokai-tui/renderer'
+import type React from 'react'
+import { useCallback, useContext, useState } from 'react'
+
+const WINDOW_WIDTH = 56
+const WINDOW_HEIGHT = 14
+
+/** Close button — captures the press so the click doesn't bubble to the
+ *  underlying Draggable's mouseDown (which would race a phantom drag-start).
+ *  Hover-red mirrors the macOS / Windows traffic-light close. */
+function CloseButton({ onClose }: { onClose: () => void }): React.ReactNode {
+  const [hover, setHover] = useState(false)
+  const handleMouseDown = useCallback(
+    (e: MouseDownEvent) => {
+      e.stopImmediatePropagation()
+      e.captureGesture({ onUp: () => onClose() })
+    },
+    [onClose],
+  )
+  return (
+    <Box
+      paddingX={1}
+      backgroundColor={hover ? 'red' : undefined}
+      onMouseEnter={() => setHover(true)}
+      onMouseLeave={() => setHover(false)}
+      onMouseDown={handleMouseDown}
+    >
+      <Text bold={hover} color={hover ? 'white' : 'gray'}>
+        ×
+      </Text>
+    </Box>
+  )
+}
+
+function App(): React.ReactNode {
+  const { exit } = useApp()
+  useInput((input, key) => {
+    if (input === 'q' || (key.ctrl && input === 'c')) exit()
+  })
+
+  const [text, setText] = useState('hello window')
+  const [open, setOpen] = useState(true)
+
+  // Center on first paint. initialPos is captured at Draggable mount and
+  // not re-applied on prop changes (matches React's defaultValue
+  // semantics), so this centers ONCE — the user can drag freely from there.
+  const size = useContext(TerminalSizeContext)
+  const initialLeft = size?.columns ? Math.max(0, Math.floor((size.columns - WINDOW_WIDTH) / 2)) : 8
+
+  return (
+    <AlternateScreen mouseTracking>
+      <Box flexDirection="column" width="100%" height="100%">
+        {open && (
+          <Draggable
+            initialPos={{ left: initialLeft, top: 2 }}
+            width={WINDOW_WIDTH}
+            height={WINDOW_HEIGHT}
+            borderStyle="single"
+            borderColor="gray"
+            backgroundColor="black"
+            flexDirection="column"
+          >
+            {/* Titlebar — drag handle (drag bubbles to the Draggable
+                naturally) + close button. */}
+            <Box flexDirection="row" justifyContent="space-between" paddingX={1}>
+              <Text dim>my window</Text>
+              <CloseButton onClose={() => setOpen(false)} />
+            </Box>
+            {/* Content area — fills remaining vertical space. */}
+            <Box flexDirection="column" flexGrow={1} paddingX={1} paddingTop={1}>
+              <TextInput value={text} onChange={setText} multiline autoFocus />
+            </Box>
+          </Draggable>
+        )}
+      </Box>
+    </AlternateScreen>
+  )
+}
+
+render(<App />)
+```
+
+## How it works
+
+1. **`<Draggable>` IS the window frame**. With `width` + `height` + `borderStyle` + `backgroundColor` + `flexDirection="column"`, a Draggable is exactly the rectangle a window needs. Press-anywhere-on-it to drag (titlebar OR content area), bordered chrome, opaque background, internal vertical layout.
+2. **Children render inside the frame**. The titlebar is the first child, the content is the rest. Border + padding clip naturally.
+3. **Close button uses gesture capture, not `onClick`**. The Draggable claims the mouseDown gesture for "potential drag-start" — but only if motion follows. A press-and-release on the close button without motion is a click semantically, but Draggable's old eager-capture meant in-window children couldn't `onClick` reliably.
+   - **`e.stopImmediatePropagation()`** halts the bubble so Draggable's own `onMouseDown` doesn't see the press.
+   - **`e.captureGesture({ onUp: ... })`** claims the gesture at the leaf. Per [`captureGesture` first-call-wins semantics](../components/draggable.md#props), the leaf wins; ancestors (Draggable) don't get to overwrite.
+   - The `onUp` handler runs on release, which is the click.
+4. **`paddingX={1}` titlebar gives drag-affordance**. The whole titlebar row is grabbable; only the close button captures the gesture for itself.
+5. **Centered on first paint via `TerminalSizeContext`**. `initialPos` is mount-only (like `defaultValue`); compute the centered `left` once and the user can drag from there. Don't try to re-center on resize — it'll fight the user's drag.
+6. **Open/close lifecycle**. Conditional render of the `<Draggable>` based on `open` state. Close button flips `open=false`; the window unmounts; reopening means a fresh mount with `initialPos` recomputed.
+
+## Variations
+
+- **No close button**: drop `<CloseButton>`. Window stays open until the host app's lifecycle decides otherwise.
+- **Different titlebar content**: replace the `<Text dim>` with breadcrumbs, tab bar, status indicators, etc. As long as one element captures the close-or-equivalent action via `onMouseDown` + `e.captureGesture`, the rest can stay clickable.
+- **Multiple windows**: render N `<Draggable>` siblings. Each owns its own z-index (Draggable bumps `persistedZ` on press for raise-on-press). The most-recently-pressed window stays in front of the others.
+- **Constrained drag**: pass `bounds={{ width, height }}` so the window can't be dragged past viewport edges. Useful when the WM should keep windows reachable.
+- **Modal mode**: combine with the [Modal](./modal.md) pattern's backdrop — render a full-viewport `<Box position="absolute" backgroundColor="black" zIndex={100}>` behind the window's `<Draggable zIndex={101}>`.
+- **Resizable corners**: not supported in this interim pattern. For resize, you'd compose `<Resizable>` inside `<Draggable>`, but the two don't currently combine cleanly (drag math vs. resize math fight over the rect). Tracked as part of the `<Window>` primitive (issue #56).
+
+## Known caveats
+
+- **Interactive children inside the window need the gesture-capture pattern.** Buttons, sidebar items, breadcrumb segments — anything clickable inside a Draggable should mirror `<CloseButton>`'s `onMouseDown` + `e.stopImmediatePropagation()` + `e.captureGesture({onUp: ...})` shape. Wrap into a `<ClickableBox>` if you have many.
+  - Sidenote: the eager-capture root cause is being addressed (issue #72 / A22). Once that's fixed, plain `onClick` on in-window children will work without the boilerplate.
+- **`width` + `height` are required.** Auto-sizing via flex doesn't work cleanly for absolute-positioned Draggable; pin both dimensions.
+- **The titlebar drag handle is implicit.** Press anywhere on the window frame to drag — there's no "title-bar-only drag" mode. If your content is a `<TextInput>` (like the scratchpad demo), the input claims the press for its own selection; users have to grab the titlebar (or any non-input area) to drag.
+
+## Related
+
+- [`Draggable`](../components/draggable.md) — the underlying primitive
+- [Modal](./modal.md) — combine with backdrop for modal-window UX
+- `examples/scratchpad/scratchpad.tsx` — live working example
+- Issue [#56](https://github.com/re-marked/yokai/issues/56) — proper `<Window>` primitive (long-term)
+- Issue [#72](https://github.com/re-marked/yokai/issues/72) — eager-capture fix that will let plain `onClick` work inside Draggable

--- a/packages/renderer/src/components/Draggable.test.tsx
+++ b/packages/renderer/src/components/Draggable.test.tsx
@@ -47,7 +47,44 @@ describe('DraggableProps', () => {
 
     expect(props.children).toBe('drag me')
   })
+
+  it('accepts onMouseDown in the exported prop type (chainable consumer handler)', () => {
+    // Compile-time: the type must include onMouseDown (was previously
+    // stripped via Except). Runtime: the satisfies check is enough.
+    const props = {
+      initialPos: { top: 0, left: 0 },
+      onMouseDown: (e: MouseDownEvent) => {
+        // Consumer handler may inspect coords, claim the gesture, etc.
+        void e.col
+      },
+    } satisfies DraggableProps
+
+    expect(props.onMouseDown).toBeTypeOf('function')
+  })
 })
+
+// ── component wrapper: chainable onMouseDown ─────────────────────────
+//
+// The component's handleMouseDown calls the consumer's onMouseDown
+// FIRST (before delegating to handleDragPress). The integration is
+// thin (one ref read + one call) so we test it inline against the
+// component's documented contract rather than spinning up React. The
+// chain order matters because:
+//   - Consumer's onMouseDown can call event.captureGesture(...) to
+//     preempt Draggable. Per A21 (PR #81), captureGesture is
+//     first-call-wins, so consumer wins iff they go first.
+//   - Draggable's press-time z-bump still fires AFTER the consumer
+//     returns, regardless of preemption — "press is press."
+//
+// Direct unit test of the ordering would require rendering the
+// component and dispatching a real MouseDownEvent through React's
+// commit phase. The Draggable test file deliberately skips React
+// (per the file header). Component-level integration is exercised
+// by the `pnpm demo:drag` and `pnpm demo:scratchpad` smoke tests.
+// What we CAN pin here without React is the type contract above
+// + the underlying captureGesture first-call-wins semantic that
+// makes consumer preemption work — covered by mouse-event.test.ts
+// (PR #81's "first call wins" tests).
 
 // ── pure math ────────────────────────────────────────────────────────
 

--- a/packages/renderer/src/components/Draggable.tsx
+++ b/packages/renderer/src/components/Draggable.tsx
@@ -37,10 +37,11 @@ export type DragInfo = {
 
 export type DraggableProps = Except<
   BoxProps,
-  // We own placement and the press handler. Letting the user override
-  // `position` would break drag math; overriding `top`/`left` would
-  // fight the internal pos state every render.
-  'position' | 'top' | 'left' | 'onMouseDown'
+  // We own placement. Letting the user override `position` would break
+  // drag math; overriding `top`/`left` would fight the internal pos
+  // state every render. `onMouseDown` IS forwarded — see the prop's own
+  // docstring below for the chain semantics.
+  'position' | 'top' | 'left'
 > & {
   /**
    * Where the draggable sits before the user moves it. Cell offsets
@@ -98,6 +99,29 @@ export type DraggableProps = Except<
   dragData?: unknown
   /** Children render inside the draggable Box; runtime already forwards them via boxProps. */
   children?: React.ReactNode
+  /**
+   * Optional consumer-supplied press handler. Fires synchronously BEFORE
+   * Draggable's internal drag wiring runs — useful for "raise window
+   * on press" / "focus this widget on click" / app-level analytics that
+   * want to observe every press regardless of whether it becomes a
+   * drag.
+   *
+   * The consumer's handler can claim the gesture by calling
+   * `event.captureGesture(...)` itself. captureGesture is first-call-
+   * wins (see MouseDownEvent docs), so a consumer that captures here
+   * preempts Draggable — Draggable's internal captureGesture call
+   * becomes a no-op, no drag will start, and the consumer owns the
+   * subsequent motion + release events.
+   *
+   * Side effects that fire BEFORE the consumer's gesture decision:
+   * none. Side effects that fire AFTER (regardless of preemption):
+   * the press-time z-index bump (raise on press) — pressing always
+   * raises, even when the consumer redirects the gesture, because
+   * "press" is a UI signal independent of "is this becoming a drag."
+   * To suppress all press behavior including the z-bump, set
+   * `disabled` instead.
+   */
+  onMouseDown?: (event: MouseDownEvent) => void
 }
 
 /**
@@ -137,6 +161,7 @@ export default function Draggable({
   onDragStart,
   onDrag,
   onDragEnd,
+  onMouseDown: userOnMouseDown,
   dragData,
   ...boxProps
 }: DraggableProps): React.ReactNode {
@@ -179,8 +204,28 @@ export default function Draggable({
   widthRef.current = typeof boxProps.width === 'number' ? boxProps.width : undefined
   heightRef.current = typeof boxProps.height === 'number' ? boxProps.height : undefined
 
+  // Stash the consumer's onMouseDown in a ref so handleMouseDown's
+  // useCallback identity stays stable across renders that only change
+  // the user handler — same pattern as the onDragStart/onDrag/onDragEnd
+  // refs above. Also lets the handler read the freshest closure each
+  // press without the parent having to memoize.
+  const userOnMouseDownRef = useRef(userOnMouseDown)
+  userOnMouseDownRef.current = userOnMouseDown
+
   const handleMouseDown = useCallback(
     (e: MouseDownEvent): void => {
+      // Run consumer's onMouseDown FIRST. They may call
+      // event.captureGesture(...) themselves to claim the press —
+      // captureGesture is first-call-wins (see MouseDownEvent docs and
+      // PR #81 / A21), so a consumer that captures here preempts
+      // Draggable's internal capture below.
+      //
+      // Either way, handleDragPress runs after — its own captureGesture
+      // call no-ops if the consumer already captured, but its
+      // press-time z-bump (raise on press) still fires unconditionally.
+      // That matches the documented prop contract: "press is press."
+      // Consumers who want NO press behavior set `disabled` instead.
+      userOnMouseDownRef.current?.(e)
       handleDragPress(e, {
         startPos: pos,
         disabled,


### PR DESCRIPTION
## Summary

Bundled follow-up to the 6 codex shakedown PRs (#76-#81). 5 commits, mostly docs, one small code change.

| # | Commit | Closes | Files |
|---|---|---|---|
| 1 | \`feat(Draggable): expose chainable onMouseDown\` | C11 #64 | Draggable.tsx + .test + draggable.md |
| 2 | \`docs(layout): document chrome flexShrink:0 pitfall\` | B6 #59 | concepts/layout.md + components/box.md |
| 3 | \`docs(text): document ink-virtual-text reconciler rewrite\` | D14 #67 | concepts/text.md + components/text.md |
| 4 | \`docs(patterns): document window pattern\` | D15 #68 | new patterns/window.md + components/draggable.md |
| 5 | \`docs(install): document link: workspace react dedup\` | E16 #69 | getting-started/install.md |

## Highlights

- **Draggable.onMouseDown is back** — consumer handler fires BEFORE Draggable's internal drag wiring, can preempt the drag via \`event.captureGesture(...)\` (first-call-wins per A21). Press-time z-bump still fires regardless of preemption — \"press is press.\"
- **Layout pitfalls section** — explicit guidance that chrome elements (titlebars / footers / status rows) need \`flexShrink={0}\` because Box defaults to 1 (CSS-flex spec).
- **Nested vs sibling Text** — explains the \`ink-virtual-text\` reconciler rewrite, why nested Text isn't a flex child, when to reach for sibling Texts in a Box instead. Forward-link to known-issue #51.
- **Window pattern** — documents the scratchpad demo's shape as the canonical \"build a window\" recipe until the proper \`<Window>\` primitive (#56) ships.
- **\`link:\` dedup guide** — the React peer-dep singleton trap that broke termos until we pinned react/react-reconciler from yokai's node_modules. Saves the next consumer the hour of debugging.

## Test plan

- [x] \`pnpm typecheck\` clean
- [x] \`pnpm test\` — 703 passing (was 702; +1 type-contract test for new \`onMouseDown\` prop)
- [x] \`pnpm lint\` clean
- [x] \`pnpm build\` clean

## Notes

- Commit 1 only: type-contract change. \`DraggableProps\` no longer omits \`onMouseDown\`. Additive at type level (consumers can now pass it; previously they couldn't), no runtime regression.
- Commit 1 z-bump semantics: confirmed in the new prop's docstring. Press always raises; consumers who want fully-suppressed press behavior set \`disabled\`.
- All commits include co-authorship per CLAUDE.md.