### PR TITLE
fix(Draggable): defer captureGesture to first motion (A22)

### DIFF
--- a/docs/components/draggable.md
+++ b/docs/components/draggable.md
@@ -45,8 +45,10 @@ All `<Box>` props are accepted except `position`, `top`, `left` (owned internall
 - **Drop integration**: `startDrag` engages on first motion, `tickDrag` fires after each `setPos`, `dispatchDrop` runs at release before `endDrag`.
 - **Press without motion is not a drag**: `onDragStart` / `onDragEnd` only fire if the cursor moves.
 
-### Known limitation
-Gesture capture suppresses `onClick` for the press that initiated the drag. A press-and-release with no motion does not capture the gesture and `onClick` fires normally; once motion begins, the gesture owns the release.
+### Click vs. drag disambiguation
+Draggable installs a TENTATIVE gesture on press. The gesture is committed only when actual motion follows; a press-and-release with no motion silently drops the gesture and falls through to normal click dispatch. Practical effect: a `<Box onClick>` (or `<TextInput>`, `<Button>`, etc.) inside a `<Draggable>` reliably receives its click on a press-without-motion — no `stopImmediatePropagation` boilerplate required.
+
+Once motion begins, the gesture is promoted: any in-progress text selection from the press is cancelled, `onMove` fires, and the release goes to `onUp` instead of being dispatched as a click.
 
 ## Related
 - [`DropTarget`](./drop-target.md)

--- a/packages/renderer/src/components/App.tsx
+++ b/packages/renderer/src/components/App.tsx
@@ -817,6 +817,14 @@ export function handleMouseEvent(app: App, m: ParsedMouse): void {
             clearSelection(sel)
             app.props.onSelectionChange()
           }
+          // Reset the multi-click chain. The tentative press updated
+          // clickCount on press (so click dispatch on release-without-
+          // motion works); now that motion proved this is a drag, those
+          // multi-click bits would otherwise count this press toward the
+          // next quick click, dispatching onMultiClick instead of
+          // onClick. Mirror what confirmed captures do at the press
+          // path.
+          app.clickCount = 0
         }
         app.activeGesture.onMove?.(new MouseMoveEvent(col, row, m.button))
         return

--- a/packages/renderer/src/components/App.tsx
+++ b/packages/renderer/src/components/App.tsx
@@ -7,6 +7,7 @@ import type { KeyboardEvent } from '../events/keyboard-event'
 import { type GestureHandlers, MouseMoveEvent, MouseUpEvent } from '../events/mouse-event'
 import { TerminalFocusEvent } from '../events/terminal-focus-event'
 import type { FocusManager } from '../focus'
+import type { CapturedGesture } from '../hit-test'
 import {
   INITIAL_STATE,
   type ParsedInput,
@@ -15,7 +16,13 @@ import {
   parseMultipleKeypresses,
 } from '../parse-keypress'
 import reconciler from '../reconciler'
-import { type SelectionState, finishSelection, hasSelection, startSelection } from '../selection'
+import {
+  type SelectionState,
+  clearSelection,
+  finishSelection,
+  hasSelection,
+  startSelection,
+} from '../selection'
 import { isXtermJs, setXtversionName, supportsExtendedKeys } from '../terminal'
 import { getTerminalFocused, setTerminalFocused } from '../terminal-focus-state'
 import { TerminalQuerier, xtversion } from '../terminal-querier'
@@ -70,9 +77,9 @@ type Props = {
   readonly onClickAt: (col: number, row: number) => boolean
   // Dispatch a mousedown at (col, row) — hit-tests the DOM tree and
   // bubbles onMouseDown handlers. Returns the GestureHandlers if any
-  // handler called event.captureGesture(...), or null. Returns null
-  // (no-op) outside fullscreen.
-  readonly onMouseDownAt: (col: number, row: number, button: number) => GestureHandlers | null
+  // handler called event.captureGesture(...) (or .captureGestureTentatively),
+  // or null. Returns null (no-op) outside fullscreen.
+  readonly onMouseDownAt: (col: number, row: number, button: number) => CapturedGesture | null
   // Dispatch hover (onMouseEnter/onMouseLeave) as the pointer moves over
   // DOM elements. Called for mode-1003 motion events with no button held.
   // No-op outside fullscreen (Ink.dispatchHover gates on altScreenActive).
@@ -220,16 +227,30 @@ export default class App extends PureComponent<Props, State> {
   lastHoverRow = -1
 
   // Active drag-style gesture, set by an onMouseDown handler calling
-  // event.captureGesture(...). When non-null:
+  // event.captureGesture(...) or .captureGestureTentatively(...).
+  // When non-null:
   //   - subsequent drag-motion events route to activeGesture.onMove
   //     instead of extending the text selection
   //   - the next mouse-release fires activeGesture.onUp and clears
   //     this field (selection finish + onClick are skipped for that
   //     release — the user dragged, didn't click)
+  //
+  // When `activeGestureTentative` is true (capture installed via
+  // captureGestureTentatively), the rules differ:
+  //   - press-time selection-start + multi-click detection still run
+  //     (so click dispatch works on release without motion)
+  //   - first motion PROMOTES the gesture: cancels the in-progress
+  //     selection, clears the tentative flag, fires onMove
+  //   - release without motion DROPS the gesture WITHOUT firing onUp,
+  //     and falls through to normal release path (click dispatch +
+  //     selection-finish) — so a press-without-motion on a Draggable
+  //     descendant's `onClick` actually clicks
+  //
   // Cleared on FOCUS_OUT and on no-button-motion lost-release recovery
   // alongside the selection finish, so a drag aborted by leaving the
   // window doesn't leave a dangling capture.
   activeGesture: GestureHandlers | null = null
+  activeGestureTentative = false
 
   // Timestamp of last stdin chunk. Used to detect long gaps (tmux attach,
   // ssh reconnect, laptop wake) and trigger terminal mode re-assert.
@@ -622,10 +643,15 @@ function processKeysInBatch(
       // Same recovery for an active gesture — the user switched apps
       // mid-drag, so the drag is implicitly cancelled. Fire onUp with
       // the last known cursor position; handlers can use the focus-out
-      // signal to treat it as cancellation rather than commit.
+      // signal to treat it as cancellation rather than commit. Tentative
+      // gestures (no motion yet) are dropped silently — onUp would be
+      // misleading because no drag actually happened.
       if (app.activeGesture) {
-        app.activeGesture.onUp?.(new MouseUpEvent(app.lastHoverCol, app.lastHoverRow, 0))
+        if (!app.activeGestureTentative) {
+          app.activeGesture.onUp?.(new MouseUpEvent(app.lastHoverCol, app.lastHoverRow, 0))
+        }
         app.activeGesture = null
+        app.activeGestureTentative = false
       }
       const event = new TerminalFocusEvent('terminalblur')
       app.internal_eventEmitter.emit('terminalblur', event)
@@ -754,9 +780,13 @@ export function handleMouseEvent(app: App, m: ParsedMouse): void {
       // Same lost-release drain for an active gesture: the cursor returned
       // to the window with no button held, so the drag is over. Fire onUp
       // at the cursor position so the gesture initiator can clean up.
+      // Tentative gestures (no motion yet) drop silently.
       if (app.activeGesture) {
-        app.activeGesture.onUp?.(new MouseUpEvent(col, row, m.button))
+        if (!app.activeGestureTentative) {
+          app.activeGesture.onUp?.(new MouseUpEvent(col, row, m.button))
+        }
         app.activeGesture = null
+        app.activeGestureTentative = false
       }
       if (col === app.lastHoverCol && row === app.lastHoverRow) return
       app.lastHoverCol = col
@@ -775,6 +805,19 @@ export function handleMouseEvent(app: App, m: ParsedMouse): void {
       // explicitly opted out of selection by capturing on press; firing
       // both would also trail a selection highlight underneath the drag.
       if (app.activeGesture) {
+        // Tentative gesture promotion: first motion proves the press was
+        // a drag (not a click). Cancel the in-progress selection that we
+        // optimistically started on press for click-dispatch purposes,
+        // clear the tentative flag, then fall through to firing onMove.
+        // After this point the gesture behaves identically to a confirmed
+        // capture.
+        if (app.activeGestureTentative) {
+          app.activeGestureTentative = false
+          if (sel.isDragging || sel.anchor) {
+            clearSelection(sel)
+            app.props.onSelectionChange()
+          }
+        }
         app.activeGesture.onMove?.(new MouseMoveEvent(col, row, m.button))
         return
       }
@@ -795,25 +838,41 @@ export function handleMouseEvent(app: App, m: ParsedMouse): void {
     // Same lost-release recovery for an active gesture: the captured
     // drag effectively ended when we missed the release. Fire onUp at
     // the new press position so the gesture initiator can clean up,
-    // then clear capture so this fresh press starts cleanly.
+    // then clear capture so this fresh press starts cleanly. Tentative
+    // gestures drop silently — onUp would be misleading because no
+    // drag actually happened.
     if (app.activeGesture) {
-      app.activeGesture.onUp?.(new MouseUpEvent(col, row, m.button))
+      if (!app.activeGestureTentative) {
+        app.activeGesture.onUp?.(new MouseUpEvent(col, row, m.button))
+      }
       app.activeGesture = null
+      app.activeGestureTentative = false
     }
     // Dispatch onMouseDown to the DOM tree. If a handler called
-    // event.captureGesture(...), store the handlers as the active
-    // gesture and short-circuit — no multi-click bookkeeping, no
-    // selection start, no click on release. The user is dragging, not
-    // clicking, and we let the captured gesture own the entire
-    // press-drag-release sequence.
+    // event.captureGesture(...) (confirmed) or .captureGestureTentatively
+    // (deferred), store the handlers as the active gesture. For
+    // CONFIRMED captures: short-circuit — no multi-click bookkeeping,
+    // no selection start, no click on release. For TENTATIVE captures:
+    // ALSO run selection-start + multi-click below, so click dispatch
+    // works on release-without-motion. The first motion event promotes
+    // tentative→confirmed and cancels the in-progress selection (see
+    // motion handler above).
     const gesture = app.props.onMouseDownAt(col, row, m.button)
-    if (gesture) {
-      app.activeGesture = gesture
+    if (gesture && !gesture.tentative) {
+      app.activeGesture = gesture.handlers
+      app.activeGestureTentative = false
       // Reset multi-click chain too — a captured gesture interrupts
       // any in-flight click cadence (releasing a drag at the same cell
       // as a prior click shouldn't compose into a double-click).
       app.clickCount = 0
       return
+    }
+    if (gesture) {
+      // Tentative capture path: install the gesture but DON'T short-
+      // circuit. Selection-start + multi-click below run normally so
+      // a press-without-motion still produces a valid click on release.
+      app.activeGesture = gesture.handlers
+      app.activeGestureTentative = true
     }
     // Fresh left press. Detect multi-click HERE (not on release) so the
     // word/line highlight appears immediately and a subsequent drag can
@@ -851,15 +910,28 @@ export function handleMouseEvent(app: App, m: ParsedMouse): void {
     return
   }
 
-  // Release: end the active gesture (if any) FIRST. The user dragged a
-  // captured object — not a text selection or a click — so the normal
-  // selection-finish + onClick paths must not run for this release.
-  // Fires onUp at the cursor's release position (handlers can hit-test
-  // for a drop target from there) and clears the capture.
+  // Release: handle the active gesture (if any) FIRST.
+  //
+  // Confirmed gestures: the user dragged a captured object — not a text
+  // selection or a click — so fire onUp and skip the normal selection-
+  // finish + onClick paths. The drag is over.
+  //
+  // Tentative gestures (still tentative at release means no motion ever
+  // arrived): the press never became a drag. DROP the gesture WITHOUT
+  // firing onUp and FALL THROUGH to the normal release path. Selection
+  // was started on press, so finishSelection + click dispatch run as if
+  // no gesture had been captured — and the click reaches the descendant
+  // that the user actually wanted to click.
   if (app.activeGesture) {
-    app.activeGesture.onUp?.(new MouseUpEvent(col, row, m.button))
+    if (!app.activeGestureTentative) {
+      app.activeGesture.onUp?.(new MouseUpEvent(col, row, m.button))
+      app.activeGesture = null
+      app.activeGestureTentative = false
+      return
+    }
+    // Tentative + no motion → drop and fall through to normal release.
     app.activeGesture = null
-    return
+    app.activeGestureTentative = false
   }
   // Release: end the drag even for non-zero button codes. Some terminals
   // encode release with the motion bit or button=3 "no button" (carried

--- a/packages/renderer/src/components/Draggable.test.tsx
+++ b/packages/renderer/src/components/Draggable.test.tsx
@@ -194,13 +194,18 @@ function makeDeps(
 }
 
 describe('handleDragPress', () => {
-  it('captures a gesture on press', () => {
+  it('captures a gesture on press (tentatively — committed on first motion)', () => {
     _resetDraggableZForTesting()
     const e = new MouseDownEvent(5, 1, 0)
     handleDragPress(e, makeDeps())
     expect(e._capturedHandlers).not.toBeNull()
     expect(e._capturedHandlers?.onMove).toBeTypeOf('function')
     expect(e._capturedHandlers?.onUp).toBeTypeOf('function')
+    // A22: capture is TENTATIVE, so the App-level coordinator drops the
+    // gesture silently on release-without-motion and falls through to
+    // normal click dispatch — descendants with `onClick` still get
+    // their click on a press-and-release.
+    expect(e.gestureTentative).toBe(true)
   })
 
   it('bumps persisted z on press, even with no motion', () => {
@@ -413,7 +418,7 @@ describe('handleDragPress', () => {
     }
 
     const captured = dispatchMouseDown(root, 2, 2, 0)
-    expect(captured?.onMove).toBe(childMove)
+    expect(captured?.handlers.onMove).toBe(childMove)
     expect(deps.setPersistedZ).not.toHaveBeenCalled()
   })
 })

--- a/packages/renderer/src/components/Draggable.tsx
+++ b/packages/renderer/src/components/Draggable.tsx
@@ -306,7 +306,13 @@ export function handleDragPress(e: MouseDownEvent, deps: DragPressDeps): void {
   // above siblings is the right affordance.
   deps.setPersistedZ(takeNextZ())
 
-  e.captureGesture({
+  // Tentative capture: claim the gesture, but only commit if motion
+  // follows. A press-without-motion is not a drag — the App-level
+  // coordinator will drop the gesture silently on release and let
+  // normal click dispatch run, so descendants with `onClick` actually
+  // get clicked. The first MouseMoveEvent promotes the gesture (see
+  // App.tsx — cancelSelection + clear tentative + fire onMove).
+  e.captureGestureTentatively({
     onMove(m: MouseMoveEvent) {
       const dx = m.col - startCol
       const dy = m.row - startRow

--- a/packages/renderer/src/events/mouse-event.test.ts
+++ b/packages/renderer/src/events/mouse-event.test.ts
@@ -52,6 +52,41 @@ describe('MouseDownEvent', () => {
     expect(e.gestureCaptured).toBe(true)
   })
 
+  describe('captureGestureTentatively', () => {
+    it('captures handlers and marks the event as tentative', () => {
+      const e = new MouseDownEvent(0, 0, 0)
+      const onMove = vi.fn()
+      e.captureGestureTentatively({ onMove })
+      expect(e.gestureCaptured).toBe(true)
+      expect(e.gestureTentative).toBe(true)
+      expect(e._capturedHandlers?.onMove).toBe(onMove)
+    })
+
+    it('confirmed capture is NOT tentative', () => {
+      const e = new MouseDownEvent(0, 0, 0)
+      e.captureGesture({ onMove: vi.fn() })
+      expect(e.gestureTentative).toBe(false)
+    })
+
+    it('first-call-wins applies across confirmed and tentative', () => {
+      // Tentative-then-confirmed: tentative wins, stays tentative.
+      const e1 = new MouseDownEvent(0, 0, 0)
+      const tentMove = vi.fn()
+      const confMove = vi.fn()
+      e1.captureGestureTentatively({ onMove: tentMove })
+      e1.captureGesture({ onMove: confMove })
+      expect(e1._capturedHandlers?.onMove).toBe(tentMove)
+      expect(e1.gestureTentative).toBe(true)
+
+      // Confirmed-then-tentative: confirmed wins, stays confirmed.
+      const e2 = new MouseDownEvent(0, 0, 0)
+      e2.captureGesture({ onMove: confMove })
+      e2.captureGestureTentatively({ onMove: tentMove })
+      expect(e2._capturedHandlers?.onMove).toBe(confMove)
+      expect(e2.gestureTentative).toBe(false)
+    })
+  })
+
   describe('modifier key decoding', () => {
     it('reads shift from button bit 0x04', () => {
       expect(new MouseDownEvent(0, 0, 0).shiftKey).toBe(false)
@@ -124,8 +159,8 @@ describe('dispatchMouseDown', () => {
     }
 
     const result = dispatchMouseDown(root, 2, 2, 0)
-    expect(result?.onMove).toBe(onMove)
-    expect(result?.onUp).toBe(onUp)
+    expect(result?.handlers.onMove).toBe(onMove)
+    expect(result?.handlers.onUp).toBe(onUp)
   })
 
   it('bubbles to ancestors when the deepest hit has no handler', () => {
@@ -179,7 +214,7 @@ describe('dispatchMouseDown', () => {
 
     const result = dispatchMouseDown(root, 2, 2, 0)
     expect(rootHandler).not.toHaveBeenCalled()
-    expect(result?.onMove).toBe(childMove)
+    expect(result?.handlers.onMove).toBe(childMove)
   })
 
   it('stops bubbling when a handler calls stopImmediatePropagation', () => {
@@ -219,7 +254,27 @@ describe('dispatchMouseDown', () => {
 
     const result = dispatchMouseDown(root, 2, 2, 0)
     expect(rootHandler).not.toHaveBeenCalled()
-    expect(result?.onMove).toBe(onMove)
+    expect(result?.handlers.onMove).toBe(onMove)
+  })
+
+  it('CapturedGesture carries tentative=false for confirmed captures', () => {
+    const root = createNode('ink-root')
+    setRect(root, 0, 0, 10, 5)
+    root._eventHandlers = {
+      onMouseDown: (e: MouseDownEvent) => e.captureGesture({ onMove: vi.fn() }),
+    }
+    const result = dispatchMouseDown(root, 2, 2, 0)
+    expect(result?.tentative).toBe(false)
+  })
+
+  it('CapturedGesture carries tentative=true for tentative captures', () => {
+    const root = createNode('ink-root')
+    setRect(root, 0, 0, 10, 5)
+    root._eventHandlers = {
+      onMouseDown: (e: MouseDownEvent) => e.captureGestureTentatively({ onMove: vi.fn() }),
+    }
+    const result = dispatchMouseDown(root, 2, 2, 0)
+    expect(result?.tentative).toBe(true)
   })
 
   it('passes (col, row, button) into the event for handlers to read', () => {

--- a/packages/renderer/src/events/mouse-event.ts
+++ b/packages/renderer/src/events/mouse-event.ts
@@ -91,6 +91,10 @@ export class MouseDownEvent extends MouseEvent {
 
   /** @internal — set by captureGesture, read by the App after dispatch. */
   _capturedHandlers: GestureHandlers | null = null
+  /** @internal — true when captured via captureGestureTentatively. Used
+   *  by the App-level coordinator to apply the tentative-vs-confirmed
+   *  release semantics. See captureGestureTentatively for the contract. */
+  _tentative = false
 
   /**
    * Claim mouse-motion + mouse-release events for the rest of this
@@ -105,11 +109,43 @@ export class MouseDownEvent extends MouseEvent {
   captureGesture(handlers: GestureHandlers): void {
     if (this._capturedHandlers) return
     this._capturedHandlers = handlers
+    this._tentative = false
   }
 
-  /** True once any handler has claimed this press via captureGesture(). */
+  /**
+   * Tentative variant of captureGesture: claim the press, but only
+   * commit to it if motion follows. On release-without-motion the
+   * gesture is silently DROPPED — `onUp` does NOT fire — and normal
+   * click dispatch runs as if no gesture had been captured. The first
+   * mouse-motion event PROMOTES the gesture (cancels any in-progress
+   * selection, clears the tentative flag, and routes the motion to
+   * `handlers.onMove`).
+   *
+   * Use this when the press might be a click OR a drag and you want
+   * actual motion to disambiguate — `<Draggable>` uses it so that an
+   * `onClick` on a descendant element fires when the user presses and
+   * releases without moving, instead of being eaten as a phantom drag.
+   *
+   * Same first-call-wins rule as captureGesture: a confirmed capture
+   * by a descendant blocks a later tentative capture from an ancestor,
+   * and vice versa. Mixing in one press is fine; whichever call
+   * arrives first wins.
+   */
+  captureGestureTentatively(handlers: GestureHandlers): void {
+    if (this._capturedHandlers) return
+    this._capturedHandlers = handlers
+    this._tentative = true
+  }
+
+  /** True once any handler has claimed this press via captureGesture()
+   *  or captureGestureTentatively(). */
   get gestureCaptured(): boolean {
     return this._capturedHandlers !== null
+  }
+
+  /** True if the captured gesture is tentative (only commits on motion). */
+  get gestureTentative(): boolean {
+    return this._tentative
   }
 }
 

--- a/packages/renderer/src/hit-test.ts
+++ b/packages/renderer/src/hit-test.ts
@@ -155,16 +155,27 @@ export function dispatchClick(
 }
 
 /**
+ * Captured-gesture record returned by dispatchMouseDown. Carries the
+ * handlers AND whether the capture is tentative (only commits on
+ * motion); see MouseDownEvent.captureGestureTentatively.
+ */
+export type CapturedGesture = {
+  handlers: GestureHandlers
+  tentative: boolean
+}
+
+/**
  * Hit-test the root at (col, row) and bubble a MouseDownEvent from the
  * deepest containing node up through parentNode. Only nodes with an
  * onMouseDown handler fire. Stops when a handler calls
  * stopImmediatePropagation() or captures the gesture. Capture is
  * leaf-first so descendants cannot be overwritten by ancestors.
  *
- * Returns the GestureHandlers installed via event.captureGesture() if
- * any handler called it, or null otherwise. The caller (App) is
- * responsible for storing those handlers as the active gesture and
- * routing subsequent motion + release events to them.
+ * Returns a CapturedGesture if any handler called captureGesture or
+ * captureGestureTentatively, or null otherwise. The caller (App) is
+ * responsible for storing the handlers as the active gesture, applying
+ * the tentative-vs-confirmed semantics, and routing subsequent motion
+ * + release events.
  *
  * Unlike dispatchClick, this does NOT trigger click-to-focus. Focus
  * still moves on click (i.e. on release after a non-drag press), so
@@ -176,7 +187,7 @@ export function dispatchMouseDown(
   col: number,
   row: number,
   button: number,
-): GestureHandlers | null {
+): CapturedGesture | null {
   let target: DOMElement | undefined = hitTest(root, col, row) ?? undefined
   if (!target) return null
 
@@ -197,7 +208,8 @@ export function dispatchMouseDown(
     }
     target = target.parentNode
   }
-  return event._capturedHandlers
+  if (!event._capturedHandlers) return null
+  return { handlers: event._capturedHandlers, tentative: event._tentative }
 }
 
 function scrollBoxWheelStep(node: DOMElement): number {

--- a/packages/renderer/src/ink.tsx
+++ b/packages/renderer/src/ink.tsx
@@ -17,11 +17,16 @@ import type {
 import { FRAME_INTERVAL_MS } from './constants'
 import * as dom from './dom'
 import { KeyboardEvent } from './events/keyboard-event'
-import type { GestureHandlers } from './events/mouse-event'
 import { PasteEvent } from './events/paste-event'
 import { FocusManager } from './focus'
 import { type Frame, type FrameEvent, emptyFrame } from './frame'
-import { dispatchClick, dispatchHover, dispatchMouseDown, dispatchWheel } from './hit-test'
+import {
+  type CapturedGesture,
+  dispatchClick,
+  dispatchHover,
+  dispatchMouseDown,
+  dispatchWheel,
+} from './hit-test'
 import instances from './instances'
 import { noop, throttle } from './lodash-replacements'
 import { LogUpdate } from './log-update'
@@ -1540,7 +1545,7 @@ export default class Ink {
     const blank = isEmptyCellAt(this.frontFrame.screen, col, row)
     return dispatchClick(this.rootNode, col, row, blank)
   }
-  dispatchMouseDown(col: number, row: number, button: number): GestureHandlers | null {
+  dispatchMouseDown(col: number, row: number, button: number): CapturedGesture | null {
     // Same alt-screen gate as dispatchClick — mouse tracking is only
     // enabled inside <AlternateScreen>, so onMouseDown handlers
     // shouldn't fire on main-screen renders even if the parser


### PR DESCRIPTION
Closes #72 (A22). Pairs with #81 (A21) to fully fix #55 (A3).

## What

\`MouseDownEvent\` gains \`captureGestureTentatively(handlers)\`. Same first-call-wins rule as \`captureGesture\` (cross-protected — confirmed and tentative compete via the same single-slot field).

\`Draggable\` switches its press handler to \`captureGestureTentatively\`. App-level coordinator (\`App.tsx\`) gets \`activeGestureTentative\` flag and:

- **Press**: tentative capture installs the gesture but does NOT skip selection-start / multi-click bookkeeping.
- **Motion**: first motion promotes (cancels in-progress selection, clears tentative flag, fires onMove). After this point behaves identically to a confirmed capture.
- **Release without motion**: drops the gesture silently (no \`onUp\`) and falls through to normal release path → click dispatches to descendants normally.
- **Lost-release recovery** (focus-out, no-button-motion, fresh-press-while-active): tentative gestures drop silently; confirmed gestures still get \`onUp\` for cleanup.

## Net effect

\`<Draggable><Box onClick={...}>I want clicks!</Box></Draggable>\` works on first try. No \`stopImmediatePropagation\` boilerplate. Same for \`<TextInput>\` / \`<Button>\` / any clickable child.

## Test plan

- [x] 708 tests passing (was 703; +5 for the new tentative API at the MouseDownEvent + dispatchMouseDown layers, plus updated Draggable assertion)
- [x] typecheck / lint / build clean

## API surface

- New: \`MouseDownEvent.captureGestureTentatively(handlers)\`, \`MouseDownEvent.gestureTentative\`
- Changed: \`dispatchMouseDown\` returns \`CapturedGesture | null\` (was \`GestureHandlers | null\`); same for \`Ink.dispatchMouseDown\` and \`App.props.onMouseDownAt\`. Tests updated.
- Existing \`captureGesture\` semantic unchanged — still confirmed-immediate, still first-call-wins.

## Cross-refs

- #71 (A21) — pairs with this for the full A3 fix
- #55 (A3) — can be closed once A22 lands; the click-eating symptom is the union of A21 + A22
- #56 (A4 — Window primitive) — windows that contain interactive widgets directly benefit