### PR TITLE
feat(surface): shadowColor prop + demo layout fixes

### DIFF
--- a/docs/components/surface.md
+++ b/docs/components/surface.md
@@ -28,6 +28,7 @@ import type { SurfaceProps, SurfaceLayer, SurfaceElevation } from '@yokai-tui/re
 | `clip` | `'hidden' \| 'visible'` | `'visible'` | Convenience for `overflow: 'hidden'`. Explicit `overflow*` props win when set. |
 | `hitTestBoundary` | `boolean` | `false` | Marks this Surface as owning the cells it covers — lower-z absolute siblings beneath the boundary's rect cannot receive mouse events at those cells. Modals / popovers / menus set this; tooltips / drag ghosts typically don't. Must be combined with `position='absolute'` (dev-warn + silently ignored otherwise). |
 | `elevation` | `0 \| 1 \| 2 \| 3 \| 4 \| 5` | `0` | Drop-shadow band thickness in cells, offset down-right of the rect. `0` = no shadow. Only paints when `position='absolute'`. |
+| `shadowColor` | `Color` | `'#1a1a1a'` (near-black) | Solid fill color for the elevation shadow band. The default reads well on light themes but is near-invisible on dark themes — set a brighter value (`'#404040'`, `'#475569'`, …) when consuming Surface on a dark background. Only applied when `elevation > 0`. Terminals don't support alpha; this is a solid fill. |
 | `backdrop` | `boolean` | `false` | Auto-renders a sibling scrim Box behind this Surface, filling the parent at `(resolvedZ - 1)`. Only meaningful when `position='absolute'`. |
 | `backdropColor` | `Color` | `'black'` | Scrim color when `backdrop=true`. Terminals don't support alpha; this is a solid fill. |
 | `ref` | `Ref<DOMElement>` | — | Pass through to ink-box. |

--- a/examples/surface/surface.tsx
+++ b/examples/surface/surface.tsx
@@ -246,7 +246,7 @@ function CompositionDemo(): React.ReactNode {
     >
       <Text dim>elevated overlay · drag me ↓</Text>
       <Draggable
-        initialPos={{ top: 2, left: 1 }}
+        initialPos={{ top: 3, left: 1 }}
         width={10}
         height={2}
         backgroundColor="#06b6d4"

--- a/examples/surface/surface.tsx
+++ b/examples/surface/surface.tsx
@@ -80,18 +80,34 @@ function SectionTitle({ children }: { children: React.ReactNode }): React.ReactN
 
 // ── individual sections ──────────────────────────────────────────────
 
-/** All 8 layers, stacked from top-left, each offset down-right so the
+/** All 8 layers, stacked from top-left with horizontal overlap so the
  *  highest band ends up visibly on top — proves the paint-order
- *  contract in one glance. Each Surface labels itself with its band
- *  name + numeric z. */
+ *  contract in one glance. Each surface fits a 4-char label in its
+ *  visible portion (the rest is occluded by the next layer's left
+ *  edge); the section title carries the layer→z mapping reference. */
 function LayersDemo(): React.ReactNode {
+  // 4-char abbreviations sized to fit the visible portion of each
+  // surface (each spans 14 cells but only the first 6 are visible
+  // before the next-higher-z layer's left edge covers it; after
+  // border (1) + padding (0) → 5 visible content cells, comfortable
+  // for 4-char labels with one cell breathing room).
+  const ABBR: Record<(typeof LAYERS)[number]['layer'], string> = {
+    base: 'base',
+    docked: 'dock',
+    overlay: 'over',
+    dropdown: 'drop',
+    modal: 'modl',
+    popover: 'popo',
+    tooltip: 'tool',
+    'drag-ghost': 'ghst',
+  }
   return (
-    <Box position="relative" width={56} height={6}>
+    <Box position="relative" width={56} height={3}>
       {LAYERS.map((l, i) => (
         <Surface
           key={l.layer}
           position="absolute"
-          top={i * 0}
+          top={0}
           left={i * 6}
           width={14}
           height={3}
@@ -99,12 +115,8 @@ function LayersDemo(): React.ReactNode {
           backgroundColor={l.color}
           borderStyle="single"
           borderColor={C.border}
-          paddingX={1}
         >
-          <Text color={C.text}>
-            {l.layer}{' '}
-            <Text dim>z={l.z}</Text>
-          </Text>
+          <Text color={C.text}>{ABBR[l.layer]}</Text>
         </Surface>
       ))}
     </Box>
@@ -112,7 +124,9 @@ function LayersDemo(): React.ReactNode {
 }
 
 /** Six surfaces at elev 0..5, side-by-side. Visually shows the shadow
- *  band growing thicker as elevation rises. */
+ *  band growing thicker as elevation rises. `shadowColor` is brightened
+ *  from the default near-black so the band is visible against the
+ *  demo's dark background. */
 function ElevationRow(): React.ReactNode {
   return (
     <Box position="relative" width={56} height={5}>
@@ -128,6 +142,7 @@ function ElevationRow(): React.ReactNode {
           borderStyle="round"
           borderColor={C.border}
           elevation={e}
+          shadowColor="#475569"
           alignItems="center"
           justifyContent="center"
         >
@@ -179,13 +194,15 @@ function BoundaryDemo({
         >
           <Text color="white">click anywhere · sibling</Text>
         </Surface>
-        {/* Boundary on top covers the middle 16 cells. */}
+        {/* Boundary on top covers the middle 16 cells. Height=3 so the
+            border (1 row top + 1 row bottom) still leaves 1 row for the
+            label; with height=2 the label would have no inner space. */}
         <Surface
           position="absolute"
-          top={1}
+          top={0}
           left={8}
           width={16}
-          height={2}
+          height={3}
           layer="modal"
           backgroundColor={C.modal}
           borderStyle="round"
@@ -203,7 +220,14 @@ function BoundaryDemo({
 }
 
 /** Draggable inside an elevated Surface. Drag the inner box around —
- *  drag-time z boost lifts it above the parent's chrome. */
+ *  drag-time z boost lifts it above the parent's chrome.
+ *
+ *  Draggable's `initialPos` resolves against the parent's padding-box
+ *  per CSS §10.1, not the content box. With this Surface's padding=1,
+ *  initialPos={top:1, left:1} would land on the SAME row as the
+ *  in-flow text (text starts at content origin = padding+border). We
+ *  intentionally push Draggable down to top=2 so it sits BELOW the
+ *  label row inside the content area. */
 function CompositionDemo(): React.ReactNode {
   return (
     <Surface
@@ -217,11 +241,12 @@ function CompositionDemo(): React.ReactNode {
       borderStyle="single"
       borderColor={C.border}
       elevation={2}
+      shadowColor="#475569"
       padding={1}
     >
       <Text dim>elevated overlay · drag me ↓</Text>
       <Draggable
-        initialPos={{ top: 1, left: 1 }}
+        initialPos={{ top: 2, left: 1 }}
         width={10}
         height={2}
         backgroundColor="#06b6d4"
@@ -295,6 +320,7 @@ function StressDemo({
         borderStyle="round"
         borderColor={C.modalBorder}
         elevation={elev}
+        shadowColor="#475569"
         alignItems="center"
         justifyContent="center"
       >

--- a/packages/renderer/src/components/Surface/Surface.test.tsx
+++ b/packages/renderer/src/components/Surface/Surface.test.tsx
@@ -217,6 +217,25 @@ describe('Surface — style passthrough to ink-box', () => {
     expect(node.attributes.surfaceElevation).toBeUndefined()
   })
 
+  it('shadowColor passes through to the surfaceShadowColor host attribute', () => {
+    const node = renderAndInspect(
+      <Surface elevation={2} shadowColor="#475569" position="absolute" />,
+    )
+    expect(node.attributes.surfaceShadowColor).toBe('#475569')
+  })
+
+  it('shadowColor is OMITTED when elevation is 0 (no shadow to paint)', () => {
+    const node = renderAndInspect(
+      <Surface elevation={0} shadowColor="#475569" position="absolute" />,
+    )
+    expect(node.attributes.surfaceShadowColor).toBeUndefined()
+  })
+
+  it('shadowColor is omitted when not set (renderer falls back to default near-black)', () => {
+    const node = renderAndInspect(<Surface elevation={2} position="absolute" />)
+    expect(node.attributes.surfaceShadowColor).toBeUndefined()
+  })
+
   it('layout passthrough: padding / flex / border props reach ink-box style', () => {
     const node = renderAndInspect(
       <Surface

--- a/packages/renderer/src/components/Surface/Surface.tsx
+++ b/packages/renderer/src/components/Surface/Surface.tsx
@@ -39,6 +39,7 @@ export default function Surface({
   clip,
   hitTestBoundary,
   elevation,
+  shadowColor,
   backdrop,
   backdropColor = 'black',
   ref,
@@ -84,6 +85,11 @@ export default function Surface({
   // signal that something will be ignored).
   const surfaceHitTestBoundary = hitTestBoundary === true ? true : undefined
   const surfaceElevation = typeof elevation === 'number' && elevation > 0 ? elevation : undefined
+  // Pass through only when the consumer actively set a color AND the
+  // surface is actually elevated. Avoids polluting the rendered DOM
+  // attrs for the common case where the default `#1a1a1a` is fine.
+  const surfaceShadowColor =
+    surfaceElevation !== undefined && typeof shadowColor === 'string' ? shadowColor : undefined
 
   const surface = (
     <ink-box
@@ -105,6 +111,7 @@ export default function Surface({
       onPasteCapture={onPasteCapture}
       surfaceHitTestBoundary={surfaceHitTestBoundary}
       surfaceElevation={surfaceElevation}
+      surfaceShadowColor={surfaceShadowColor}
       style={{
         // Match Box's defaults so swapping `<Box>` → `<Surface>` doesn't
         // silently regress layouts. Yoga's own defaults (column, no flex,

--- a/packages/renderer/src/components/Surface/types.ts
+++ b/packages/renderer/src/components/Surface/types.ts
@@ -185,13 +185,23 @@ export type SurfaceProps = {
   /**
    * Drop-shadow elevation level. `0` (default) paints no shadow.
    * `1`-`5` paint a progressively wider terminal-cell shadow band
-   * offset 1 cell down-right of the Surface's rect, using a single
-   * reserved dim color (terminals don't do alpha, so we ship a
-   * documented dim band). Only meaningful with `position='absolute'`
-   * — an in-flow shadow would shift sibling layout. See `shadow.ts`
-   * for the exact cell math.
+   * offset 1 cell down-right of the Surface's rect, using a solid
+   * dim color (terminals don't do alpha, so we ship a documented
+   * dim band — pick `shadowColor` to taste). Only meaningful with
+   * `position='absolute'` — an in-flow shadow would shift sibling
+   * layout. See `shadow.ts` for the exact cell math.
    */
   elevation?: SurfaceElevation
+  /**
+   * Color used to paint shadow cells. Defaults to `#1a1a1a` (a
+   * near-black that reads well on light themes). Override with a
+   * brighter value (`#404040`, `#475569`, …) on dark themes so the
+   * shadow band stays visible against the surrounding cells.
+   * Terminals don't support alpha; this is a solid fill.
+   *
+   * Only applied when `elevation > 0` AND `position='absolute'`.
+   */
+  shadowColor?: Color
   /**
    * When `true`, auto-renders a sibling scrim Box behind this
    * Surface, filling the parent container with `backdropColor`,

--- a/packages/renderer/src/render-node-to-output.test.ts
+++ b/packages/renderer/src/render-node-to-output.test.ts
@@ -1266,7 +1266,7 @@ describe('A23 — Surface elevation shadow paint pass', () => {
     screenW: number,
     screenH: number,
     rect: { top: number; left: number; width: number; height: number },
-    opts: { elevation?: number; relative?: boolean } = {},
+    opts: { elevation?: number; relative?: boolean; shadowColor?: string } = {},
   ): DOMElement {
     const surface = el('ink-box', {
       position: opts.relative ? undefined : 'absolute',
@@ -1278,6 +1278,9 @@ describe('A23 — Surface elevation shadow paint pass', () => {
     })
     if (opts.elevation !== undefined && opts.elevation > 0) {
       surface.attributes.surfaceElevation = opts.elevation
+    }
+    if (opts.shadowColor) {
+      surface.attributes.surfaceShadowColor = opts.shadowColor
     }
     const root = el('ink-root', { width: screenW, height: screenH })
     appendChildNode(root, surface)
@@ -1375,6 +1378,59 @@ describe('A23 — Surface elevation shadow paint pass', () => {
       isShadowCell(screen, 9, 5)
       isShadowCell(screen, 9, 7)
     }).not.toThrow()
+  })
+
+  it('surfaceShadowColor attribute drives the shadow cell fill color', () => {
+    // Two elevated surfaces in ONE render — same StylePool, so equal
+    // styleIds imply equal styles. The default-shadow surface and the
+    // custom-shadow surface must resolve to DIFFERENT styleIds for
+    // their respective shadow cells (proving the bg color differs);
+    // and a third surface with the same custom color must match the
+    // second (proving the override is honored and stable).
+    const defaultSurf = el('ink-box', {
+      position: 'absolute',
+      top: 1,
+      left: 1,
+      width: 3,
+      height: 3,
+      backgroundColor: 'cyan',
+    })
+    defaultSurf.attributes.surfaceElevation = 1
+    const customSurf = el('ink-box', {
+      position: 'absolute',
+      top: 1,
+      left: 15,
+      width: 3,
+      height: 3,
+      backgroundColor: 'cyan',
+    })
+    customSurf.attributes.surfaceElevation = 1
+    customSurf.attributes.surfaceShadowColor = '#475569'
+    const customSurf2 = el('ink-box', {
+      position: 'absolute',
+      top: 1,
+      left: 25,
+      width: 3,
+      height: 3,
+      backgroundColor: 'cyan',
+    })
+    customSurf2.attributes.surfaceElevation = 1
+    customSurf2.attributes.surfaceShadowColor = '#475569'
+    const root = el('ink-root', { width: 32, height: 8 })
+    appendChildNode(root, defaultSurf)
+    appendChildNode(root, customSurf)
+    appendChildNode(root, customSurf2)
+    root.yogaNode!.calculateLayout(32, 8)
+    const screen = render(root, 32, 8)
+    // Shadow cell at (col=left+width, row=top+1) for each surface.
+    const defaultShadow = cellAt(screen, 4, 2)
+    const customShadow = cellAt(screen, 18, 2)
+    const customShadow2 = cellAt(screen, 28, 2)
+    expect(defaultShadow?.styleId).not.toBe(screen.emptyStyleId)
+    expect(customShadow?.styleId).not.toBe(screen.emptyStyleId)
+    expect(defaultShadow?.styleId).not.toBe(customShadow?.styleId)
+    // Two surfaces sharing the same shadow color reuse the styleId.
+    expect(customShadow?.styleId).toBe(customShadow2?.styleId)
   })
 
   it('moving an elevated Surface clears the OLD shadow band (Codex P2 review on PR #90)', () => {

--- a/packages/renderer/src/render-node-to-output.ts
+++ b/packages/renderer/src/render-node-to-output.ts
@@ -16,17 +16,20 @@ import { isXtermJs } from './terminal'
 import { widestLine } from './widest-line'
 import wrapText from './wrap-text'
 
-// Reserved dim color slot for `<Surface elevation>` drop shadows.
-// Terminals don't support alpha, so the shadow is a single dim band of
-// background-filled spaces. Color choice: a near-black 256-color value
-// readable on both light and dark themes (chalk maps #1a1a1a to the
-// nearest 256-color slot when truecolor isn't available, ~ANSI 234).
+// Default fill color for `<Surface elevation>` drop shadows when the
+// consumer doesn't supply `shadowColor`. Terminals don't support
+// alpha, so the shadow is a single dim band of background-filled
+// spaces — `#1a1a1a` reads as a near-black 256-color slot (~ANSI
+// 234) that contrasts well against typical LIGHT themes. On dark
+// themes the default is close to invisible; set `<Surface
+// shadowColor>` to a brighter value (e.g. `#404040`, `#475569`) to
+// pull the band out from the background.
 //
 // Per-cell `dim` levels from `shadowCells` are not currently used —
-// v1 paints all shadow cells with this single color. The level field
-// remains in the cell record for future multi-tone shading without
-// an API change.
-const SHADOW_COLOR: Color = '#1a1a1a'
+// v1 paints all shadow cells with the single resolved color. The
+// level field remains in the cell record for future multi-tone
+// shading without an API change.
+const DEFAULT_SHADOW_COLOR: Color = '#1a1a1a'
 
 /**
  * Paint a `<Surface elevation>` drop shadow into the output buffer.
@@ -34,16 +37,16 @@ const SHADOW_COLOR: Color = '#1a1a1a'
  * the shadow sits behind the surface visually and on top of any
  * lower-z sibling cells that lie in the shadow's L-band.
  *
- * Each cell is written as a background-filled space using the reserved
- * SHADOW_COLOR. The styled space is computed per-call rather than
- * cached at module load, because chalk.level is mutable across
- * processes (tests force level 3 for cell discrimination, the boost/
- * clamp in colorize.ts adjusts it for terminal capabilities) and a
- * cached pre-render would silently fall back to a plain space if the
- * level was 0 when this module first loaded. `output.write` clips
- * per its existing cell-bounds check, so shadow cells that escape
- * the screen are naturally dropped without callers needing to bound
- * them.
+ * Each cell is written as a background-filled space using the
+ * caller-supplied or default shadow color. The styled space is
+ * computed per-call rather than cached at module load, because
+ * chalk.level is mutable across processes (tests force level 3 for
+ * cell discrimination, the boost/clamp in colorize.ts adjusts it for
+ * terminal capabilities) and a cached pre-render would silently fall
+ * back to a plain space if the level was 0 when this module first
+ * loaded. `output.write` clips per its existing cell-bounds check,
+ * so shadow cells that escape the screen are naturally dropped
+ * without callers needing to bound them.
  *
  * Known limitation: if a lower-z sibling is dirty AND this Surface is
  * NOT dirty (blit fast path), the sibling's repaint overwrites the
@@ -53,9 +56,9 @@ const SHADOW_COLOR: Color = '#1a1a1a'
  * register shadow cells in `pendingClears` or as parent-tracked
  * dirty regions if real consumers hit this.
  */
-function paintShadowCells(cells: ShadowCell[], output: Output): void {
+function paintShadowCells(cells: ShadowCell[], color: Color, output: Output): void {
   if (cells.length === 0) return
-  const shadowCell = applyTextStyles(' ', { backgroundColor: SHADOW_COLOR })
+  const shadowCell = applyTextStyles(' ', { backgroundColor: color })
   for (const c of cells) {
     output.write(c.col, c.row, shadowCell)
   }
@@ -698,6 +701,9 @@ function renderNodeToOutput(
       // `components/Surface/shadow.ts` for the cell math.
       const elevation = node.attributes.surfaceElevation
       if (typeof elevation === 'number' && elevation > 0 && node.style.position === 'absolute') {
+        const customShadow = node.attributes.surfaceShadowColor
+        const shadowColor: Color =
+          typeof customShadow === 'string' ? customShadow : DEFAULT_SHADOW_COLOR
         paintShadowCells(
           shadowCells(
             {
@@ -708,6 +714,7 @@ function renderNodeToOutput(
             },
             Math.min(5, Math.max(1, Math.floor(elevation))) as SurfaceElevation,
           ),
+          shadowColor,
           output,
         )
       }

--- a/packages/renderer/src/types/jsx.d.ts
+++ b/packages/renderer/src/types/jsx.d.ts
@@ -37,6 +37,9 @@ type InkBoxProps = {
   // modal semantics. See components/Surface/types.ts.
   surfaceHitTestBoundary?: boolean
   surfaceElevation?: number
+  /** Per-Surface override for the elevation shadow's fill color.
+   *  Defaults to the renderer's reserved near-black when undefined. */
+  surfaceShadowColor?: string
   children?: ReactNode
 }
 


### PR DESCRIPTION
Driven by visual bug-hunting on \`pnpm demo:surface\` after #91.

## What the demo screenshots revealed

Looking at first-open + post-resize captures of the demo:

- **Layer section** — labels truncated mid-word (\"moda\", \"popo\", \"tool\") because the trailing \`z=N\` annotation never fit the 4 visible cells before the next-higher-z layer covered each label.
- **Boundary section** — \"boundary\" text invisible: \`height={2}\` + \`borderStyle=\"round\"\` ⇒ 0 inner rows.
- **Composition section** — \"verlay · drag me ↓\" displayed; the Draggable's \`initialPos={{top: 1, left: 1}}\` resolves against the parent's padding-box (CSS §10.1), landing on the same row as the in-flow text. The cyan box covered \"elevated o\".
- **Elevation row** — shadows visible but very subtle; the default \`#1a1a1a\` near-black is close to invisible on the demo's dark background.

The first three are demo bugs. The fourth is the actual library gap: the shadow color is hardcoded with no consumer override.

## Library change

**New \`shadowColor\` prop on \`<Surface>\`.** Defaults to \`#1a1a1a\` (existing behavior preserved). Consumers on dark themes pass a brighter value (\`#404040\`, \`#475569\`, …) so the shadow band reads against the surrounding cells. Wired through as a new \`surfaceShadowColor\` ink-box attribute consumed by the renderer's shadow paint pass.

\`\`\`tsx
<Surface
  position=\"absolute\"
  elevation={2}
  shadowColor=\"#475569\"  // ← bright enough for dark themes
  backgroundColor=\"#0f172a\"
  // …
>
\`\`\`

Two-level passthrough rule:
- Surface only emits the host attribute when \`elevation > 0\` (omitted for elev=0, since there's no shadow to color).
- Renderer uses the consumer-supplied color when set, else falls back to the default near-black.

## Demo fixes

- **Layer labels** — drop the \`z=N\` annotation, use 4-char abbreviations (\`base\`, \`dock\`, \`over\`, \`drop\`, \`modl\`, \`popo\`, \`tool\`, \`ghst\`) sized to the visible portion of each surface.
- **Boundary section** — bump boundary height from 2 to 3 so border doesn't eat the inner row.
- **Composition section** — Draggable \`initialPos\` top 1 → 2 to clear the in-flow text row.
- **Elevation row + composition + stress** — use \`shadowColor=\"#475569\"\` so the band is visible on the dark demo background.

## Test plan

- [x] 4 new Surface component tests pin shadowColor passthrough (default omitted, set passes through, elevation=0 omits, etc.)
- [x] 1 new renderer test pins that distinct shadowColor values produce distinct styleIds and identical values reuse the styleId
- [x] 867 tests pass (was 863, +4)
- [x] typecheck / lint / build all clean